### PR TITLE
Avoiding merge dispatch conflicts

### DIFF
--- a/src/BlackBoxOptim.jl
+++ b/src/BlackBoxOptim.jl
@@ -11,7 +11,7 @@ export  Optimizer, PopulationOptimizer,
         XNESOpt, xnes,
 
         # Parameters
-        Parameters,
+        Parameters, mergeparam,
 
         # Fitness
 

--- a/src/adaptive_differential_evolution.jl
+++ b/src/adaptive_differential_evolution.jl
@@ -1,6 +1,6 @@
 include("bimodal_cauchy_distribution.jl")
 
-ADE_DefaultOptions = merge(DE_DefaultOptions, {
+ADE_DefaultOptions = mergeparam(DE_DefaultOptions, {
   # Distributions we will use to generate new F and CR values.
   "fdistr" => bimodal_cauchy(0.65, 0.1, 1.0, 0.1),
   "crdistr" => bimodal_cauchy(0.1, 0.1, 0.95, 0.1),
@@ -34,7 +34,7 @@ type AdaptConstantsDiffEvoOpt <: DifferentialEvolutionOpt
     popsize = size(pop, 1)
     fs = [sample_bimodal_cauchy(options["fdistr"]; truncateBelow0 = false) for i in 1:popsize]
     crs = [sample_bimodal_cauchy(options["crdistr"]) for i in 1:popsize]
-    new(name, pop, ss, merge(DE_DefaultOptions, options), 
+    new(name, pop, ss, mergeparam(DE_DefaultOptions, options), 
       sample, mutate, crossover, bound, fs, crs)
   end
 end

--- a/src/differential_evolution.jl
+++ b/src/differential_evolution.jl
@@ -32,7 +32,7 @@ type DiffEvoOpt <: DifferentialEvolutionOpt
   bound::Function
 
   function DiffEvoOpt(name, pop, ss, options, sample, mutate, crossover, bound)
-    new(name, pop, ss, merge(DE_DefaultOptions, options), sample, mutate, crossover, bound)
+    new(name, pop, ss, mergeparam(DE_DefaultOptions, options), sample, mutate, crossover, bound)
   end
 end
 

--- a/src/experiments/parameter_experiment.jl
+++ b/src/experiments/parameter_experiment.jl
@@ -105,7 +105,7 @@ function run_based_on_design_matrix_in_file_while_saving_results_to_csvfile(runf
   for(i in 1:length(pvs))
     param_dict = pvs[i]
     # Add other arguments.
-    param_dict = merge(param_dict, fixed_params)
+    param_dict = mergeparam(param_dict, fixed_params)
     print("params: "); show(param_dict); println("")
 
     # Set up for saving results

--- a/src/natural_evolution_strategies.jl
+++ b/src/natural_evolution_strategies.jl
@@ -46,7 +46,7 @@ NES_DefaultOptions = {
 }
 
 function separable_nes(parameters)
-  params = merge(NES_DefaultOptions, parameters)
+  params = mergeparam(NES_DefaultOptions, parameters)
   SeparableNESOpt(params[:SearchSpace]; 
     lambda = params["lambda"], 
     mu_learnrate = params["mu_learnrate"], 
@@ -140,7 +140,7 @@ type XNESOpt <: NaturalEvolutionStrategyOpt
 end
 
 function xnes(parameters)
-  params = merge(NES_DefaultOptions, parameters)
+  params = mergeparam(NES_DefaultOptions, parameters)
   XNESOpt(params[:SearchSpace]; lambda = params["lambda"])
 end
 

--- a/src/parameters.jl
+++ b/src/parameters.jl
@@ -30,7 +30,8 @@ function setindex!(p::Parameters, value, key)
   setindex!(first(p.dicts), value, key)
 end
 
-import Base.haskey, Base.get, Base.merge, Base.delete!
+import Base.haskey, Base.get, Base.delete!
+
 
 function haskey(p::Parameters, key)
   for d in p.dicts
@@ -48,7 +49,7 @@ end
 
 # In a merge the last parameter should be prioritized since this is the way
 # the normal Julia merge of dicts works.
-merge(p1::Union(Dict, Parameters), p2::Union(Dict, Parameters)) = Parameters(p2, p1)
+mergeparam(p1::Union(Dict, Parameters), p2::Union(Dict, Parameters)) = Parameters(p2, p1)
 
 function delete!(p::Parameters, key)
   for d in p.dicts

--- a/test/test_parameters.jl
+++ b/test/test_parameters.jl
@@ -92,7 +92,7 @@ facts("Parameters") do
   context("Merge with Parameters or Dict") do
 
     ps = Parameters({:a => 1, "c" => 4}, {:a => 2, :b => 3})
-    ps2 = merge(ps, {:d => 5, :a => 20})
+    ps2 = mergeparam(ps, {:d => 5, :a => 20})
     @fact ps2[:d] => 5
     @fact ps2[:b] => 3
     @fact ps2[:a] => 20


### PR DESCRIPTION
Resolving `Base.merge`-related issues involving the `Parameter` type.

Rather than exploring all possible conflicts with the `merge` dispatch, it seemed more straightforward to just use a different function name for combining parameter dictionaries. Tests in `test_parameters.jl` all pass, but @robertfeldt please re-run the whole test setup with your custom `Rakefile` (have not read into that).

Thanks @MichaelHatherly for [debugging](https://github.com/robertfeldt/BlackBoxOptim.jl/issues/7#issuecomment-98963828) the problem.
