### PR TITLE
MutationClock and MutationMixture

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,5 @@
 julia 0.3-
 FactCheck
+StatsBase
 Distributions
 Compat

--- a/src/BlackBoxOptim.jl
+++ b/src/BlackBoxOptim.jl
@@ -1,6 +1,6 @@
 module BlackBoxOptim
 
-using Distributions, Compat
+using Distributions, StatsBase, Compat
 
 export  Optimizer, PopulationOptimizer,
         bboptimize, compare_optimizers,
@@ -44,7 +44,7 @@ export  Optimizer, PopulationOptimizer,
 
         # Genetic operators
         GeneticOperator, MutationOperator, CrossoverOperator, EmbeddingOperator,
-        NoMutation, MutationClock, MutationMixture, GibbsMutationOperator, SimpleGibbsMutation,
+        NoMutation, MutationClock, GibbsMutationOperator, SimpleGibbsMutation, MutationMixture,
         RandomBound,
         SimpleSelector, RadiusLimitedSelector,
 

--- a/src/BlackBoxOptim.jl
+++ b/src/BlackBoxOptim.jl
@@ -44,6 +44,7 @@ export  Optimizer, PopulationOptimizer,
 
         # Genetic operators
         GeneticOperator, MutationOperator, CrossoverOperator, EmbeddingOperator,
+        NoMutation, MutationClock, MutationMixture, GibbsMutationOperator, SimpleGibbsMutation,
         RandomBound,
         SimpleSelector, RadiusLimitedSelector,
 

--- a/src/genetic_operators/genetic_operator.jl
+++ b/src/genetic_operators/genetic_operator.jl
@@ -27,6 +27,7 @@ function apply!(mo::NoMutation, target) end
 
 include("mutation/polynomial_mutation.jl")
 include("mutation/mutation_clock.jl")
+include("mutation/mutation_mixture.jl")
 include("crossover/simulated_binary_crossover.jl")
 include("crossover/differential_evolution_crossover.jl")
 include("embedding/random_bound.jl")

--- a/src/genetic_operators/mutation/mutation_mixture.jl
+++ b/src/genetic_operators/mutation/mutation_mixture.jl
@@ -1,0 +1,21 @@
+# Randomly selects the mutator from the vector
+# according to its weight and applies it
+type MutationMixture <: MutationOperator
+    mutators::Vector{MutationOperator} # available mutations
+    weights::WeightVec{Float64}        # mutation weights
+
+    function MutationMixture(mutators::Vector{MutationOperator}, rates::Vector{Float64})
+      length(mutators) == length(rates) || throw(DimensionMismatch("Number of mutators does not match the number of their rates"))
+      new(mutators, weights(rates))
+    end
+    MutationMixture(mutators::Vector{MutationOperator}) =
+      # uniform distribution of rates of diff
+      new(mutators, weights(fill(1.0/length(mutators), length(mutators))))
+end
+
+function apply!{T<:Real}(mm::MutationMixture, v::Vector{T})
+  if isempty(mm.mutators) return v end # no change
+
+  m = sample(mm.mutators, mm.weights) # randomly select the mutation to apply
+  return apply!(m, v)
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -10,6 +10,7 @@ my_tests = [
   "test_population.jl",
   "test_bimodal_cauchy_distribution.jl",
   "test_search_space.jl",
+  "test_mutation_operators.jl",
   "test_frequency_adaptation.jl",
   "test_archive.jl",
 

--- a/test/test_mutation_operators.jl
+++ b/test/test_mutation_operators.jl
@@ -1,0 +1,35 @@
+facts("Mutation operators") do
+  ss = RangePerDimSearchSpace([(-1.0, 1.0), (0.0, 100.0), (-5.0, 0.0)])
+
+  context("SimpleGibbsMutation") do
+    gibbs = SimpleGibbsMutation(ss)
+
+    @fact search_space(gibbs) => ss
+    # incorrect dimensions
+    @fact_throws BoundsError BlackBoxOptim.apply(gibbs, 2.0, 0)
+    @fact_throws BoundsError BlackBoxOptim.apply(gibbs, 2.0, 4)
+
+    for dim in 1:numdims(ss)
+      dim_range = range_for_dim(ss, dim)
+      for i in 1:NumTestRepetitions
+        t = BlackBoxOptim.apply(gibbs, 0.0, dim)
+        @fact dim_range[1] <= t <= dim_range[2] => true
+      end
+    end
+  end
+
+  context("MutationClock") do
+    mc = MutationClock(SimpleGibbsMutation(ss), 0.05)
+
+    n_params_mutated = 0
+    for i in 1:10000
+      ref_ind = rand_individual(ss)
+      ind = copy(ref_ind)
+      BlackBoxOptim.apply!(mc, ind)
+      @fact isinspace(ind, ss) => true
+      n_params_mutated += sum(ind .!= ref_ind)
+    end
+    @fact 300 <= n_params_mutated/numdims(ss) <= 700 => true # roughly matches the probability
+  end
+
+end

--- a/test/test_mutation_operators.jl
+++ b/test/test_mutation_operators.jl
@@ -32,4 +32,19 @@ facts("Mutation operators") do
     @fact 300 <= n_params_mutated/numdims(ss) <= 700 => true # roughly matches the probability
   end
 
+  context("MutationMixture") do
+    mx = MutationMixture([NoMutation(), MutationClock(SimpleGibbsMutation(ss), 0.05)], [0.3, 0.7])
+
+    ref_ind = rand_individual(ss)
+    n_params_mutated = 0
+    for i in 1:10000
+      ind = copy(ref_ind)
+      BlackBoxOptim.apply!(mx, ind)
+      @fact isinspace(ind, ss) => true
+      n_params_mutated += (any(ind .!= ref_ind))
+    end
+    # the number of parameters changed should roughly match the weight of MutationClock multiplied by its mutation probability
+    @fact 200 < n_params_mutated/numdims(ss) < 500 => true
+  end
+
 end


### PR DESCRIPTION
The PR makes ```MutationClock``` working by adding ```GibbsMutationOperator``` types (mutates one specific dimension at a time) and adds ```MutationMixture``` that randomly applies the mutation from a list according to the weights.

It requires #15 to be merged first, so when and if that would be done, I'll rebase this PR.