### PR TITLE
Update DE and ADE to use GeneticOperator approach

### DIFF
--- a/src/BlackBoxOptim.jl
+++ b/src/BlackBoxOptim.jl
@@ -1,5 +1,7 @@
 module BlackBoxOptim
 
+using Distributions, Compat
+
 export  Optimizer, PopulationOptimizer,
         bboptimize, compare_optimizers,
 
@@ -44,8 +46,6 @@ export  Optimizer, PopulationOptimizer,
 
 abstract Optimizer
 
-using Compat
-
 module Utils
   include("utilities/latin_hypercube_sampling.jl")
   include("utilities/assign_ranks.jl")
@@ -55,6 +55,10 @@ include("search_space.jl")
 include("parameters.jl")
 include("fitness.jl")
 include("population.jl")
+
+# Genetic Operators
+include("genetic_operators/genetic_operator.jl")
+
 include("frequency_adaptation.jl")
 include("archive.jl")
 
@@ -130,9 +134,6 @@ include("direct_search_with_probabilistic_descent.jl")
 
 # End-user/interface functions
 include("bboptimize.jl")
-
-# Genetic Operators
-include("genetic_operators/genetic_operator.jl")
 
 # Fitness
 include("fitness/fitness_types.jl")

--- a/src/adaptive_differential_evolution.jl
+++ b/src/adaptive_differential_evolution.jl
@@ -4,90 +4,55 @@ ADE_DefaultOptions = mergeparam(DE_DefaultOptions, @compat Dict{Symbol,Any}(
   # Distributions we will use to generate new F and CR values.
   :fdistr => bimodal_cauchy(0.65, 0.1, 1.0, 0.1),
   :crdistr => bimodal_cauchy(0.1, 0.1, 0.95, 0.1),
+  :SearchSpace => symmetric_search_space(1)
 ))
 
-# An Adaptive DE typically change parameters of the search dynamically. This is
+# Specific data and functions for adaptation
+# An Adaptive DE typically changes parameters of the search dynamically. This is
 # typically done in the tell! function when we know if the trial vector
 # was better than the target vector.
-type AdaptConstantsDiffEvoOpt <: DifferentialEvolutionOpt
-  name::ASCIIString
+type AdaptiveDiffEvoParameters <: DiffEvoParameters
+  # Distributions we will use to generate new F and CR values.
+  # FIXME allow any distribution?
+  fdistr::BimodalCauchy
+  crdistr::BimodalCauchy
 
-  # A population is a matrix of floats, individuals are stored column-wise
-  population::Array{Float64, 2}
-
-  search_space::SearchSpace
-
-  # Options
-  options
-
-  # Set of functions that together define a specific DE strategy.
-  sample::Function
-  mutate::Function
-  crossover::Function
-  bound::Function
-
-  # Specific data and functions for adaptation
   fs::Vector{Float64}   # One f value per individual in population
   crs::Vector{Float64}  # One cr value per individual in population
 
-  function AdaptConstantsDiffEvoOpt(name, pop, ss, options, sample, mutate, crossover, bound)
-    popsize = size(pop, 2)
-    fs = [sample_bimodal_cauchy(options[:fdistr]; truncateBelow0 = false) for i in 1:popsize]
-    crs = [sample_bimodal_cauchy(options[:crdistr]) for i in 1:popsize]
-    new(name, pop, ss, mergeparam(DE_DefaultOptions, options),
-      sample, mutate, crossover, bound, fs, crs)
+  function AdaptiveDiffEvoParameters(options, popsize::Int)
+    fdistr = options[:fdistr]
+    crdistr = options[:crdistr]
+    new(fdistr, crdistr,
+        [sample_bimodal_cauchy(fdistr; truncateBelow0 = false) for i in 1:popsize],
+        [sample_bimodal_cauchy(crdistr) for i in 1:popsize])
   end
 end
 
-# To get the constants for an adaptive DE we access the vectors of constants.
-fconst(ade::AdaptConstantsDiffEvoOpt, i) = ade.fs[i]
-crconst(ade::AdaptConstantsDiffEvoOpt, i) = ade.crs[i]
+crossover_parameters(params::AdaptiveDiffEvoParameters, index) = params.crs[index], params.fs[index]
 
-# To sample we use the distribution given as options
-sample_f(ade::AdaptConstantsDiffEvoOpt) = sample_bimodal_cauchy(ade.options[:fdistr]; truncateBelow0 = false)
-sample_cr(ade::AdaptConstantsDiffEvoOpt) = sample_bimodal_cauchy(ade.options[:crdistr]; truncateBelow0 = false)
-
-# Tell the optimizer about the ranking of candidates. Returns the number of
-# better candidates that were inserted into the population.
-function tell!(de::AdaptConstantsDiffEvoOpt,
-  # archive::Archive, # Skip for now
-  rankedCandidates)
-  num_candidates = length(rankedCandidates)
-  num_better = 0
-  for i in 1:div(num_candidates, 2)
-    candidate, index = rankedCandidates[i]
-    if candidate != de.population[:,index]
-      num_better += 1
-      old = de.population[:,index]
-      de.population[:,index] = candidate
-      # Since the trial vector was better we keep the f and cr values for this target.
-    else
+function adjust!( params::AdaptiveDiffEvoParameters, index, is_improved::Bool )
+    if !is_improved
       # The trial vector for this target was not better so we change the f and cr constants.
-      de.fs[index] = sample_f(de)
-      de.crs[index] = sample_cr(de)
+      params.fs[index] = sample_bimodal_cauchy( params.fdistr; truncateBelow0 = false)
+      params.crs[index] = sample_bimodal_cauchy( params.crdistr; truncateBelow0 = false)
     end
-  end
-  num_better
 end
 
-function adaptive_de_rand_1_bin(parameters = @compat Dict{Symbol,Any}())
-  params = Parameters(parameters, ADE_DefaultOptions)
-  ss = get(params, :SearchSpace, BlackBoxOptim.symmetric_search_space(1))
-  population = get(params, :Population, BlackBoxOptim.rand_individuals_lhs(ss, 50))
-  AdaptConstantsDiffEvoOpt("AdaptiveDE/rand/1/bin", population, ss, params,
-    random_sampler,
-    de_mutation_rand_1,
-    de_crossover_binomial,
-    rand_bound_from_target!)
+function adaptive_de_rand_1_bin(options = @compat Dict{Symbol,Any}())
+  opts = Parameters(options, ADE_DefaultOptions)
+  ss = opts[:SearchSpace]
+  population = get(opts, :Population, rand_individuals_lhs(ss, 50))
+  DiffEvoOpt{AdaptiveDiffEvoParameters,NoMutation,DiffEvoRandBin1}(
+        "AdaptiveDE/rand/1/bin", population, ss, opts,
+        AdaptiveDiffEvoParameters(opts, size(population,2)), random_sampler )
 end
 
-function adaptive_de_rand_1_bin_radiuslimited(parameters = @compat Dict{Symbol,Any})
-  params = Parameters(parameters, ADE_DefaultOptions)
-  ss = get(params, :SearchSpace, BlackBoxOptim.symmetric_search_space(1))
-  population = get(params, :Population, BlackBoxOptim.rand_individuals_lhs(ss, 50))
-  AdaptConstantsDiffEvoOpt("AdaptiveDE/rand/1/bin/radiuslimited", population, ss, params,
-    radius_limited_sampler,
-    de_mutation_rand_1,
-    de_crossover_binomial,
-    rand_bound_from_target!)
+function adaptive_de_rand_1_bin_radiuslimited(options = @compat Dict{Symbol,Any})
+  opts = Parameters(options, ADE_DefaultOptions)
+  ss = opts[:SearchSpace]
+  population = get(opts, :Population, rand_individuals_lhs(ss, 50))
+  DiffEvoOpt{AdaptiveDiffEvoParameters,NoMutation,DiffEvoRandBin1}(
+        "AdaptiveDE/rand/1/bin/radiuslimited", population, ss, opts,
+        AdaptiveDiffEvoParameters(opts, size(population,2)), radius_limited_sampler )
 end

--- a/src/bimodal_cauchy_distribution.jl
+++ b/src/bimodal_cauchy_distribution.jl
@@ -1,14 +1,17 @@
 using Distributions
 
+# FIXME implement actual distribution using Distributions.MixtureModel
+typealias BimodalCauchy @compat Tuple{Cauchy, Cauchy}
+
 # In the literature Cauchy distributions have been used for sampling the
 # f and cr constants used in DE.
-function sample_bimodal_cauchy_once(cauchyDistrs, cutoffProb = 0.5)
+function sample_bimodal_cauchy_once(cauchyDistrs::BimodalCauchy, cutoffProb = 0.5)
   index = (rand() < cutoffProb) ? 1 : 2
   rand(cauchyDistrs[index])
 end
 
 # When sampling it is common to truncate in either or both ends.
-function sample_bimodal_cauchy(cauchyDistrs; cutoffProb = 0.5, 
+function sample_bimodal_cauchy(cauchyDistrs::BimodalCauchy; cutoffProb = 0.5,
   truncateAbove1 = true, truncateBelow0 = true)
   value = sample_bimodal_cauchy_once(cauchyDistrs, cutoffProb)
   if value > 1.0

--- a/src/genetic_operators/crossover/differential_evolution_crossover.jl
+++ b/src/genetic_operators/crossover/differential_evolution_crossover.jl
@@ -1,37 +1,36 @@
 abstract DiffEvoCrossoverOperator{NP,NC} <: CrossoverOperator{NP,NC}
 
-type DiffEvoRandBin1{T <: Real} <: DiffEvoCrossoverOperator{3,1}
-  f::Float64
-  cr::Float64
-  DiffEvoRandBin1(f = 0.65, cr = 0.4) = new(f, cr)
+# FIXME is it possible somehow to do arithmetic operations with N?
+type DiffEvoRandBin{N} <: DiffEvoCrossoverOperator{N,1}
 end
 
-function apply{T <: Real}(xo::DiffEvoRandBin1{T}, p1::Vector{T}, p2::Vector{T}, p3::Vector{T})
-  donor = p3 .+ xo.f .* (p1 .- p2)
-  de_crossover_binomial(p3, donor)
+typealias DiffEvoRandBin1 DiffEvoRandBin{3}
+typealias DiffEvoRandBin2 DiffEvoRandBin{5}
+
+function apply!(xo::DiffEvoRandBin{3}, cr::Real, f::Number, target, pop, parentIndices)
+  @assert length(parentIndices) == 3
+  p1ix, p2ix, p3ix = parentIndices
+  # Always ensure at least one parameter is xovered
+  mut_ix = rand(1:length(target))
+  for i in 1:length(target)
+    if i == mut_ix || rand() <= cr
+      target[i] = pop[i,p3ix] + f .* (pop[i,p1ix] .- pop[i,p2ix])
+    end
+  end
+  return target
 end
 
-type DiffEvoRandBin2{T <: Real} <: DiffEvoCrossoverOperator{5,1}
-  f::Float64
-  cr::Float64
-  DiffEvoRandBin2(f = 0.65, cr = 0.4) = new(f, cr)
-end
-
-function apply{T <: Real}(xo::DiffEvoRandBin2{T}, p1::Vector{T}, p2::Vector{T}, p3::Vector{T}, p4::Vector{T}, p5::Vector{T})
-  donor = p3 .+ de.f * (p1 .- p2) .+ de.f * (p4 .- p5)
-  de_crossover_binomial(p3, donor)
-end
-
-function de_crossover_binomial{T <: Real}(target::Vector{T}, donor::Vector{T})
-  trial = copy(target)
-
-  # Always ensure at least one value from donor is copied to trial vector.
-  jrand = rand(1:length(trial))
-  trial[jrand] = donor[jrand]
-
-  # Now crossover randomly for the rest of the indices.
-  switch = rand(length(trial)) .<= de.cr
-  trial[switch] = donor[switch]
-
-  return trial
+function apply!(xo::DiffEvoRandBin{5}, cr::Real, f::Number, target, pop, parentIndices)
+  @assert length(parentIndices) == 5
+  p1ix, p2ix, p3ix, p4ix, p5ix = parentIndices
+  # Always ensure at least one parameter is xovered
+  mut_ix = rand(1:length(target))
+  for i in 1:length(target)
+    if i == mut_ix || rand() <= cr
+      target[i] = pop[i,p3ix] +
+                f .* (pop[i,p1ix] .- pop[i,p2ix]) +
+                f .* (pop[i,p4ix] .- pop[i,p5ix])
+    end
+  end
+  return target
 end

--- a/src/genetic_operators/crossover/differential_evolution_crossover.jl
+++ b/src/genetic_operators/crossover/differential_evolution_crossover.jl
@@ -1,4 +1,6 @@
-type DiffEvoRandBin1{T <: Real} <: XoverOp3to1
+abstract DiffEvoCrossoverOperator{NP,NC} <: CrossoverOperator{NP,NC}
+
+type DiffEvoRandBin1{T <: Real} <: DiffEvoCrossoverOperator{3,1}
   f::Float64
   cr::Float64
   DiffEvoRandBin1(f = 0.65, cr = 0.4) = new(f, cr)
@@ -9,7 +11,7 @@ function apply{T <: Real}(xo::DiffEvoRandBin1{T}, p1::Vector{T}, p2::Vector{T}, 
   de_crossover_binomial(p3, donor)
 end
 
-type DiffEvoRandBin2{T <: Real} <: XoverOp5to1
+type DiffEvoRandBin2{T <: Real} <: DiffEvoCrossoverOperator{5,1}
   f::Float64
   cr::Float64
   DiffEvoRandBin2(f = 0.65, cr = 0.4) = new(f, cr)

--- a/src/genetic_operators/crossover/simulated_binary_crossover.jl
+++ b/src/genetic_operators/crossover/simulated_binary_crossover.jl
@@ -2,7 +2,7 @@
 
 calc_eta_exponent(eta) = 1 / (eta + 1)
 
-type SimulatedBinaryCrossover <: XoverOp2to2
+type SimulatedBinaryCrossover <: CrossoverOperator{2,2}
   eta
   etaexponent # Precalc the eta exponent used in calc of beta
   SimulatedBinaryCrossover(eta = 3.0) = new(eta, calc_eta_exponent(eta))

--- a/src/genetic_operators/genetic_operator.jl
+++ b/src/genetic_operators/genetic_operator.jl
@@ -1,22 +1,13 @@
 abstract GeneticOperator
 abstract MutationOperator <: GeneticOperator
-abstract CrossoverOperator <: GeneticOperator
+abstract CrossoverOperator{NP,NC} <: GeneticOperator
 
 apply{T <: Real}(o::MutationOperator, parents::Vector{Vector{T}}) = map(p -> apply(o, p), parents)
 
 numchildren(o::GeneticOperator) = 1
 numparents(o::MutationOperator) = 1 # But it will apply to each parent separately if given more than one...
-
-abstract XoverOp2to2 <: CrossoverOperator
-numparents(o::XoverOp2to2) = 2
-numchildren(o::XoverOp2to2) = 2
-
-abstract XoverOp3to1 <: CrossoverOperator
-numparents(o::XoverOp3to1) = 3
-
-abstract XoverOp5to1 <: CrossoverOperator
-numparents(o::XoverOp5to1) = 5
-numchildren(o::XoverOp5to1) = 1
+numparents{NP,NC}(o::CrossoverOperator{NP,NC}) = NP
+numchildren{NP,NC}(o::CrossoverOperator{NP,NC}) = NC
 
 apply{T <: Real}(xo::CrossoverOperator, parents::Vector{Vector{T}}) = apply(xo, parents...)
 

--- a/src/genetic_operators/genetic_operator.jl
+++ b/src/genetic_operators/genetic_operator.jl
@@ -9,7 +9,9 @@ numparents(o::MutationOperator) = 1 # But it will apply to each parent separatel
 numparents{NP,NC}(o::CrossoverOperator{NP,NC}) = NP
 numchildren{NP,NC}(o::CrossoverOperator{NP,NC}) = NC
 
-apply{T <: Real}(xo::CrossoverOperator, parents::Vector{Vector{T}}) = apply(xo, parents...)
+# mutation operator that does nothing
+type NoMutation <: MutationOperator end
+function apply!(mo::NoMutation, target) end
 
 include("mutation/polynomial_mutation.jl")
 include("mutation/mutation_clock.jl")

--- a/test/test_adaptive_differential_evolution.jl
+++ b/test/test_adaptive_differential_evolution.jl
@@ -4,13 +4,20 @@ facts("Adaptive differential evolution optimizer") do
 
 ade = adaptive_de_rand_1_bin()
 
-context("sample_f") do
+context("parameters adjust!()") do
   for(i in 1:NumTestRepetitions)
-    @fact 0.0 <= BlackBoxOptim.sample_f(ade) <= 1.0 => true
+    cur_cr, cur_f = BlackBoxOptim.crossover_parameters(ade.params, 1)
+    @fact 0.0 <= cur_cr <= 1.0 => true
+    @fact 0.0 <= cur_f <= 1.0 => true
+    BlackBoxOptim.adjust!(ade.params, 1, false)
+    # FIXME this fails too often; needs adjusting the distribution?
+    #new_cr, new_f = BlackBoxOptim.crossover_parameters(ade.params, 1)
+    #@fact new_cr != cur_cr => true
+    #@fact new_f != cur_f => true
   end
 end
 
-context("ask") do
+context("ask()") do
   for(i in 1:NumTestRepetitions)
     res = BlackBoxOptim.ask(ade)
 


### PR DESCRIPTION
It's me again. The package already had the code for genetic operators (mutation, crossover etc) abstraction, in this PR I convert DE and ADE algorithms to actually use it. There are some key advantages of operators:
 * operator-specific parameters could be encapsulated in the operator's class; that is not possible when using functions
 * specifying genetic operators as the parameters of an algorithm class facilitates compile-time optimizations of the algorithm code

I also introduced DiffEvoParameters class that allows unifying code for ADE and DE.

Finally, the crossover operators were optimized to only calculate the new values for the dimensions that are actually crossed-over.