### PR TITLE
Fitness-storing Population & friends

### DIFF
--- a/examples/benchmarking/compare_optimizers.jl
+++ b/examples/benchmarking/compare_optimizers.jl
@@ -184,10 +184,10 @@ increase_runs_per_problem(problemname, numdims) = begin
   RunsPerProblem[k] = get(RunsPerProblem, k, 0) + 1
 end
 
-function fitness_for_opt(problem, numDimensions, populationSize, numFuncEvals,
+function fitness_for_opt(family::FunctionBasedProblemFamily, numDimensions, populationSize, numFuncEvals,
     method, showtrace = true)
 
-  problem = BlackBoxOptim.as_fixed_dim_problem(problem, numDimensions)
+  problem = BlackBoxOptim.fixed_dim_problem(family, numDimensions)
 
   best, fitness = bboptimize(problem; method = method, parameters = {
     :NumDimensions => numDimensions,

--- a/examples/benchmarking/compare_optimizers.jl
+++ b/examples/benchmarking/compare_optimizers.jl
@@ -200,7 +200,7 @@ function fitness_for_opt(family::FunctionBasedProblemFamily, numDimensions, popu
 end
 
 function latest_git_id()
-  strip(readall(`git log --format="%H" -n 1`))
+  strip(readall(`git -C "$(Pkg.dir("BlackBoxOptim"))" log --format="%H" -n 1`))
 end
 
 # Test an optimizer on multiple problems and dimensions, return results in dict.

--- a/src/BlackBoxOptim.jl
+++ b/src/BlackBoxOptim.jl
@@ -30,7 +30,7 @@ export  Optimizer, AskTellOptimizer, SteppingOptimizer, PopulationOptimizer,
         Problems,
         OptimizationProblem, FunctionBasedProblem,
         name, fitness_scheme, search_space, numdims, opt_value,
-        fitness_is_within_ftol, objfunc,
+        fitness_is_within_ftol, objfunc, fitness,
 
         # Problem factory/family
         FunctionBasedProblemFamily, MinimizationProblemFamily,
@@ -50,7 +50,7 @@ export  Optimizer, AskTellOptimizer, SteppingOptimizer, PopulationOptimizer,
         rand_individual, rand_individuals, isinspace, rand_individuals_lhs,
 
         # Population
-        FloatVectorPopulation,
+        FitPopulation,
         popsize,
 
         # Genetic operators
@@ -75,6 +75,7 @@ abstract AskTellOptimizer <: Optimizer
 # population-based optimizers
 abstract PopulationOptimizer <: AskTellOptimizer
 population(popopt::PopulationOptimizer) = popopt.population
+popsize(popopt::PopulationOptimizer) = popsize(population(popopt))
 
 module Utils
   include("utilities/latin_hypercube_sampling.jl")
@@ -84,7 +85,6 @@ end
 include("search_space.jl")
 include("parameters.jl")
 include("fitness.jl")
-include("population.jl")
 
 # Genetic Operators
 include("genetic_operators/genetic_operator.jl")
@@ -115,6 +115,9 @@ function name(o::Optimizer)
     return s
   end
 end
+
+# Population
+include("population.jl")
 
 # Our design is inspired by the object-oriented, ask-and-tell "optimizer API
 # format" as proposed in:

--- a/src/BlackBoxOptim.jl
+++ b/src/BlackBoxOptim.jl
@@ -2,7 +2,7 @@ module BlackBoxOptim
 
 using Distributions, StatsBase, Compat
 
-export  Optimizer, PopulationOptimizer,
+export  Optimizer, AskTellOptimizer, SteppingOptimizer, PopulationOptimizer,
         bboptimize, compare_optimizers,
 
         DiffEvoOpt, de_rand_1_bin, de_rand_1_bin_radiuslimited,
@@ -50,7 +50,20 @@ export  Optimizer, PopulationOptimizer,
 
         name
 
+# base abstract class for black-box optimization algorithms
 abstract Optimizer
+
+# SteppingOptimizer's do not have an ask and tell interface since they would be
+# complex to implement if forced into that form.
+abstract SteppingOptimizer <: Optimizer
+evaluator(so::SteppingOptimizer) = so.evaluator
+
+# optimizer using ask()/..eval fitness../tell!() sequence at each step
+abstract AskTellOptimizer <: Optimizer
+
+# population-based optimizers
+abstract PopulationOptimizer <: AskTellOptimizer
+population(popopt::PopulationOptimizer) = popopt.population
 
 module Utils
   include("utilities/latin_hypercube_sampling.jl")
@@ -92,10 +105,6 @@ function name(o::Optimizer)
   end
 end
 
-abstract PopulationOptimizer <: Optimizer
-
-population(o::PopulationOptimizer) = o.population # Fallback method if sub-types have not implemented it.
-
 # Our design is inspired by the object-oriented, ask-and-tell "optimizer API
 # format" as proposed in:
 #
@@ -125,8 +134,6 @@ population(o::PopulationOptimizer) = o.population # Fallback method if sub-types
 # is no single optimum. Instead there are many pareto optimal solutions.
 # An archive collects information about the pareto optimal set or some
 # approximation of it. Different archival strategies can be implemented.
-
-has_ask_tell_interface(o::Optimizer) = true # Default is to have an ask and tell interface...
 
 # Different optimization algorithms
 include("random_search.jl")

--- a/src/BlackBoxOptim.jl
+++ b/src/BlackBoxOptim.jl
@@ -27,10 +27,16 @@ export  Optimizer, AskTellOptimizer, SteppingOptimizer, PopulationOptimizer,
         #ProblemEvaluator,
 
         # Problems
-        Problems, FixedDimProblem, is_fixed_dimensional, is_any_dimensional,
-        is_single_objective_problem, is_multi_objective_problem,
-        search_space, eval1, evalall, anydim_problem, as_fixed_dim_problem,
-        fitness_is_within_ftol, save_fitness_history_to_csv_file,
+        Problems,
+        OptimizationProblem, FunctionBasedProblem,
+        name, fitness_scheme, search_space, numdims, opt_value,
+        fitness_is_within_ftol, objfunc,
+
+        # Problem factory/family
+        FunctionBasedProblemFamily, MinimizationProblemFamily,
+        fixed_dim_problem,
+
+        save_fitness_history_to_csv_file,
 
         # Archive
         TopListArchive, best_fitness, add_candidate!, best_candidate,
@@ -86,8 +92,8 @@ include("genetic_operators/genetic_operator.jl")
 include("frequency_adaptation.jl")
 include("archive.jl")
 
-# Problems for testing
 include(joinpath("problems", "all_problems.jl"))
+include(joinpath("problems", "problem_family.jl"))
 
 include("evaluator.jl")
 
@@ -158,5 +164,8 @@ include("bboptimize.jl")
 include("fitness/pareto_dominance.jl")
 include("fitness/epsilon_pareto_dominance.jl")
 include("fitness/epsilon_box_dominance.jl")
+
+# Problems for testing
+include(joinpath("problems", "single_objective.jl"))
 
 end # module BlackBoxOptim

--- a/src/BlackBoxOptim.jl
+++ b/src/BlackBoxOptim.jl
@@ -16,6 +16,12 @@ export  Optimizer, AskTellOptimizer, SteppingOptimizer, PopulationOptimizer,
         Parameters, mergeparam,
 
         # Fitness
+        FitnessScheme,
+        ScalarFitness, ComplexFitness, VectorFitness,
+        fitness_type, numobjectives,
+        is_minimizing, nafitness, isnafitness,
+        hat_compare, is_better, is_worse, same_fitness,
+        vector_fitness_scheme_min, vector_fitness_scheme_max,
 
         # Evaluator
         #ProblemEvaluator,
@@ -37,10 +43,9 @@ export  Optimizer, AskTellOptimizer, SteppingOptimizer, PopulationOptimizer,
         numdims, mins, maxs, deltas, ranges, range_for_dim, diameters,
         rand_individual, rand_individuals, isinspace, rand_individuals_lhs,
 
-        hat_compare, is_better, is_worse, same_fitness,
-        popsize,
-        FloatVectorFitness, float_vector_scheme_min, float_vector_scheme_max,
+        # Population
         FloatVectorPopulation,
+        popsize,
 
         # Genetic operators
         GeneticOperator, MutationOperator, CrossoverOperator, EmbeddingOperator,
@@ -149,7 +154,7 @@ include("direct_search_with_probabilistic_descent.jl")
 include("bboptimize.jl")
 
 # Fitness
-include("fitness/fitness_types.jl")
+# include("fitness/fitness_types.jl") FIXME merge it with fitness.jl
 include("fitness/pareto_dominance.jl")
 include("fitness/epsilon_pareto_dominance.jl")
 include("fitness/epsilon_box_dominance.jl")

--- a/src/adaptive_differential_evolution.jl
+++ b/src/adaptive_differential_evolution.jl
@@ -41,22 +41,21 @@ function adjust!( params::AdaptiveDiffEvoParameters, index, is_improved::Bool )
     end
 end
 
-function adaptive_diffevo(name::ASCIIString,
+function adaptive_diffevo(problem::OptimizationProblem, name::ASCIIString,
                  crossover::DiffEvoCrossoverOperator,
                  select::IndividualsSelector = SimpleSelector(),
                  options = @compat Dict{Symbol,Any}())
   opts = Parameters(options, ADE_DefaultOptions)
-  ss = opts[:SearchSpace]
   pop = opts[:Population]
   DiffEvoOpt(name, pop, AdaptiveDiffEvoParameters(opts, popsize(pop)), select,
-        NoMutation(), crossover, RandomBound(ss))
+        NoMutation(), crossover, RandomBound(search_space(problem)))
 end
 
-adaptive_de_rand_1_bin(options = @compat(Dict{Symbol,Any}()),
+adaptive_de_rand_1_bin(problem::OptimizationProblem, options = @compat(Dict{Symbol,Any}()),
               name = "AdaptiveDE/rand/1/bin") =
-    adaptive_diffevo(name, DiffEvoRandBin1(), SimpleSelector(), options)
+    adaptive_diffevo(problem, name, DiffEvoRandBin1(), SimpleSelector(), options)
 
-adaptive_de_rand_1_bin_radiuslimited(options = @compat(Dict{Symbol,Any}()),
+adaptive_de_rand_1_bin_radiuslimited(problem::OptimizationProblem, options = @compat(Dict{Symbol,Any}()),
                                      name = "AdaptiveDE/rand/1/bin/radiuslimited") =
-    adaptive_diffevo(name, DiffEvoRandBin1(),
+    adaptive_diffevo(problem, name, DiffEvoRandBin1(),
                      RadiusLimitedSelector(Parameters(options, ADE_DefaultOptions)[:SamplerRadius]), options)

--- a/src/adaptive_differential_evolution.jl
+++ b/src/adaptive_differential_evolution.jl
@@ -41,21 +41,22 @@ function adjust!( params::AdaptiveDiffEvoParameters, index, is_improved::Bool )
     end
 end
 
-function adaptive_de_rand_1_bin(options = @compat Dict{Symbol,Any}())
+function adaptive_diffevo(name::ASCIIString,
+                 crossover::DiffEvoCrossoverOperator,
+                 select::IndividualsSelector = SimpleSelector(),
+                 options = @compat Dict{Symbol,Any}())
   opts = Parameters(options, ADE_DefaultOptions)
   ss = opts[:SearchSpace]
-  population = get(opts, :Population, rand_individuals_lhs(ss, get(opts,:PopulationSize,50)))
-  DiffEvoOpt( "AdaptiveDE/rand/1/bin", population,
-        AdaptiveDiffEvoParameters( opts, size(population,2) ), SimpleSelector(),
-        NoMutation(), DiffEvoRandBin1(), RandomBound(ss) )
+  pop = opts[:Population]
+  DiffEvoOpt(name, pop, AdaptiveDiffEvoParameters(opts, popsize(pop)), select,
+        NoMutation(), crossover, RandomBound(ss))
 end
 
-function adaptive_de_rand_1_bin_radiuslimited(options = @compat Dict{Symbol,Any})
-  opts = Parameters(options, ADE_DefaultOptions)
-  ss = opts[:SearchSpace]
-  population = get(opts, :Population, rand_individuals_lhs(ss, get(opts,:PopulationSize,50)))
-  DiffEvoOpt( "AdaptiveDE/rand/1/bin/radiuslimited", population,
-        AdaptiveDiffEvoParameters( opts, size(population,2) ),
-        RadiusLimitedSelector(opts[:SamplerRadius]),
-        NoMutation(), DiffEvoRandBin1(), RandomBound(ss) )
-end
+adaptive_de_rand_1_bin(options = @compat(Dict{Symbol,Any}()),
+              name = "AdaptiveDE/rand/1/bin") =
+    adaptive_diffevo(name, DiffEvoRandBin1(), SimpleSelector(), options)
+
+adaptive_de_rand_1_bin_radiuslimited(options = @compat(Dict{Symbol,Any}()),
+                                     name = "AdaptiveDE/rand/1/bin/radiuslimited") =
+    adaptive_diffevo(name, DiffEvoRandBin1(),
+                     RadiusLimitedSelector(Parameters(options, ADE_DefaultOptions)[:SamplerRadius]), options)

--- a/src/adaptive_differential_evolution.jl
+++ b/src/adaptive_differential_evolution.jl
@@ -46,7 +46,7 @@ function adaptive_diffevo(problem::OptimizationProblem, name::ASCIIString,
                  select::IndividualsSelector = SimpleSelector(),
                  options = @compat Dict{Symbol,Any}())
   opts = Parameters(options, ADE_DefaultOptions)
-  pop = opts[:Population]
+  pop = population(problem, opts)
   DiffEvoOpt(name, pop, AdaptiveDiffEvoParameters(opts, popsize(pop)), select,
         NoMutation(), crossover, RandomBound(search_space(problem)))
 end

--- a/src/bboptimize.jl
+++ b/src/bboptimize.jl
@@ -84,7 +84,7 @@ function setup_problem(func::Function, parameters = @compat Dict{Symbol,Any}())
   # Now create an optimization problem with the given information. We currently reuse the type
   # from our pre-defined problems so some of the data for the constructor is dummy.
 
-  problem = FunctionBasedProblem(func, "", ScalarFitness{true}(), ss)
+  problem = convert(FunctionBasedProblem, func, "", ScalarFitness{true}(), ss) # FIXME v0.3 workaround
 
   return problem, params
 end

--- a/src/bboptimize.jl
+++ b/src/bboptimize.jl
@@ -235,11 +235,9 @@ function setup_bboptimize(functionOrProblem; max_time = false,
   if (typeof(method) != Symbol) || !any([(method == vm) for vm in MethodNames])
     throw(ArgumentError("The method specified, $(method), is NOT among the valid methods: $(MethodNames)"))
   end
-  pop = BlackBoxOptim.rand_individuals_lhs(BlackBoxOptim.search_space(problem), params[:PopulationSize])
 
   params = Parameters(params, @compat Dict{Symbol,Any}(
-    :Evaluator    => ProblemEvaluator(problem),
-    :Population   => pop,
+    :Evaluator    => ProblemEvaluator(problem)
   ))
   optimizer_func = ValidMethods[method]
   optimizer = optimizer_func(problem, params)
@@ -384,8 +382,8 @@ function run_optimizer(opt::Optimizer, problem::OptimizationProblem, parameters 
   tr("Total function evaluations = $(num_evals(evaluator))\n", parameters)
 
   if typeof(opt) <: PopulationOptimizer
-    tr("\nMean value (in population) per position:", parameters, mean(population(opt),1))
-    tr("\n\nStd dev (in population) per position:", parameters, std(population(opt),1))
+    tr("\nMean value (in population) per position:", parameters, params_mean(population(opt)))
+    tr("\n\nStd dev (in population) per position:", parameters, params_std(population(opt)))
   end
 
   best = best_candidate(evaluator.archive)

--- a/src/bboptimize.jl
+++ b/src/bboptimize.jl
@@ -263,14 +263,6 @@ function tr(msg, parameters, obj = None)
   end
 end
 
-function find_best_individual(e::Evaluator, opt::PopulationOptimizer)
-  (best_candidate(e.archive), 1, best_fitness(e.archive))
-end
-
-function find_best_individual(e::Evaluator, opt::Optimizer)
-  (best_candidate(e.archive), 1, best_fitness(e.archive))
-end
-
 # The ask and tell interface is more general since you can mix and max
 # elements from several optimizers using it. However, in this top-level
 # execution function we do not make use of this flexibility...
@@ -400,7 +392,8 @@ function run_optimizer_on_problem(opt::Optimizer, problem::OptimizationProblem;
     tr("\n\nStd dev (in population) per position:", parameters, std(population(opt),1))
   end
 
-  best, index, fitness = find_best_individual(evaluator, opt)
+  best = best_candidate(evaluator.archive)
+  fitness = best_fitness(evaluator.archive)
   tr("\n\nBest candidate found: ", parameters, best)
   tr("\n\nFitness: ", parameters, fitness)
   tr("\n\n", parameters)

--- a/src/bboptimize.jl
+++ b/src/bboptimize.jl
@@ -1,19 +1,19 @@
 # FIXME replace Any with Type{Optimizer} when the support for Julia v0.3 would be dropped
 ValidMethods = @compat Dict{Symbol,Union(Any,Function)}(
-  :random_search => BlackBoxOptim.random_search,
-  :de_rand_1_bin => BlackBoxOptim.de_rand_1_bin,
-  :de_rand_2_bin => BlackBoxOptim.de_rand_2_bin,
-  :de_rand_1_bin_radiuslimited => BlackBoxOptim.de_rand_1_bin_radiuslimited,
-  :de_rand_2_bin_radiuslimited => BlackBoxOptim.de_rand_2_bin_radiuslimited,
-  :adaptive_de_rand_1_bin => BlackBoxOptim.adaptive_de_rand_1_bin,
-  :adaptive_de_rand_1_bin_radiuslimited => BlackBoxOptim.adaptive_de_rand_1_bin_radiuslimited,
-  :separable_nes => BlackBoxOptim.separable_nes,
-  :xnes => BlackBoxOptim.xnes,
-  :resampling_memetic_search => BlackBoxOptim.resampling_memetic_searcher,
-  :resampling_inheritance_memetic_search => BlackBoxOptim.resampling_inheritance_memetic_searcher,
-  :simultaneous_perturbation_stochastic_approximation => BlackBoxOptim.SimultaneousPerturbationSA2,
-  :generating_set_search => BlackBoxOptim.GeneratingSetSearcher,
-  :probabilistic_descent => BlackBoxOptim.direct_search_probabilistic_descent,
+  :random_search => random_search,
+  :de_rand_1_bin => de_rand_1_bin,
+  :de_rand_2_bin => de_rand_2_bin,
+  :de_rand_1_bin_radiuslimited => de_rand_1_bin_radiuslimited,
+  :de_rand_2_bin_radiuslimited => de_rand_2_bin_radiuslimited,
+  :adaptive_de_rand_1_bin => adaptive_de_rand_1_bin,
+  :adaptive_de_rand_1_bin_radiuslimited => adaptive_de_rand_1_bin_radiuslimited,
+  :separable_nes => separable_nes,
+  :xnes => xnes,
+  :resampling_memetic_search => resampling_memetic_searcher,
+  :resampling_inheritance_memetic_search => resampling_inheritance_memetic_searcher,
+  :simultaneous_perturbation_stochastic_approximation => SimultaneousPerturbationSA2,
+  :generating_set_search => GeneratingSetSearcher,
+  :probabilistic_descent => direct_search_probabilistic_descent,
 )
 
 MethodNames = collect(keys(ValidMethods))

--- a/src/differential_evolution.jl
+++ b/src/differential_evolution.jl
@@ -105,31 +105,34 @@ end
 # Now we can create specific DE optimizers that are commonly used in the
 # literature.
 
-function diffevo(name::ASCIIString,
+function diffevo(problem::OptimizationProblem, name::ASCIIString,
                  select::IndividualsSelector = SimpleSelector(),
                  crossover::DiffEvoCrossoverOperator = DiffEvoRandBin1(),
                  options = @compat Dict{Symbol,Any}())
   opts = Parameters(options, DE_DefaultOptions)
-  ss = opts[:SearchSpace]
   pop = opts[:Population]
   DiffEvoOpt(name, pop, FixedDiffEvoParameters(opts, popsize(pop)), select,
-        NoMutation(), crossover, RandomBound(ss))
+        NoMutation(), crossover, RandomBound(search_space(problem)))
 end
 
 # The most used DE/rand/1/bin.
-de_rand_1_bin(options = @compat(Dict{Symbol,Any}()),
-              name = "DE/rand/1/bin") = diffevo(name, SimpleSelector(), DiffEvoRandBin1(), options)
+de_rand_1_bin(problem::OptimizationProblem,
+              options = @compat(Dict{Symbol,Any}()),
+              name = "DE/rand/1/bin") = diffevo(problem, name, SimpleSelector(), DiffEvoRandBin1(), options)
 
-de_rand_2_bin(options = @compat(Dict{Symbol,Any}()),
-              name = "DE/rand/2/bin") = diffevo(name, SimpleSelector(), DiffEvoRandBin2(), options)
+de_rand_2_bin(problem::OptimizationProblem,
+              options = @compat(Dict{Symbol,Any}()),
+              name = "DE/rand/2/bin") = diffevo(problem, name, SimpleSelector(), DiffEvoRandBin2(), options)
 
 # The most used DE/rand/1/bin with "local geography" via radius limited sampling.
-de_rand_1_bin_radiuslimited(options = @compat(Dict{Symbol,Any}()),
+de_rand_1_bin_radiuslimited(problem::OptimizationProblem,
+                            options = @compat(Dict{Symbol,Any}()),
                             name = "DE/rand/1/bin/radiuslimited") =
-    diffevo(name, RadiusLimitedSelector(Parameters(options, DE_DefaultOptions)[:SamplerRadius]),
+    diffevo(problem, name, RadiusLimitedSelector(Parameters(options, DE_DefaultOptions)[:SamplerRadius]),
             DiffEvoRandBin1(), options)
 
-de_rand_2_bin_radiuslimited(options = @compat(Dict{Symbol,Any}()),
+de_rand_2_bin_radiuslimited(problem::OptimizationProblem,
+                            options = @compat(Dict{Symbol,Any}()),
                             name = "DE/rand/2/bin/radiuslimited") =
-    diffevo(name, RadiusLimitedSelector(Parameters(options, DE_DefaultOptions)[:SamplerRadius]),
+    diffevo(problem, name, RadiusLimitedSelector(Parameters(options, DE_DefaultOptions)[:SamplerRadius]),
             DiffEvoRandBin2(), options)

--- a/src/differential_evolution.jl
+++ b/src/differential_evolution.jl
@@ -25,12 +25,11 @@ function adjust!( params::FixedDiffEvoParameters, index, is_improved::Bool )
     # do nothing
 end
 
-type DiffEvoOpt{P<:DiffEvoParameters,S<:IndividualsSelector,M<:MutationOperator,X<:DiffEvoCrossoverOperator,E<:EmbeddingOperator} <: DifferentialEvolutionOpt
+type DiffEvoOpt{POP<:Population,P<:DiffEvoParameters,S<:IndividualsSelector,M<:MutationOperator,X<:DiffEvoCrossoverOperator,E<:EmbeddingOperator} <: DifferentialEvolutionOpt
   # TODO when sampler and bound would be parameterized, name is no longer required -- as everything is seen in the type name
   name::ASCIIString
 
-  # A population is a matrix of floats, individuals stored in columns.
-  population::Array{Float64, 2}
+  population::POP
 
   # Set of operators that together define a specific DE strategy.
   params::P        # adjust crossover parameters after fitness calculation
@@ -40,17 +39,12 @@ type DiffEvoOpt{P<:DiffEvoParameters,S<:IndividualsSelector,M<:MutationOperator,
   embed::E         # embedding operator
 end
 
-function DiffEvoOpt{P<:DiffEvoParameters, S<:IndividualsSelector,
+function DiffEvoOpt{POP<:Population,P<:DiffEvoParameters, S<:IndividualsSelector,
                     M<:MutationOperator, X<:DiffEvoCrossoverOperator, E<:EmbeddingOperator}(
-    name::ASCIIString, pop, params::P,
+    name::ASCIIString, pop::POP, params::P,
     select::S = S(), mutate::M = M(), crossover::X = X(), embed::E = E())
-  DiffEvoOpt{P,S,M,X,E}(name, pop, params, select, mutate, crossover, embed)
+  DiffEvoOpt{POP,P,S,M,X,E}(name, pop, params, select, mutate, crossover, embed)
 end
-
-popsize(pop::Matrix{Float64}) = size(pop,2)
-popsize(opt::DifferentialEvolutionOpt) = popsize(population(opt))
-
-make_candidate(pop::Matrix{Float64}, i::Int) = Candidate{Float64}(pop[:, i], i)
 
 # Ask for a new candidate object to be evaluated, and a list of individuals
 # it should be ranked with. The individuals are supplied as an array of tuples
@@ -61,17 +55,21 @@ function ask(de::DiffEvoOpt)
   parent_indices = indices[1:numparents(de.crossover)]
   #println("parent_indices = $(parent_indices)")
   target_index = indices[end]
-  target = make_candidate(de.population, target_index) # FIXME we can cache target somewhere
+  target = acquire_candi(de.population, target_index)
   #println("target[$(target_index)] = $(target)")
 
   # Crossover parents and target
   @assert numchildren(de.crossover)==1
-  trial = copy(target) # FIXME reuse some trial vector
-  apply!( de.crossover,
-          crossover_parameters( de.params, target_index )...,
-          trial.params, de.population, parent_indices )
+  trial = acquire_candi(de.population, target)
+  apply!(de.crossover,
+         crossover_parameters( de.params, target_index )...,
+         trial.params, de.population, parent_indices)
   # embed the trial parameter vector into the search space
   apply!(de.embed, trial.params, de.population, [target_index])
+  if trial.params != target.params
+    reset_fitness!(trial, de.population)
+  end
+
   #println("trial = $(trial)")
 
   # Return the candidates that should be ranked as tuples including their
@@ -84,19 +82,27 @@ end
 function tell!{F}(de::DiffEvoOpt,
   # archive::Archive, # Skip for now
   rankedCandidates::Vector{Candidate{F}})
-  num_candidates = length(rankedCandidates)
+  n_acceptable_candidates = length(rankedCandidates)÷2
   num_better = 0
-  for i in 1:div(num_candidates, 2)
+  for i in eachindex(rankedCandidates)
     candi = rankedCandidates[i]
-    is_inserted = candi.params != de.population[:,candi.index]
-    adjust!( de.params, candi.index, is_inserted )
-    if is_inserted
+    # accept the modified individuals from the top ranked half
+    if i <= n_acceptable_candidates
+      is_improved = candi.params != population(de)[candi.index]
+      adjust!(de.params, candi.index, is_improved)
+    else
+      is_improved = false
+    end
+    if is_improved
       num_better += 1
       #print("candidate = "); show(candidate); println("")
       #print("index = "); show(index); println("")
       #print("target = "); show(de.population[index,:]); println("")
       #old = de.population[:,index]
-      de.population[:,candi.index] = candi.params
+      accept_candi!(de.population, candi)
+    else
+      # just return candidate to the pool
+      release_candi(de.population, candi)
     end
   end
   num_better
@@ -110,7 +116,7 @@ function diffevo(problem::OptimizationProblem, name::ASCIIString,
                  crossover::DiffEvoCrossoverOperator = DiffEvoRandBin1(),
                  options = @compat Dict{Symbol,Any}())
   opts = Parameters(options, DE_DefaultOptions)
-  pop = opts[:Population]
+  pop = population(problem, opts)
   DiffEvoOpt(name, pop, FixedDiffEvoParameters(opts, popsize(pop)), select,
         NoMutation(), crossover, RandomBound(search_space(problem)))
 end

--- a/src/differential_evolution.jl
+++ b/src/differential_evolution.jl
@@ -105,32 +105,31 @@ end
 # Now we can create specific DE optimizers that are commonly used in the
 # literature.
 
-# The most used DE/rand/1/bin.
-function de_rand_1_bin(options = @compat Dict{Symbol,Any}();
-                       select = SimpleSelector(), name = "DE/rand/1/bin")
+function diffevo(name::ASCIIString,
+                 select::IndividualsSelector = SimpleSelector(),
+                 crossover::DiffEvoCrossoverOperator = DiffEvoRandBin1(),
+                 options = @compat Dict{Symbol,Any}())
   opts = Parameters(options, DE_DefaultOptions)
-  DiffEvoOpt(name, opts[:Population],
-        FixedDiffEvoParameters(opts, size(opts[:Population], 2)), select,
-        NoMutation(), DiffEvoRandBin1(), RandomBound(opts[:SearchSpace]))
+  ss = opts[:SearchSpace]
+  pop = opts[:Population]
+  DiffEvoOpt(name, pop, FixedDiffEvoParameters(opts, popsize(pop)), select,
+        NoMutation(), crossover, RandomBound(ss))
 end
 
-function de_rand_2_bin(options = @compat Dict{Symbol,Any}();
-                       select = SimpleSelector(), name = "DE/rand/2/bin")
-  opts = Parameters(options, DE_DefaultOptions)
-  DiffEvoOpt(name, opts[:Population],
-        FixedDiffEvoParameters(opts, size(opts[:Population], 2)), select,
-        NoMutation(), DiffEvoRandBin2(), RandomBound(opts[:SearchSpace]))
-end
+# The most used DE/rand/1/bin.
+de_rand_1_bin(options = @compat(Dict{Symbol,Any}()),
+              name = "DE/rand/1/bin") = diffevo(name, SimpleSelector(), DiffEvoRandBin1(), options)
+
+de_rand_2_bin(options = @compat(Dict{Symbol,Any}()),
+              name = "DE/rand/2/bin") = diffevo(name, SimpleSelector(), DiffEvoRandBin2(), options)
 
 # The most used DE/rand/1/bin with "local geography" via radius limited sampling.
-function de_rand_1_bin_radiuslimited(options = @compat Dict{Symbol,Any}())
-  opts = Parameters(options, DE_DefaultOptions)
-  de_rand_1_bin(opts; select = RadiusLimitedSelector(opts[:SamplerRadius]),
-                name = "DE/rand/1/bin/radiuslimited")
-end
+de_rand_1_bin_radiuslimited(options = @compat(Dict{Symbol,Any}()),
+                            name = "DE/rand/1/bin/radiuslimited") =
+    diffevo(name, RadiusLimitedSelector(Parameters(options, DE_DefaultOptions)[:SamplerRadius]),
+            DiffEvoRandBin1(), options)
 
-function de_rand_2_bin_radiuslimited(options = @compat Dict{Symbol,Any}())
-  opts = Parameters(options, DE_DefaultOptions)
-  de_rand_2_bin(opts; select = RadiusLimitedSelector(opts[:SamplerRadius]),
-                name = "DE/rand/2/bin/radiuslimited")
-end
+de_rand_2_bin_radiuslimited(options = @compat(Dict{Symbol,Any}()),
+                            name = "DE/rand/2/bin/radiuslimited") =
+    diffevo(name, RadiusLimitedSelector(Parameters(options, DE_DefaultOptions)[:SamplerRadius]),
+            DiffEvoRandBin2(), options)

--- a/src/direct_search_with_probabilistic_descent.jl
+++ b/src/direct_search_with_probabilistic_descent.jl
@@ -30,8 +30,8 @@ type MirroredRandomDirectionGen <: DirectionGenerator
   numDirections::Int
 
   MirroredRandomDirectionGen(numDims, numDirections) = begin
-    if numDirections % 2 == 1
-      throw("the number of directions must be even")
+    if !iseven(numDirections)
+      throw(ArgumentError("the number of directions must be even"))
     end
     new(numDims, numDirections)
   end
@@ -46,8 +46,8 @@ DirectSearchProbabilisticDescentDefaultParameters = @compat Dict{Symbol,Any}(
   :NumDirections => 2, # This should be a function of Gamma and Phi for the GSS but 2 is often enough
 )
 
-function direct_search_probabilistic_descent(parameters)
+function direct_search_probabilistic_descent(problem::OptimizationProblem, parameters)
   params = Parameters(parameters, DirectSearchProbabilisticDescentDefaultParameters)
-  params[:DirectionGenerator] = MirroredRandomDirectionGen(numdims(params[:Evaluator]), params[:NumDirections])
-  GeneratingSetSearcher(params)
+  params[:DirectionGenerator] = MirroredRandomDirectionGen(numdims(problem), params[:NumDirections])
+  GeneratingSetSearcher(problem, params)
 end

--- a/src/evaluator.jl
+++ b/src/evaluator.jl
@@ -67,6 +67,15 @@ type Candidate{F}
               fitness::F = NaN) = new(params, index, fitness)
 end
 
+Base.copy{F}(c::Candidate{F}) = Candidate{F}(copy(c.params), c.index, c.fitness)
+
+function Base.copy!{F}(c::Candidate{F}, o::Candidate{F})
+  copy!(c.params, o.params)
+  c.index = o.index
+  c.fitness = o.fitness # FIXME if vector?
+  return c
+end
+
 function rank_by_fitness!{F,P<:OptimizationProblem}(e::Evaluator{P}, candidates::Vector{Candidate{F}})
   fs = fitness_scheme(e)
   for i in eachindex(candidates)
@@ -78,7 +87,5 @@ function rank_by_fitness!{F,P<:OptimizationProblem}(e::Evaluator{P}, candidates:
 
   sort!(candidates; by = c -> c.fitness, lt = (x, y) -> is_better(x, y, fs))
 end
-
-Base.copy{F}(c::Candidate{F}) = Candidate{F}(copy(c.params), c.index, c.fitness)
 
 fitness_is_within_ftol(e::Evaluator, atol) = fitness_is_within_ftol(problem(e), best_fitness(e.archive), atol)

--- a/src/evaluator.jl
+++ b/src/evaluator.jl
@@ -32,10 +32,10 @@ num_evals(e::ProblemEvaluator) = e.num_evals
 
 # evaluates the fitness (and implicitly updates the stats)
 function fitness(params::Individual, e::ProblemEvaluator)
-  e.last_fitness = fitness(params, e.problem)
+  e.last_fitness = res = fitness(params, e.problem)
   e.num_evals += 1
-  add_candidate!(e.archive, e.last_fitness, params, e.num_evals)
-  e.last_fitness
+  add_candidate!(e.archive, res, params, e.num_evals)
+  res
 end
 
 # A way to get the fitness of the last evaluated candidate. Leads to nicer

--- a/src/evaluator.jl
+++ b/src/evaluator.jl
@@ -23,7 +23,7 @@ problem_summary(e::Evaluator) = "$(name(e.problem))_$(numdims(e))d"
 problem(e::Evaluator) = e.problem
 
 function evaluate(e::Evaluator, candidate)
-  e.last_fitness = eval1(candidate, e.problem)
+  e.last_fitness = fitness(candidate, e.problem)
   e.num_evals += 1
   add_candidate!(e.archive, e.last_fitness, candidate, e.num_evals)
   e.last_fitness
@@ -69,4 +69,4 @@ end
 
 Base.copy{F}(c::Candidate{F}) = Candidate{F}(copy(c.params), c.index, c.fitness)
 
-fitness_is_within_ftol(e::Evaluator, ftolerance, index::Int = 1) = fitness_is_within_ftol(problem(e), ftolerance, best_fitness(e.archive), index)
+fitness_is_within_ftol(e::Evaluator, atol::Float64) = fitness_is_within_ftol(problem(e), best_fitness(e.archive), atol)

--- a/src/evaluator.jl
+++ b/src/evaluator.jl
@@ -8,7 +8,7 @@ type ProblemEvaluator <: Evaluator
   last_fitness
 
   ProblemEvaluator(problem::OptimizationProblem; archive = false,
-    fitness_scheme = FloatFitness()) = begin
+    fitness_scheme = ScalarFitness{true}()) = begin
     archive = archive || TopListArchive(numdims(problem))
     new(problem, fitness_scheme, archive, 0, nothing)
   end
@@ -34,15 +34,11 @@ end
 # and only want the fitness itself if the criteria fulfilled.
 last_fitness(e::Evaluator) = e.last_fitness
 
-function is_better(e::Evaluator, f1::Fitness, f2::Fitness)
-  is_better(f1, f2, e.fitness_scheme)
-end
+is_better{F}(f1::F, f2::F, e::Evaluator) = is_better(f1, f2, e.fitness_scheme)
 
-function is_better(e::Evaluator, candidate, fitness::Fitness)
-  is_better(evaluate(e, candidate), fitness, e.fitness_scheme)
-end
+is_better(candidate, fitness, e::Evaluator) = is_better(evaluate(e, candidate), fitness, e.fitness_scheme)
 
-function best_of(e::Evaluator, candidate1, candidate2)
+function best_of(candidate1, candidate2, e::Evaluator)
   f1 = evaluate(e, candidate1)
   f2 = evaluate(e, candidate2)
   if is_better(f1, f2, e.fitness_scheme)

--- a/src/evaluator.jl
+++ b/src/evaluator.jl
@@ -1,31 +1,40 @@
-abstract Evaluator
+# Manages the objective function evaluation
+# P is the optimization problem it is used for
+abstract Evaluator{P <: OptimizationProblem}
 
-type ProblemEvaluator <: Evaluator
-  problem::OptimizationProblem
-  fitness_scheme::FitnessScheme
-  archive::Archive
-  num_evals::Int
-  last_fitness
-
-  ProblemEvaluator(problem::OptimizationProblem; archive = false,
-    fitness_scheme = ScalarFitness{true}()) = begin
-    archive = archive || TopListArchive(numdims(problem))
-    new(problem, fitness_scheme, archive, 0, nothing)
-  end
-end
-
-worst_fitness(e::Evaluator) = worst_fitness(e.fitness_scheme)
-num_evals(e::Evaluator) = e.num_evals
-numdims(e::Evaluator) = numdims(e.problem)
-search_space(e::Evaluator) = search_space(e.problem)
+fitness_scheme(e::Evaluator) = fitness_scheme(problem(e))
+worst_fitness(e::Evaluator) = worst_fitness(fitness_scheme(e))
+numdims(e::Evaluator) = numdims(problem(e))
+search_space(e::Evaluator) = search_space(problem(e))
 describe(e::Evaluator) = "Problem: $(name(e.problem)) (dimensions = $(numdims(e)))"
 problem_summary(e::Evaluator) = "$(name(e.problem))_$(numdims(e))d"
-problem(e::Evaluator) = e.problem
 
-function evaluate(e::Evaluator, candidate)
-  e.last_fitness = fitness(candidate, e.problem)
+# Default implementation of the evaluator
+# FIXME F is the fitness type of the problem, but with current Julia it's
+# not possible to get and use it at declaration type
+type ProblemEvaluator{F, P<:OptimizationProblem} <: Evaluator{P}
+  problem::P
+  archive::Archive
+  num_evals::Int
+  last_fitness::F
+end
+
+function ProblemEvaluator{P<:OptimizationProblem}(
+        problem::P;
+        archiveCapacity::Int = 10 )
+    ProblemEvaluator{fitness_type(fitness_scheme(problem)), P}(problem,
+        TopListArchive(numdims(problem), archiveCapacity),
+        0, nafitness(fitness_scheme(problem)))
+end
+
+problem(e::Evaluator) = e.problem
+num_evals(e::ProblemEvaluator) = e.num_evals
+
+# evaluates the fitness (and implicitly updates the stats)
+function fitness(params::Individual, e::ProblemEvaluator)
+  e.last_fitness = fitness(params, e.problem)
   e.num_evals += 1
-  add_candidate!(e.archive, e.last_fitness, candidate, e.num_evals)
+  add_candidate!(e.archive, e.last_fitness, params, e.num_evals)
   e.last_fitness
 end
 
@@ -34,14 +43,14 @@ end
 # and only want the fitness itself if the criteria fulfilled.
 last_fitness(e::Evaluator) = e.last_fitness
 
-is_better{F}(f1::F, f2::F, e::Evaluator) = is_better(f1, f2, e.fitness_scheme)
+is_better{F}(f1::F, f2::F, e::Evaluator) = is_better(f1, f2, fitness_scheme(e))
 
-is_better(candidate, fitness, e::Evaluator) = is_better(evaluate(e, candidate), fitness, e.fitness_scheme)
+is_better(candidate, f, e::Evaluator) = is_better(fitness(candidate, e), f, fitness_scheme(e))
 
-function best_of(candidate1, candidate2, e::Evaluator)
-  f1 = evaluate(e, candidate1)
-  f2 = evaluate(e, candidate2)
-  if is_better(f1, f2, e.fitness_scheme)
+function best_of(candidate1::Individual, candidate2::Individual, e::Evaluator)
+  f1 = fitness(candidate1, e)
+  f2 = fitness(candidate2, e)
+  if is_better(f1, f2, e)
     return candidate1, f1
   else
     return candidate2, f2
@@ -58,15 +67,18 @@ type Candidate{F}
               fitness::F = NaN) = new(params, index, fitness)
 end
 
-function rank_by_fitness!{F}(e::Evaluator, candidates::Vector{Candidate{F}})
-  # Note that we re-evaluate all candidates here. This might be wasteful and
-  # we should cache if evaluations are costly.
+function rank_by_fitness!{F,P<:OptimizationProblem}(e::Evaluator{P}, candidates::Vector{Candidate{F}})
+  fs = fitness_scheme(e)
   for i in eachindex(candidates)
-    candidates[i].fitness = evaluate(e, candidates[i].params)
+      # evaluate fitness if not known yet
+      if isnafitness(candidates[i].fitness, fs)
+          candidates[i].fitness = fitness(candidates[i].params, e)
+      end
   end
-  sort!(candidates; by = c -> c.fitness)
+
+  sort!(candidates; by = c -> c.fitness, lt = (x, y) -> is_better(x, y, fs))
 end
 
 Base.copy{F}(c::Candidate{F}) = Candidate{F}(copy(c.params), c.index, c.fitness)
 
-fitness_is_within_ftol(e::Evaluator, atol::Float64) = fitness_is_within_ftol(problem(e), best_fitness(e.archive), atol)
+fitness_is_within_ftol(e::Evaluator, atol) = fitness_is_within_ftol(problem(e), best_fitness(e.archive), atol)

--- a/src/fitness.jl
+++ b/src/fitness.jl
@@ -1,28 +1,52 @@
 # A FitnessScheme is a specific way in which fitness vectors/values are
-# aggregated, compared and presented. A fitness represents the score of one 
-# and the same individual on one or a set of evaluations. A scheme is a specific 
+# aggregated, compared and presented. A fitness represents the score of one
+# and the same individual on one or a set of evaluations. A scheme is a specific
 # way in which these scores are considered in a coherent way.
-abstract FitnessScheme
+# Type parameter F specifies the type of fitness values.
+abstract FitnessScheme{F}
 
-# A fitness datum is either complex or a FloatingPoint
-abstract ComplexFitness
-Fitness = Union(ComplexFitness, FloatingPoint)
+fitness_type{F}(::Type{FitnessScheme{F}}) = F
+fitness_type{F}(::FitnessScheme{F}) = F
+#fitness_type{FS<:FitnessScheme}(::Type{FS}) = fitness_type(super(FS))
+#fitness_type{FS<:FitnessScheme}(::FS) = fitness_type(FS)
 
 # In a RatioFitnessScheme the fitness values can be ranked on a ratio scale so
 # we need not rank them based on pairwise comparisons. The default scale used
 # is the aggregate of the fitness values.
-abstract RatioFitnessScheme <: FitnessScheme
+# FIXME
+abstract RatioFitnessScheme{F} <: FitnessScheme{F}
+
+# Fitness using a single floating value.
+# The boolean type parameter specifies if smaller fitness is better (MIN=true)
+# or worse (MIN=false).
+immutable ScalarFitness{MIN} <: RatioFitnessScheme{Float64}
+end
+
+is_minimizing{MIN}(::ScalarFitness{MIN}) = MIN
+nafitness(::ScalarFitness) = NaN
+isnafitness(f::Float64, ::ScalarFitness) = isnan(f)
+numobjectives(::ScalarFitness) = 1
+
+# Aggregation is just the identity function for scalar fitness
+aggregate(fitness, ::ScalarFitness) = fitness
+
+is_better(f1::Float64, f2::Float64, scheme::ScalarFitness{true}) = f1 < f2
+is_better(f1::Float64, f2::Float64, scheme::ScalarFitness{false}) = f1 > f2
+
+# Complex-valued fitness
+# FIXME what is isbetter() for ComplexFitness
+immutable ComplexFitness <: FitnessScheme{Complex128}
+end
 
 worst_fitness(fs::FitnessScheme) = is_minimizing(fs) ? Inf : (-Inf)
 best_fitness(fs::FitnessScheme) = -worst_fitness(fs)
-is_minimizing(fs::FitnessScheme) = true # Default is to minimize, override if not
 
 hat_compare(a1::Number, a2::Number) = (a1 < a2) ? -1 : ((a1 > a2) ? 1 : 0)
 
 # Hat comparison function that indicates which of fitness f1 and f2 is the better.
 # Returns -1 if f1 is better than f2, 1 if f2 is better than f1 and
 # 0 if they are equal.
-function hat_compare(f1, f2, s::FitnessScheme)
+function hat_compare(f1, f2, s::RatioFitnessScheme)
   if is_minimizing(s)
     hat_compare(aggregate(f1, s), aggregate(f2, s))
   else
@@ -34,41 +58,33 @@ is_better(f1, f2, scheme::FitnessScheme) = hat_compare(f1, f2, scheme) == -1
 is_worse(f1, f2, scheme::FitnessScheme) = hat_compare(f1, f2, scheme) == 1
 same_fitness(f1, f2, scheme::FitnessScheme) = hat_compare(f1, f2, scheme) == 0
 
-# A FloatFitness scheme is simply a single floating value.
-type FloatFitness <: RatioFitnessScheme
-  minimize::Bool
-
-  FloatFitness(minimize = true) = begin
-    new(minimize)
-  end
-end
-
-is_minimizing(fs::FloatFitness) = fs.minimize
-
-# Aggregation is just the identity function for float fitness values.
-aggregate(fitness, fs::FloatFitness) = fitness
-
-# All FloatVectorFitness scheme has individual fitness scores (at least 1) in 
-# an array.
-type FloatVectorFitness <: RatioFitnessScheme
+# All VectorFitness scheme has N individual fitness scores (at least 1) in
+# an array and could be aggregated to a float value.
+# FIXME
+immutable VectorFitness{MIN,N,AGG} <: RatioFitnessScheme{Vector{Float64}}
   # Function mapping a fitness array to a single numerical value. Might be used
   # for comparisons (or not, depending on setup). Always used when printing
   # fitness vectors though.
-  aggregate::Function
-
-  worst_fitness::Float64
+  aggregate::AGG
 end
 
-worst_fitness(f::FloatVectorFitness) = f.worst_fitness
+numobjectives{MIN,N}(::VectorFitness{MIN,N}) = N
+is_minimizing{MIN,N}(fs::VectorFitness{MIN,N}) = MIN
 
-aggregate(fitness, fs::FloatVectorFitness) = fs.aggregate(fitness)
+nafitness{MIN,N}(::VectorFitness{MIN,N}) = fill(NaN, N)
+isnafitness{MIN,N}(f::Vector{Float64}, ::VectorFitness{MIN,N}) = any(isnan(f)) # or all?
 
-# For minimization we just pass the aggregator on.
-function float_vector_scheme_min(aggregator = sum)
-  FloatVectorFitness(aggregator, Inf)
+aggregate(fitness, fs::VectorFitness) = fs.aggregate(fitness)
+
+# Fitness scheme that minimizes the sum of objectives
+function vector_fitness_scheme_min(nobjectives::Int, aggregate = sum)
+  VectorFitness{true, nobjectives, Function}(aggregate)
 end
 
-# For maximization we need to set a different aggregator.
-function float_vector_scheme_max(agg = ((fs) -> -1 * sum(fs)))
-  FloatVectorFitness(agg, -Inf)
+# Fitness scheme that maximizes the sum of objectives
+function vector_fitness_scheme_max(nobjectives::Int, aggregate = sum)
+  VectorFitness{false, nobjectives, Function}(aggregate)
 end
+
+# FIXME now it's here just to avoid undeclared types
+type NewFitness end

--- a/src/fitness/epsilon_box_dominance.jl
+++ b/src/fitness/epsilon_box_dominance.jl
@@ -4,12 +4,12 @@ function epsilon_box_dominates_and_epsilon_progress(u, v, epsilon)
   uindex = floor(u ./ epsilon)
   vindex = floor(v ./ epsilon)
   inner_epsilon_box_dominates_and_epsilon_progress(
-    u, uindex, (epsilon .* uindex), 
+    u, uindex, (epsilon .* uindex),
     v, vindex, (epsilon .* vindex))
 end
 
+# FIXME
 epsilon_box_dominates_and_epsilon_progress(f1::NewFitness, f2::NewFitness, epsilon) = epsilon_box_dominates_and_epsilon_progress(fitnessvalues(f1), fitnessvalues(f2), epsilon)
-
 epsilon_box_dominates(u, v, epsilon) = epsilon_box_dominates_and_epsilon_progress(u, v, epsilon)[1]
 epsilon_box_progress(u, v, epsilon) = epsilon_box_dominates_and_epsilon_progress(u, v, epsilon)[2]
 
@@ -17,7 +17,7 @@ epsilon_box_progress(u, v, epsilon) = epsilon_box_dominates_and_epsilon_progress
 # This is to speed up processing when there is a whole archive of solutions to compare
 # a new solution to.
 function inner_epsilon_box_dominates_and_epsilon_progress(
-  u, uindex, uindextimesepsilon, 
+  u, uindex, uindextimesepsilon,
   v, vindex, vindextimesepsilon)
 
   if pareto_dominates_fast(uindex, vindex)

--- a/src/fitness/pareto_dominance.jl
+++ b/src/fitness/pareto_dominance.jl
@@ -32,4 +32,5 @@ end
 
 pareto_dominates{T <: Real}(v1::Vector{T}, v2::Vector{T}) = pareto_dominates_fast(v1, v2)
 
+# FIXME
 pareto_dominates(f1::NewFitness, f2::NewFitness) = pareto_dominates(fitnessvalues(f1), fitnessvalues(f2))

--- a/src/generating_set_search.jl
+++ b/src/generating_set_search.jl
@@ -103,7 +103,7 @@ function step!(gss::GeneratingSetSearcher)
     candidate = gss.x + gss.step_size .* directions[:, direction]
     apply!(gss.embed, candidate, gss.x)
 
-    if is_better(gss.evaluator, candidate, gss.xfitness)
+    if is_better(candidate, gss.xfitness, gss.evaluator)
       found_better = true
       break
     end

--- a/src/generating_set_search.jl
+++ b/src/generating_set_search.jl
@@ -58,7 +58,7 @@ function GeneratingSetSearcher{V<:Evaluator, D<:DirectionGenerator, E<:Embedding
     step_size = calc_initial_step_size(ss, params[:InitialStepSizeFactor])
     x = rand_individual(ss)
     GeneratingSetSearcher{V, D, E}(params, dgen, evaluator, embed, ss, n, 0, step_size,
-      x, evaluate(evaluator, x))
+      x, fitness(x, evaluator))
 end
 
 # by default use RandomBound embedder
@@ -79,7 +79,7 @@ function step!(gss::GeneratingSetSearcher)
   if has_converged(gss)
     # Restart from a random point
     gss.x = rand_individual(gss.search_space)
-    gss.xfitness = evaluate(gss.evaluator, gss.x)
+    gss.xfitness = fitness(gss.x, gss.evaluator)
     gss.step_size = calc_initial_step_size(gss.search_space, gss.parameters[:InitialStepSizeFactor])
   end
 

--- a/src/generating_set_search.jl
+++ b/src/generating_set_search.jl
@@ -5,7 +5,7 @@
 #
 
 # GSS is a type of DirectSearch
-abstract DirectSearcher <: Optimizer
+abstract DirectSearcher <: SteppingOptimizer
 
 # A direction generator generates the search directions to use at each step of
 # a GSS search.
@@ -70,8 +70,6 @@ GeneratingSetSearcher(parameters) = GeneratingSetSearcher(parameters[:Evaluator]
 function name(opt::GeneratingSetSearcher)
   "GeneratingSetSearcher($(typeof(opt.direction_gen)))"
 end
-
-has_ask_tell_interface(gss::GeneratingSetSearcher) = false
 
 function has_converged(gss::GeneratingSetSearcher)
   gss.step_size < gss.parameters[:DeltaTolerance]

--- a/src/generating_set_search.jl
+++ b/src/generating_set_search.jl
@@ -62,9 +62,11 @@ function GeneratingSetSearcher{V<:Evaluator, D<:DirectionGenerator, E<:Embedding
 end
 
 # by default use RandomBound embedder
-GeneratingSetSearcher(parameters) = GeneratingSetSearcher(parameters[:Evaluator],
-                                                          get(parameters, :DirectionGenerator, compass_search_directions(numdims(parameters[:Evaluator]))),
-                                                          RandomBound(parameters[:SearchSpace]), parameters)
+function GeneratingSetSearcher(problem::OptimizationProblem, parameters)
+  GeneratingSetSearcher(parameters[:Evaluator],
+                        get(parameters, :DirectionGenerator, compass_search_directions(numdims(parameters[:Evaluator]))),
+                        RandomBound(search_space(problem)), parameters)
+end
 
 # We also include the name of the direction generator.}
 function name(opt::GeneratingSetSearcher)

--- a/src/genetic_operators/crossover/differential_evolution_crossover.jl
+++ b/src/genetic_operators/crossover/differential_evolution_crossover.jl
@@ -1,7 +1,7 @@
 abstract DiffEvoCrossoverOperator{NP,NC} <: CrossoverOperator{NP,NC}
 
 # FIXME is it possible somehow to do arithmetic operations with N?
-type DiffEvoRandBin{N} <: DiffEvoCrossoverOperator{N,1}
+immutable DiffEvoRandBin{N} <: DiffEvoCrossoverOperator{N,1}
 end
 
 typealias DiffEvoRandBin1 DiffEvoRandBin{3}

--- a/src/genetic_operators/genetic_operator.jl
+++ b/src/genetic_operators/genetic_operator.jl
@@ -22,7 +22,7 @@ numparents(o::EmbeddingOperator) = 1
 numchildren(o::EmbeddingOperator) = 1
 
 # mutation operator that does nothing
-type NoMutation <: MutationOperator end
+immutable NoMutation <: MutationOperator end
 function apply!(mo::NoMutation, target) end
 
 include("mutation/polynomial_mutation.jl")

--- a/src/genetic_operators/mutation/mutation_clock.jl
+++ b/src/genetic_operators/mutation/mutation_clock.jl
@@ -11,7 +11,7 @@ num_vars_to_next_mutation_point(probMutation) = ceil( Int, (-log(rand())) / prob
 abstract GibbsMutationOperator
 
 # randomly mutate one index of parameter vector within its boundaries
-type SimpleGibbsMutation <: GibbsMutationOperator
+immutable SimpleGibbsMutation <: GibbsMutationOperator
     ss::SearchSpace
 end
 

--- a/src/genetic_operators/selector/radius_limited.jl
+++ b/src/genetic_operators/selector/radius_limited.jl
@@ -11,7 +11,7 @@
 #  and B. Worzel, pp. 109-124. Boston, MA: Kluwer Academic Publishers.
 #  http://faculty.hampshire.edu/lspector/pubs/trivial-geography-toappear.pdf
 #
-type RadiusLimitedSelector <: IndividualsSelector
+immutable RadiusLimitedSelector <: IndividualsSelector
     radius::Int
 end
 

--- a/src/genetic_operators/selector/simple.jl
+++ b/src/genetic_operators/selector/simple.jl
@@ -1,5 +1,5 @@
 # simple random selector
-type SimpleSelector <: IndividualsSelector
+immutable SimpleSelector <: IndividualsSelector
 end
 
 function select(::SimpleSelector, population, numSamples::Int)

--- a/src/natural_evolution_strategies.jl
+++ b/src/natural_evolution_strategies.jl
@@ -12,7 +12,7 @@ type SeparableNESOpt <: NaturalEvolutionStrategyOpt
   mu_learnrate::Float64
   sigma_learnrate::Float64
   last_s::Array{Float64,2}        # The s values sampled in the last call to ask
-  population::Array{Float64,2}    # The last sampled values, now being evaluated
+  population::PopulationMatrix    # The last sampled values, now being evaluated
   utilities::Vector{Float64}      # The fitness shaping utility vector
 
   function SeparableNESOpt(searchSpace; lambda::Int = 0, mu_learnrate::Float64 = 1.0,
@@ -77,7 +77,7 @@ function mix_with_indices(individuals::Matrix{Float64}, indices::Range)
   if popsize(individuals) != length(indices)
     throw(DimensionMismatch("The number of candidates does not match the number of indices"))
   end
-  Candidate{Float64}[make_candidate(individuals, i) for i in indices]
+  Candidate{Float64}[Candidate{Float64}(individuals[:,i], i) for i in indices]
 end
 
 # Tell the sNES the ranking of a set of candidates.

--- a/src/natural_evolution_strategies.jl
+++ b/src/natural_evolution_strategies.jl
@@ -49,9 +49,9 @@ NES_DefaultOptions = @compat Dict{String,Any}(
   "sigma_learnrate" => 0.0,   # If 0.0 it will be set based on the number of dimensions
 )
 
-function separable_nes(parameters)
+function separable_nes(problem::OptimizationProblem, parameters)
   params = mergeparam(NES_DefaultOptions, parameters)
-  SeparableNESOpt(params[:SearchSpace];
+  SeparableNESOpt(search_space(problem),
     lambda = params["lambda"],
     mu_learnrate = params["mu_learnrate"],
     sigma_learnrate = params["sigma_learnrate"])
@@ -134,9 +134,9 @@ type XNESOpt <: NaturalEvolutionStrategyOpt
   end
 end
 
-function xnes(parameters)
+function xnes(problem::OptimizationProblem, parameters)
   params = mergeparam(NES_DefaultOptions, parameters)
-  XNESOpt(params[:SearchSpace]; lambda = params["lambda"])
+  XNESOpt(search_space(problem); lambda = params["lambda"])
 end
 
 function ask(xnes::XNESOpt)

--- a/src/population.jl
+++ b/src/population.jl
@@ -17,9 +17,9 @@ type FloatVectorPopulation <: PopulationWithFitness
   top_size::Int
 
   function FloatVectorPopulation(size = 100, dimensions = 1,
-    scheme = float_vector_scheme_min(), numTopIndividuals = 10)
+    scheme = ScalarFitness{true}(), numTopIndividuals = 10)
     inds = rand(size, dimensions)
-    fs = ones(size, dimensions) * scheme.worst_fitness # Bug! Need not be the same num of objectives as there are dimensions...
+    fs = fill(nafitness(scheme), size, dimensions)
     new(inds, fs, scheme, inds[1:numTopIndividuals,:], fs[1:numTopIndividuals,:], numTopIndividuals)
   end
 end

--- a/src/population.jl
+++ b/src/population.jl
@@ -20,7 +20,7 @@ type FitPopulation{F} <: PopulationWithFitness{F}
 
   function FitPopulation(individuals::PopulationMatrix, nafitness::F, fitness::Vector{F})
     popsize(individuals) == length(fitness) || throw(DimensionMismatch("Fitness vector length does not match the population size"))
-    new(individuals, nafitness, fitness, Vector{Candidate{F}}())
+    new(individuals, nafitness, fitness, @compat(Vector{Candidate{F}}()))
   end
 end
 
@@ -43,10 +43,11 @@ params_std(pop::FitPopulation) = std(pop.individuals, 1)
 fitness(pop::FitPopulation, ix::Int) = pop.fitness[ix]
 
 getindex(pop::FitPopulation, rows, cols) = pop.individuals[rows, cols]
+getindex(pop::FitPopulation, ::Colon, cols) = pop.individuals[:, cols] # FIXME remove v0.3 workaround
 getindex(pop::FitPopulation, indi_ixs) = pop.individuals[:, indi_ixs]
 
 # get unitialized individual from a pool, or create one, if it's empty
-acquire_candi{F}(pop::FitPopulation{F}) = isempty(pop.candi_pool) ? Candidate{F}(Individual(numdims(pop)), -1, pop.nafitness) : pop!(pop.candi_pool)
+acquire_candi{F}(pop::FitPopulation{F}) = isempty(pop.candi_pool) ? Candidate{F}(@compat(Vector{Float64}(numdims(pop))), -1, pop.nafitness) : pop!(pop.candi_pool)
 
 # get an individual from a pool and set it to ix-th individual from population
 function acquire_candi(pop::FitPopulation, ix::Int)

--- a/src/problems/all_problems.jl
+++ b/src/problems/all_problems.jl
@@ -1,114 +1,63 @@
-abstract OptimizationProblem
+# root type for all optimization problems
+abstract OptimizationProblem{FS<:FitnessScheme}
 
-type FixedDimProblem <: OptimizationProblem
-  name::ASCIIString
-  funcs::Vector{Function}  # Objective functions
-  ss::SearchSpace
-  fmins::Nullable{Vector{Float64}}
-
-  function FixedDimProblem(name, funcs, ss, fmins::Nullable{Vector{Float64}} = Nullable{Vector{Float64}}())
-    @assert isnull(fmins) || length(funcs) == length(get(fmins))
-    new(name, funcs, ss, fmins)
-  end
-end
-
+# common definitions for OptimizationProblem
+# (enforce field names of subtypes)
 name(p::OptimizationProblem) = p.name
+fitness_scheme(p::OptimizationProblem) = p.fitness_scheme
+fitness_type(p::OptimizationProblem) = fitness_type(fitness_scheme(p))
+numobjectives(p::OptimizationProblem) = numobjectives(fitness_scheme(p))
+search_space(p::OptimizationProblem) = p.ss
+numdims(p::OptimizationProblem) = numdims(search_space(p))
 
-is_fixed_dimensional(p::Any) = false
-is_fixed_dimensional(p::FixedDimProblem) = true
+# by default the optimum is unknown
+fitness_is_within_ftol(p::OptimizationProblem, fitness, atol::Number) = false
 
-is_any_dimensional(p::OptimizationProblem) = !is_fixed_dimensional(p)
+# problem with the objective function defined by some Julia function
+abstract FunctionBasedProblem{FS<:FitnessScheme} <: OptimizationProblem{FS}
 
-numfuncs(p::OptimizationProblem) = length(p.funcs)
-is_single_objective_problem(p::OptimizationProblem) = numfuncs(p) == 1
+objfunc(p::FunctionBasedProblem) = p.objfunc
 
-is_multi_objective_problem(p::OptimizationProblem) = !is_single_objective_problem(p)
+# Evaluate fitness of a candidate
+fitness(x, p::FunctionBasedProblem) = objfunc(p)(x)
 
-numdims(p::OptimizationProblem) = nothing
-numdims(p::FixedDimProblem) = numdims(p.ss)
-
-search_space(p::OptimizationProblem) = nothing
-search_space(p::FixedDimProblem) = p.ss
-
-fmins(p::OptimizationProblem) = p.fmins
-
-fmin(p::OptimizationProblem) = !isnull(fmins(p)) ? Nullable{Float64}( get(fmins(p))[1] ) : Nullable{Float64}()
-
-ofunc(p::OptimizationProblem, i) = p.funcs[i]
-
-evalfunc(x, i, p::OptimizationProblem) = ofunc(p, i)(x)
-
-# Evaluate fitness of a candidate solution on the 1st objective function of a problem.
-eval1(x, p::OptimizationProblem) = evalfunc(x, 1, p)
-
-# Evaluate fitness of a candidate solution on all objective functions of a problem.
-evalall(x, p::OptimizationProblem) = Float64[ f(x) for f in p.funcs ]
-
-# Within ftol of a certain fmin
-fitness_is_within_ftol(p::OptimizationProblem, ftol, fitness, index = 1) = isnull(fmins(p)) ? false : ( abs(get(fmins(p))[index] - fitness) < ftol )
-
-type AnyDimProblem <: OptimizationProblem
+# problem with unknown global optimum,
+# a wrapper around Julia objective function
+type UnboundedProblem{FS<:FitnessScheme, SS<:SearchSpace} <: FunctionBasedProblem{FS}
+  objfunc::Function  # Objective function
   name::ASCIIString
-  funcs::Vector{Function}                 # Objective functions
-  range_per_dimension::ParamBounds        # Default range per dimension
-  fmins::Nullable{Vector{Float64}}
-end
+  fitness_scheme::FS
+  ss::SS          # search space
 
-function Base.convert( ::Type{Nullable{Vector{Float64}}}, v::Nullable{Float64} )
-  isnull(v) ? Nullable{Vector{Float64}}() : Nullable{Vector{Float64}}( Float64[get(v)] )
-end
-
-function Base.convert( ::Type{Nullable{Vector{Float64}}}, v::Float64 )
-  Nullable{Vector{Float64}}( Float64[v] )
-end
-
-anydim_problem(name, f::Function, range, fmin = Float64 ) = AnyDimProblem( name, Function[f], range, convert( Nullable{Vector{Float64}}, fmin ) )
-anydim_problem(name, f::Function, range ) = AnyDimProblem( name, Function[f], range, Nullable{Vector{Float64}}() )
-
-function as_fixed_dim_problem(p::AnyDimProblem, dim::Int)
-  ss = symmetric_search_space(dim, p.range_per_dimension)
-  FixedDimProblem(p.name, p.funcs, ss, p.fmins)
-end
-
-function as_fixed_dim_problem(p::FixedDimProblem, dim::Int)
-  if numdims(p) != dim
-    throw(DimensionMismatch("Trying to set dimension $(dim) on a fixed dimensional problem of dimension $(numdims(p))"))
-  end
-  p
-end
-
-function fixeddim_problem(f::Function; search_space = false, range = (-1.0, 1.0),
-  dims = 5, name = "unknown", fmin = Nullable{Float64}() )
-  fmins = convert( Nullable{Vector{Float64}}, fmin )
-  if search_space == false
-    as_fixed_dim_problem(anydim_problem(name, f, range, fmins), dims)
-  elseif typeof(search_space) <: SearchSpace
-    FixedDimProblem(name, Function[f], search_space, fmins)
-  elseif typeof(search_space) <: Vector{ParamBounds}
-    FixedDimProblem(name, Function[f], RangePerDimSearchSpace(search_space), fmins)
-  else
-    throw("Unknown search space $(search_space).")
+  function UnboundedProblem(objfunc::Function, name::ASCIIString, fitness_scheme::FS, ss::SS)
+    new(objfunc, name, fitness_scheme, ss)
   end
 end
 
-# A function set is specified through a dict mapping its function number
-# to an optimization problem. We can create a fixed dimensional variant of
-# an any dimensional function set with:
-function as_fixed_dim_problem_set(ps::Dict{Any, Any}, dim::Int)
-  as_fixed_dim_problem_set(ps, [dim])
-end
+# problem with known global optimum,
+# a wrapper around Julia objective function
+type BoundedProblem{F, FS<:FitnessScheme, SS<:SearchSpace} <: FunctionBasedProblem{FS}
+  objfunc::Function  # Objective function
+  name::ASCIIString
+  fitness_scheme::FS
+  ss::SS          # search space
+  opt_value::F    # known optimal value
 
-# Create a fixed dim version of each problem in ps for each dim in dims.
-function as_fixed_dim_problem_set(ps::Dict{Any, Any}, dims::Array{Int,1})
-  next_free_index = 1
-  result = Dict{Any, FixedDimProblem}()
-  for(d in dims)
-    for(p in values(ps))
-      result[next_free_index] = as_fixed_dim_problem(p, d)
-      next_free_index += 1
+  function BoundedProblem(objfunc::Function, name::ASCIIString, fitness_scheme::FS, ss::SS, opt_value::F)
+    if isnafitness(opt_value, fitness_scheme)
+      throw(ArgumentError("The object function must be specified"))
     end
+    new(objfunc, name, fitness_scheme, ss, opt_value)
   end
-  result
 end
 
-include("single_objective.jl")
+opt_value(p::BoundedProblem) = p.opt_value
+fitness_is_within_ftol(p::BoundedProblem, fitness, atol::Number) = norm(opt_value(p) - fitness) < atol
+
+function Base.convert{FS<:FitnessScheme,SS<:SearchSpace}(::Type{FunctionBasedProblem}, func::Function, name::ASCIIString, fitness_scheme::FS, ss::SS)
+  return UnboundedProblem{FS,SS}(func, name, fitness_scheme, ss)
+end
+
+function Base.convert{F,FS<:FitnessScheme,SS<:SearchSpace}(::Type{FunctionBasedProblem}, func::Function, name::ASCIIString, fitness_scheme::FS, ss::SS, opt_value::F)
+  return BoundedProblem{F,FS,SS}(func, name, fitness_scheme, ss, opt_value)
+end

--- a/src/problems/problem_family.jl
+++ b/src/problems/problem_family.jl
@@ -1,0 +1,59 @@
+# family of FunctionBasedProblem parameterized by the search space dimension
+type FunctionBasedProblemFamily{F,FS<:FitnessScheme}
+  objfunc::Function                          # Objective function
+  name::ASCIIString
+  fitness_scheme::FS
+  range_per_dimension::ParamBounds        # Default range per dimension
+  opt_value::Nullable{F}                  # optional optimal value
+
+  FunctionBasedProblemFamily(objfunc::Function, name::ASCIIString, fitness_scheme::FS, range::ParamBounds,
+                opt_value::Nullable{F}) = new(objfunc, name, fitness_scheme, range, opt_value)
+end
+
+objfunc(family::FunctionBasedProblemFamily) = family.objfunc
+
+# generates the problem with the specified number of dimensions
+function fixed_dim_problem(family::FunctionBasedProblemFamily, ndim::Int)
+  ss = symmetric_search_space(ndim, family.range_per_dimension)
+  if isnull(family.opt_value)
+    return FunctionBasedProblem(family.objfunc, family.name, family.fitness_scheme, ss)
+  else
+    return FunctionBasedProblem(family.objfunc, family.name, family.fitness_scheme, ss, get(family.opt_value))
+  end
+end
+
+function MinimizationProblemFamily(f::Function, name::ASCIIString, range::ParamBounds, fmin::Float64)
+  FunctionBasedProblemFamily{Float64, ScalarFitness{true}}(f, name, ScalarFitness{true}(), range, convert(Nullable{Float64}, fmin))
+end
+
+function MinimizationProblemFamily(f::Function, name::ASCIIString, range::ParamBounds)
+  FunctionBasedProblemFamily{Float64, ScalarFitness{true}}(f, name, ScalarFitness{true}(), range, Nullable{Float64}())
+end
+
+function minimization_problem(f::Function, name::ASCIIString, range::ParamBounds, ndim::Int)
+    fixed_dim_problem(MinimizationProblemFamily(f, name, range), ndim)
+end
+
+function minimization_problem(f::Function, name::ASCIIString, range::ParamBounds, ndim::Int, fmin::Float64)
+    fixed_dim_problem(MinimizationProblemFamily(f, name, range, fmin), ndim)
+end
+
+# A function set is specified through a dict mapping its function number
+# to an optimization problem. We can create a fixed dimensional variant of
+# an any dimensional function set with:
+function problem_set(ps::Dict{Any, Any}, dim::Int)
+  problem_set(ps, [dim])
+end
+
+# Create a fixed dim version of each problem in ps for each dim in dims.
+function problem_set(ps::Dict{Any, FunctionBasedProblemFamily}, dims::Vector{Int})
+  next_free_index = 1
+  result = Dict{Int, FunctionBasedProblem}()
+  for d in dims
+    for p in values(ps)
+      result[next_free_index] = generate(p, d)
+      next_free_index += 1
+    end
+  end
+  result
+end

--- a/src/problems/problem_family.jl
+++ b/src/problems/problem_family.jl
@@ -10,24 +10,27 @@ type FunctionBasedProblemFamily{F,FS<:FitnessScheme}
                 opt_value::Nullable{F}) = new(objfunc, name, fitness_scheme, range, opt_value)
 end
 
+Base.convert{F,FS<:FitnessScheme}(FunctionBasedProblemFamily, objfunc::Function, name::ASCIIString, fitness_scheme::FS, range::ParamBounds,
+                opt_value::Nullable{F}) = FunctionBasedProblemFamily{F,FS}(objfunc, name, fitness_scheme, range, opt_value)
+
 objfunc(family::FunctionBasedProblemFamily) = family.objfunc
 
 # generates the problem with the specified number of dimensions
 function fixed_dim_problem(family::FunctionBasedProblemFamily, ndim::Int)
   ss = symmetric_search_space(ndim, family.range_per_dimension)
   if isnull(family.opt_value)
-    return FunctionBasedProblem(family.objfunc, family.name, family.fitness_scheme, ss)
+    return convert(FunctionBasedProblem, family.objfunc, family.name, family.fitness_scheme, ss)
   else
-    return FunctionBasedProblem(family.objfunc, family.name, family.fitness_scheme, ss, get(family.opt_value))
+    return convert(FunctionBasedProblem, family.objfunc, family.name, family.fitness_scheme, ss, get(family.opt_value))
   end
 end
 
 function MinimizationProblemFamily(f::Function, name::ASCIIString, range::ParamBounds, fmin::Float64)
-  FunctionBasedProblemFamily{Float64, ScalarFitness{true}}(f, name, ScalarFitness{true}(), range, convert(Nullable{Float64}, fmin))
+  convert(FunctionBasedProblemFamily, f, name, ScalarFitness{true}(), range, convert(Nullable{Float64}, fmin))
 end
 
 function MinimizationProblemFamily(f::Function, name::ASCIIString, range::ParamBounds)
-  FunctionBasedProblemFamily{Float64, ScalarFitness{true}}(f, name, ScalarFitness{true}(), range, Nullable{Float64}())
+  convert(FunctionBasedProblemFamily, f, name, ScalarFitness{true}(), range, Nullable{Float64}())
 end
 
 function minimization_problem(f::Function, name::ASCIIString, range::ParamBounds, ndim::Int)

--- a/src/problems/single_objective.jl
+++ b/src/problems/single_objective.jl
@@ -43,7 +43,7 @@ JadeFunctionSet = @compat Dict{Int,FunctionBasedProblemFamily}(
 
 # A TransformedProblem just makes a few changes in a sub-problem but refers
 # most func calls to it. Concrete types must implement a sub_problem func.
-abstract TransformedProblem <: OptimizationProblem
+abstract TransformedProblem{FS<:FitnessScheme} <: OptimizationProblem{FS}
 search_space(tp::TransformedProblem) = search_space(sub_problem(tp))
 is_fixed_dimensional(tp::TransformedProblem) = is_fixed_dimensional(sub_problem(tp))
 numfuncs(tp::TransformedProblem) = numfuncs(sub_problem(tp))
@@ -53,12 +53,12 @@ name(tp::TransformedProblem) = name(sub_problem(tp))
 
 # A ShiftedAndBiasedProblem shifts the minimum value and biases the returned
 # function values.
-type ShiftedAndBiasedProblem <: TransformedProblem
+type ShiftedAndBiasedProblem{FS<:FitnessScheme} <: TransformedProblem{FS}
   xshift::Array{Float64, 1}
   funcshift::Float64
-  subp::OptimizationProblem
+  subp::OptimizationProblem{FS}
 
-  ShiftedAndBiasedProblem(sub_problem::OptimizationProblem;
+  ShiftedAndBiasedProblem(sub_problem::OptimizationProblem{FS};
     xshift = false, funcshift = 0.0) = begin
     xshift = (xshift != false) ? xshift : rand_individual(search_space(sub_problem))
     new(xshift[:], funcshift, sub_problem)
@@ -74,7 +74,7 @@ evalfunc(x, i, sp::ShiftedAndBiasedProblem) = begin
   ofunc(sub_problem(sp), i)(x - sp.xshift) + sp.funcshift
 end
 
-shifted(p::OptimizationProblem; funcshift = 0.0) = ShiftedAndBiasedProblem(p;
+shifted{FS<:FitnessScheme}(p::OptimizationProblem{FS}; funcshift = 0.0) = ShiftedAndBiasedProblem{FS}(p;
   funcshift = funcshift)
 
 
@@ -160,7 +160,7 @@ function xrotatedandshifted(n, f, shiftAmplitude = 1.0, rotateAmplitude = 1.0)
   transformed_f(x) = f(rotmatrix * (x .- shift))
 end
 
-example_problems = @compat Dict{String,Union{OptimizationProblem,FunctionBasedProblemFamily}}(
+example_problems = @compat Dict{String,Any}( #FIXME use Union{Optimization,FunctionBasedProblemFamily}
   "Sphere" => JadeFunctionSet[1],
   "Rosenbrock" => JadeFunctionSet[5],
   "Schwefel2.22" => JadeFunctionSet[2],

--- a/src/problems/single_objective.jl
+++ b/src/problems/single_objective.jl
@@ -8,27 +8,27 @@
 # focus is on large-scale optimization but these problems also can be used
 # in lower dimensions.
 include(joinpath(dirname(@__FILE__()), "single_objective_base_functions.jl"))
-Shekel10 = fixeddim_problem(shekel10; range = (0.0, 10.0), dims = 4, name = "Shekel10", fmin = -10.5364)
-Shekel7 = fixeddim_problem(shekel7; range = (0.0, 10.0), dims = 4, name = "Shekel7", fmin = -10.4029)
-Shekel5 = fixeddim_problem(shekel5; range = (0.0, 10.0), dims = 4, name = "Shekel5", fmin = -10.1532)
-Hartman6 = fixeddim_problem(hartman6; range = (0.0, 1.0), dims = 6, name = "Hartman6", fmin = -3.32237)
-Hartman3 = fixeddim_problem(hartman3; range = (0.0, 1.0), dims = 3, name = "Hartman3", fmin = -3.860038442)
+Shekel10 = minimization_problem(shekel10, "Shekel10", (0.0, 10.0), 4, -10.5364)
+Shekel7 = minimization_problem(shekel7, "Shekel7", (0.0, 10.0), 4, -10.4029)
+Shekel5 = minimization_problem(shekel5, "Shekel5", (0.0, 10.0), 4, -10.1532)
+Hartman6 = minimization_problem(hartman6, "Hartman6", (0.0, 1.0), 6, -3.32237)
+Hartman3 = minimization_problem(hartman3, "Hartman3", (0.0, 1.0), 3, -3.860038442)
 
 # We skip (for now) f12 and f13 in the JADE paper since they are penalized
 # functions which are quite nonstandard. We also skip f8 since we are unsure
 # about its proper implementation.
-JadeFunctionSet = @compat Dict{Int,OptimizationProblem}(
-  1   => anydim_problem("Sphere",        sphere,        (-100.0, 100.0), 0.0),
-  2   => anydim_problem("Schwefel2.22",  schwefel2_22,  ( -10.0,  10.0), 0.0),
-  3   => anydim_problem("Schwefel1.2",   schwefel1_2,   (-100.0, 100.0), 0.0),
-  4   => anydim_problem("Schwefel2.21",  schwefel2_21,  (-100.0, 100.0), 0.0),
-  5   => anydim_problem("Rosenbrock",    rosenbrock,    ( -30.0,  30.0), 0.0),
-  6   => anydim_problem("Step",          s2_step,       (-100.0, 100.0), 0.0),
-  7   => anydim_problem("Noisy quartic", noisy_quartic, ( -30.0,  30.0)),
-#  8   => anydim_problem("Schwefel2.26",  schwefel2_26,  (-500.0, 500.0)),
-  9   => anydim_problem("Rastrigin",     rastrigin,     ( -5.12,  5.12), 0.0),
-  10  => anydim_problem("Ackley",        ackley,        ( -32.0,  32.0), 0.0),
-  11  => anydim_problem("Griewank",      griewank,      (-600.0, 600.0), 0.0)
+JadeFunctionSet = @compat Dict{Int,FunctionBasedProblemFamily}(
+  1   => MinimizationProblemFamily(sphere, "Sphere", (-100.0, 100.0), 0.0),
+  2   => MinimizationProblemFamily(schwefel2_22,  "Schwefel2.22",  ( -10.0,  10.0), 0.0),
+  3   => MinimizationProblemFamily(schwefel1_2,   "Schwefel1.2",   (-100.0, 100.0), 0.0),
+  4   => MinimizationProblemFamily(schwefel2_21,  "Schwefel2.21",  (-100.0, 100.0), 0.0),
+  5   => MinimizationProblemFamily(rosenbrock,    "Rosenbrock",    ( -30.0,  30.0), 0.0),
+  6   => MinimizationProblemFamily(s2_step,       "Step",          (-100.0, 100.0), 0.0),
+  7   => MinimizationProblemFamily(noisy_quartic, "Noisy quartic", ( -30.0,  30.0)),
+#  8   => MinimizationProblemFamily(schwefel2_26,  "Schwefel2.26",  (-500.0, 500.0)),
+  9   => MinimizationProblemFamily(rastrigin,     "Rastrigin",     ( -5.12,  5.12), 0.0),
+  10  => MinimizationProblemFamily(ackley,        "Ackley",        ( -32.0,  32.0), 0.0),
+  11  => MinimizationProblemFamily(griewank,      "Griewank",      (-600.0, 600.0), 0.0)
 )
 
 
@@ -160,7 +160,7 @@ function xrotatedandshifted(n, f, shiftAmplitude = 1.0, rotateAmplitude = 1.0)
   transformed_f(x) = f(rotmatrix * (x .- shift))
 end
 
-example_problems = @compat Dict{String,OptimizationProblem}(
+example_problems = @compat Dict{String,Union{OptimizationProblem,FunctionBasedProblemFamily}}(
   "Sphere" => JadeFunctionSet[1],
   "Rosenbrock" => JadeFunctionSet[5],
   "Schwefel2.22" => JadeFunctionSet[2],
@@ -170,9 +170,9 @@ example_problems = @compat Dict{String,OptimizationProblem}(
   "Rastrigin" => JadeFunctionSet[9],
   "Ackley" => JadeFunctionSet[10],
   "Griewank" => JadeFunctionSet[11],
-  "Ellipsoid" => anydim_problem("Ellipsoid", ellipsoid, (-65.536, 65.536), 0.0),
-  "Cigar" => anydim_problem("Cigar", cigar, (-100.0, 100.0), 0.0),
-  "DeceptiveCuccu2011_15_2" => anydim_problem("DeceptiveCuccu2011_15_2", deceptive_cuccu2011_15_2, (-100.0, 100.0), 0.0),
+  "Ellipsoid" => MinimizationProblemFamily(ellipsoid, "Ellipsoid", (-65.536, 65.536), 0.0),
+  "Cigar" => MinimizationProblemFamily(cigar, "Cigar", (-100.0, 100.0), 0.0),
+  "DeceptiveCuccu2011_15_2" => MinimizationProblemFamily(deceptive_cuccu2011_15_2, "DeceptiveCuccu2011_15_2", (-100.0, 100.0), 0.0),
   "Shekel10" => Shekel10,
   "Shekel7" => Shekel7,
   "Shekel5" => Shekel5,

--- a/src/random_search.jl
+++ b/src/random_search.jl
@@ -26,8 +26,8 @@ function tell!{F}(rs::RandomSearcher, rankedCandidates::Vector{Candidate{F}})
   end
 end
 
-function random_search(parameters::Parameters)
-  RandomSearcher(parameters[:SearchSpace])
+function random_search(problem::OptimizationProblem, parameters::Parameters)
+  RandomSearcher(search_space(problem))
 end
 
 function random_search(ss::SearchSpace)

--- a/src/random_search.jl
+++ b/src/random_search.jl
@@ -1,4 +1,4 @@
-type RandomSearcher{S<:SearchSpace} <: Optimizer
+type RandomSearcher{S<:SearchSpace} <: AskTellOptimizer
   name::ASCIIString
   search_space::S
   best_fitness          # FIXME fitness type should be known

--- a/src/resampling_memetic_search.jl
+++ b/src/resampling_memetic_search.jl
@@ -19,10 +19,10 @@ RSDefaultParameters = @compat Dict{Symbol,Any}(
   :PrecisionTreshold => 1e-6  # They use 1e-6 in the paper.
 )
 
-type ResamplingMemeticSearcher <: SteppingOptimizer
+type ResamplingMemeticSearcher{E<:Evaluator} <: SteppingOptimizer
   name::ASCIIString
   params::Parameters
-  evaluator::Evaluator
+  evaluator::E
   resampling_func::Function
 
   precisions      # Cache the starting precision values so we need not calc them for each step
@@ -32,7 +32,7 @@ type ResamplingMemeticSearcher <: SteppingOptimizer
   elite_fitness   # Fitness of current elite
 
   # Constructor for RS:
-  ResamplingMemeticSearcher(evaluator; parameters = @compat(Dict{Symbol,Any}()),
+  ResamplingMemeticSearcher(evaluator::E, parameters = @compat(Dict{Symbol,Any}());
     resampling_function = random_resample,
     name = "Resampling Memetic Search (RS)"
     ) = begin
@@ -45,7 +45,7 @@ type ResamplingMemeticSearcher <: SteppingOptimizer
 
     new(name, params, evaluator, resampling_function,
       params[:PrecisionRatio] * diams, diams,
-      elite, evaluate(evaluator, elite))
+      elite, fitness(elite, evaluator))
 
   end
 end
@@ -56,20 +56,24 @@ RISDefaultParameters = @compat Dict{Symbol,Any}(
   :InheritanceRatio => 0.30   # On average, 30% of positions are inherited when resampling in RIS
 )
 
+function ResamplingMemeticSearcher{E<:Evaluator}(evaluator::E, params)
+  ResamplingMemeticSearcher{E}(evaluator, params)
+end
+
 # Constructor for the RIS:
-function ResamplingInheritanceMemeticSearcher(evaluator; parameters = @compat(Dict{Symbol,Any}()))
-  ResamplingMemeticSearcher(evaluator;
-    parameters = Parameters(parameters, RISDefaultParameters, RSDefaultParameters),
+function ResamplingInheritanceMemeticSearcher{E<:Evaluator}(evaluator::E, parameters = @compat(Dict{Symbol,Any}()))
+  ResamplingMemeticSearcher{E}(evaluator,
+    Parameters(parameters, RISDefaultParameters, RSDefaultParameters),
     resampling_function = random_resample_with_inheritance,
     name = "Resampling Inheritance Memetic Search (RIS)")
 end
 
 function resampling_memetic_searcher(params)
-  ResamplingMemeticSearcher(params[:Evaluator]; parameters = params)
+  ResamplingMemeticSearcher(params[:Evaluator], params)
 end
 
 function resampling_inheritance_memetic_searcher(params)
-  ResamplingInheritanceMemeticSearcher(params[:Evaluator]; parameters = params)
+  ResamplingInheritanceMemeticSearcher(params[:Evaluator], params)
 end
 
 # For Resampling Search (RS) the resample is purely random.

--- a/src/resampling_memetic_search.jl
+++ b/src/resampling_memetic_search.jl
@@ -56,24 +56,24 @@ RISDefaultParameters = @compat Dict{Symbol,Any}(
   :InheritanceRatio => 0.30   # On average, 30% of positions are inherited when resampling in RIS
 )
 
-function ResamplingMemeticSearcher{E<:Evaluator}(evaluator::E, params)
+function ResamplingMemeticSearcher{E<:Evaluator}(problem::OptimizationProblem, evaluator::E, params)
   ResamplingMemeticSearcher{E}(evaluator, params)
 end
 
 # Constructor for the RIS:
-function ResamplingInheritanceMemeticSearcher{E<:Evaluator}(evaluator::E, parameters = @compat(Dict{Symbol,Any}()))
+function ResamplingInheritanceMemeticSearcher{E<:Evaluator}(problem::OptimizationProblem, evaluator::E, parameters = @compat(Dict{Symbol,Any}()))
   ResamplingMemeticSearcher{E}(evaluator,
     Parameters(parameters, RISDefaultParameters, RSDefaultParameters),
     resampling_function = random_resample_with_inheritance,
     name = "Resampling Inheritance Memetic Search (RIS)")
 end
 
-function resampling_memetic_searcher(params)
-  ResamplingMemeticSearcher(params[:Evaluator], params)
+function resampling_memetic_searcher(problem::OptimizationProblem, params)
+  ResamplingMemeticSearcher(problem, params[:Evaluator], params)
 end
 
-function resampling_inheritance_memetic_searcher(params)
-  ResamplingInheritanceMemeticSearcher(params[:Evaluator], params)
+function resampling_inheritance_memetic_searcher(problem::OptimizationProblem, params)
+  ResamplingInheritanceMemeticSearcher(problem, params[:Evaluator], params)
 end
 
 # For Resampling Search (RS) the resample is purely random.

--- a/src/resampling_memetic_search.jl
+++ b/src/resampling_memetic_search.jl
@@ -19,11 +19,6 @@ RSDefaultParameters = @compat Dict{Symbol,Any}(
   :PrecisionTreshold => 1e-6  # They use 1e-6 in the paper.
 )
 
-# SteppingOptimizer's do not have an ask and tell interface since they would be
-# complex to implement if forced into that form.
-abstract SteppingOptimizer <: Optimizer
-has_ask_tell_interface(rms::SteppingOptimizer) = false
-
 type ResamplingMemeticSearcher <: SteppingOptimizer
   name::ASCIIString
   params::Parameters

--- a/src/resampling_memetic_search.jl
+++ b/src/resampling_memetic_search.jl
@@ -97,7 +97,7 @@ function step!(rms::ResamplingMemeticSearcher)
   # First randomly sample two candidates and select the best one. It seems
   # RS and RIS might be doing this in two different ways but use the RS way for
   # now.
-  trial, fitness = best_of(rms.evaluator, rms.resampling_func(rms), rms.resampling_func(rms))
+  trial, fitness = best_of(rms.resampling_func(rms), rms.resampling_func(rms), rms.evaluator)
 
   # Update elite if new trial is better. This is how they write it in the RIS paper
   # but in the RS paper it seems they always update the elite. Unclear! To me it
@@ -116,7 +116,7 @@ function step!(rms::ResamplingMemeticSearcher)
 end
 
 function set_as_elite_if_better(rms::ResamplingMemeticSearcher, candidate, fitness)
-  if is_better(rms.evaluator, fitness, rms.elite_fitness)
+  if is_better(fitness, rms.elite_fitness, rms.evaluator)
     rms.elite = candidate
     rms.elite_fitness = fitness
     return true
@@ -159,7 +159,7 @@ function local_search(rms::ResamplingMemeticSearcher, xstart, fitness)
         xs[i] = ssmins[i] + rand() * (xt[i] - ssmins[i])
       end
 
-      if is_better(rms.evaluator, xs, tfitness)
+      if is_better(xs, tfitness, rms.evaluator)
         xt[i] = xs[i]
         tfitness = last_fitness(rms.evaluator)
       else
@@ -170,7 +170,7 @@ function local_search(rms::ResamplingMemeticSearcher, xstart, fitness)
           xs[i] = xt[i] + rand() * (ssmaxs[i] - xt[i])
         end
 
-        if is_better(rms.evaluator, xs, tfitness)
+        if is_better(xs, tfitness, rms.evaluator)
           xt[i] = xs[i]
           tfitness = last_fitness(rms.evaluator)
         end
@@ -178,7 +178,7 @@ function local_search(rms::ResamplingMemeticSearcher, xstart, fitness)
 
     end
 
-    if is_better(rms.evaluator, tfitness, fitness)
+    if is_better(tfitness, fitness, rms.evaluator)
       fitness = tfitness
       xstart = xt
     else

--- a/src/simultaneous_perturbation_stochastic_approximation.jl
+++ b/src/simultaneous_perturbation_stochastic_approximation.jl
@@ -1,4 +1,4 @@
-abstract StochasticApproximationOptimizer <: Optimizer
+abstract StochasticApproximationOptimizer <: AskTellOptimizer
 
 SPSADefaultParameters = @compat Dict{Symbol,Any}(
   :Alpha => 0.602,  # The optimal value is 1.0 but values down to 0.602 often can give faster convergence

--- a/src/simultaneous_perturbation_stochastic_approximation.jl
+++ b/src/simultaneous_perturbation_stochastic_approximation.jl
@@ -17,15 +17,15 @@ type SimultaneousPerturbationSA2{E<:EmbeddingOperator} <: StochasticApproximatio
   delta_ck::Individual
 end
 
-function SimultaneousPerturbationSA2{E<:EmbeddingOperator}( embed::E, parameters )
-    ss = parameters[:SearchSpace]
+function SimultaneousPerturbationSA2{E<:EmbeddingOperator}(problem::OptimizationProblem, embed::E, parameters)
+    ss = search_space(problem)
     n = numdims(ss)
     SimultaneousPerturbationSA2{E}(embed, Parameters(parameters, SPSADefaultParameters),
                                    0, n, rand_individual(ss), zeros(Float64, n))
 end
 
 # by default use RandomBound embedder
-SimultaneousPerturbationSA2(parameters) = SimultaneousPerturbationSA2( RandomBound(parameters[:SearchSpace]), parameters )
+SimultaneousPerturbationSA2(problem::OptimizationProblem, parameters) = SimultaneousPerturbationSA2(problem, RandomBound(search_space(problem)), parameters)
 
 name(spsa::SimultaneousPerturbationSA2) = "SPSA2 (Simultaneous Perturbation Stochastic Approximation, 1st order, 2 samples)"
 

--- a/test/problems/test_single_objective.jl
+++ b/test/problems/test_single_objective.jl
@@ -2,7 +2,7 @@ facts("Single objective functions") do
 
 context("Sphere") do
   p = BlackBoxOptim.example_problems["Sphere"]
-  sphere = p.funcs[1]
+  sphere = objfunc(p)
 
   @fact sphere([0]) => 0
 
@@ -16,14 +16,14 @@ context("Sphere") do
 
   @fact_throws sphere([])
 
-  p2 = BlackBoxOptim.as_fixed_dim_problem(p, 3)
+  p2 = fixed_dim_problem(p, 3)
   @fact numdims(p2) => 3
   @fact ranges(search_space(p2)) => [(-100.0, 100.0), (-100.0, 100.0), (-100.0, 100.0)]
 end
 
 context("Schwefel2.22") do
   p = BlackBoxOptim.example_problems["Schwefel2.22"]
-  schwefel2_22 = p.funcs[1]
+  schwefel2_22 = objfunc(p)
 
   @fact schwefel2_22([0]) => 0
 
@@ -37,14 +37,14 @@ context("Schwefel2.22") do
 
   @fact_throws schwefel2_22([])
 
-  p2 = BlackBoxOptim.as_fixed_dim_problem(p, 4)
+  p2 = fixed_dim_problem(p, 4)
   @fact numdims(p2) => 4
   @fact ranges(search_space(p2)) => [(-10.0, 10.0), (-10.0, 10.0), (-10.0, 10.0), (-10.0, 10.0)]
 end
 
 context("Schwefel1.2") do
   p = BlackBoxOptim.example_problems["Schwefel1.2"]
-  schwefel1_2 = p.funcs[1]
+  schwefel1_2 = objfunc(p)
 
   @fact schwefel1_2([0]) => 0
 
@@ -61,7 +61,7 @@ end
 
 context("Schwefel2.21") do
   p = BlackBoxOptim.example_problems["Schwefel2.21"]
-  schwefel2_21 = p.funcs[1]
+  schwefel2_21 = objfunc(p)
 
   @fact schwefel2_21([0]) => 0
 
@@ -78,7 +78,7 @@ end
 
 context("Rosenbrock") do
   p = BlackBoxOptim.example_problems["Rosenbrock"]
-  rosenbrock = p.funcs[1]
+  rosenbrock = objfunc(p)
 
   @fact rosenbrock([1, 2]) => 100
 

--- a/test/test_adaptive_differential_evolution.jl
+++ b/test/test_adaptive_differential_evolution.jl
@@ -2,7 +2,10 @@ NumTestRepetitions = 100
 
 facts("Adaptive differential evolution optimizer") do
 
-ade = adaptive_de_rand_1_bin(@compat Dict{Symbol,Any}(
+ss = symmetric_search_space(1, (0.0, 10.0))
+fake_problem = FunctionBasedProblem(x -> 0.0, "test_problem", ScalarFitness{true}(), ss)
+
+ade = adaptive_de_rand_1_bin(fake_problem, @compat Dict{Symbol,Any}(
   :Population => rand(1, 100)))
 
 context("parameters adjust!()") do

--- a/test/test_adaptive_differential_evolution.jl
+++ b/test/test_adaptive_differential_evolution.jl
@@ -2,7 +2,8 @@ NumTestRepetitions = 100
 
 facts("Adaptive differential evolution optimizer") do
 
-ade = adaptive_de_rand_1_bin()
+ade = adaptive_de_rand_1_bin(@compat Dict{Symbol,Any}(
+  :Population => rand(1, 100)))
 
 context("parameters adjust!()") do
   for(i in 1:NumTestRepetitions)

--- a/test/test_adaptive_differential_evolution.jl
+++ b/test/test_adaptive_differential_evolution.jl
@@ -3,7 +3,7 @@ NumTestRepetitions = 100
 facts("Adaptive differential evolution optimizer") do
 
 ss = symmetric_search_space(1, (0.0, 10.0))
-fake_problem = FunctionBasedProblem(x -> 0.0, "test_problem", ScalarFitness{true}(), ss)
+fake_problem = convert(FunctionBasedProblem, x -> 0.0, "test_problem", ScalarFitness{true}(), ss) # FIXME v0.3 workaround
 
 ade = adaptive_de_rand_1_bin(fake_problem, @compat Dict{Symbol,Any}(
   :Population => rand(1, 100)))

--- a/test/test_differential_evolution.jl
+++ b/test/test_differential_evolution.jl
@@ -138,9 +138,10 @@ context("DiffEvoRandBin1") do
   end
 end
 
-context("ask()") do
+context("ask()/tell!()") do
   for(i in 1:NumTestRepetitions)
     res = BlackBoxOptim.ask(DE)
+    @fact BlackBoxOptim.candi_pool_size(BlackBoxOptim.population(DE)) => 0 # no candidates in the pool as we just exhausted it
     @fact length(res) => 2
 
     trial, target = res
@@ -154,6 +155,9 @@ context("ask()") do
     @fact isinspace(target.params, DE.embed.searchSpace) => true
 
     @fact trial.index == target.index => true
+
+    BlackBoxOptim.tell!(DE, res)
+    @fact BlackBoxOptim.candi_pool_size(BlackBoxOptim.population(DE)) => 2 # test that all candidates returned to the pool
   end
 end
 

--- a/test/test_differential_evolution.jl
+++ b/test/test_differential_evolution.jl
@@ -1,7 +1,7 @@
 facts("Differential evolution optimizer") do
 
 ss = symmetric_search_space(1, (0.0, 10.0))
-fake_problem = FunctionBasedProblem(x -> 0.0, "test_problem", ScalarFitness{true}(), ss)
+fake_problem = convert(FunctionBasedProblem, x -> 0.0, "test_problem", ScalarFitness{true}(), ss) # FIXME v0.3 workaround
 DE = de_rand_1_bin(fake_problem, @compat Dict{Symbol,Any}(
   :Population => collect(1.0:10.0)',
   :f => 0.4, :cr => 0.5, :NumParents => 3))

--- a/test/test_differential_evolution.jl
+++ b/test/test_differential_evolution.jl
@@ -1,11 +1,10 @@
-DE = de_rand_1_bin(@compat Dict{Symbol,Any}(
-  :SearchSpace => symmetric_search_space(1, (0.0, 10.0)),
-  :Population => collect(1.0:10.0)',
-  :f => 0.4,
-  :cr => 0.5,
-  :NumParents => 3))
-
 facts("Differential evolution optimizer") do
+
+ss = symmetric_search_space(1, (0.0, 10.0))
+fake_problem = FunctionBasedProblem(x -> 0.0, "test_problem", ScalarFitness{true}(), ss)
+DE = de_rand_1_bin(fake_problem, @compat Dict{Symbol,Any}(
+  :Population => collect(1.0:10.0)',
+  :f => 0.4, :cr => 0.5, :NumParents => 3))
 
 context("SimpleSelector") do
   @fact popsize(DE) => 10
@@ -22,8 +21,7 @@ context("SimpleSelector") do
 end
 
 context("RadiusLimitedSelector") do
-  DE = de_rand_1_bin_radiuslimited(@compat Dict{Symbol,Any}(
-    :SearchSpace => symmetric_search_space(1, (0.0, 10.0)),
+  local DE = de_rand_1_bin_radiuslimited(fake_problem, @compat Dict{Symbol,Any}(
     :Population => rand(1,100),
     :f => 0.4, :cr => 0.5, :NumParents => 3))
 

--- a/test/test_fitness.jl
+++ b/test/test_fitness.jl
@@ -12,16 +12,16 @@ facts("Fitness") do
     @fact hat_compare(-1.0, -1.0) => 0
   end
 
-  context("is_minimizing in float fitness schemes") do
-    mins = BlackBoxOptim.FloatFitness(true)
+  context("is_minimizing in ScalarFitness schemes") do
+    mins = BlackBoxOptim.ScalarFitness{true}()
     @fact BlackBoxOptim.is_minimizing(mins) => true
 
-    maxs = BlackBoxOptim.FloatFitness(false)
+    maxs = BlackBoxOptim.ScalarFitness{false}()
     @fact BlackBoxOptim.is_minimizing(maxs) => false
   end
 
   context("hat_compare floats in a minimizing fitness scheme") do
-    scheme = BlackBoxOptim.FloatFitness(true)
+    scheme = BlackBoxOptim.ScalarFitness{true}()
 
     @fact hat_compare(1.0, 2.0, scheme) => -1
     @fact hat_compare(2.0, 1.0, scheme) => 1
@@ -29,7 +29,7 @@ facts("Fitness") do
   end
 
   context("hat_compare floats in a maximizing fitness scheme") do
-    scheme = BlackBoxOptim.FloatFitness(false)
+    scheme = BlackBoxOptim.ScalarFitness{false}()
 
     @fact hat_compare(1.0, 2.0, scheme) => 1
     @fact hat_compare(2.0, 1.0, scheme) => -1
@@ -37,7 +37,8 @@ facts("Fitness") do
   end
 
   context("hat_compare fitnesses of size 1 in a minimizing FitnessScheme") do
-    scheme = float_vector_scheme_min()
+    scheme = vector_fitness_scheme_min(1)
+    @fact BlackBoxOptim.is_minimizing(scheme) => true
 
     @fact hat_compare([-1.0], [1.0], scheme) => -1
     @fact hat_compare([0.0], [0.3], scheme) => -1
@@ -53,7 +54,8 @@ facts("Fitness") do
   end
 
   context("hat_compare fitnesses of size 1 in a maximizing FitnessScheme") do
-    scheme = float_vector_scheme_max()
+    scheme = vector_fitness_scheme_max(1)
+    @fact BlackBoxOptim.is_minimizing(scheme) => false
 
     @fact hat_compare([-1.0], [1.0], scheme) => 1
     @fact hat_compare([0.0], [0.3], scheme) => 1
@@ -69,7 +71,8 @@ facts("Fitness") do
   end
 
   context("hat_compare fitnesses of size > 1 in a minimizing FitnessScheme") do
-    scheme = float_vector_scheme_min()
+    scheme = vector_fitness_scheme_min(2)
+    @fact BlackBoxOptim.is_minimizing(scheme) => true
 
     @fact hat_compare([-1.0, 0.0], [1.0, 0.0], scheme) => -1
     @fact hat_compare([0.0, -1.0], [0.3, 1.0], scheme) => -1
@@ -85,7 +88,8 @@ facts("Fitness") do
   end
 
   context("hat_compare fitnesses of size > 1 in a minimizing FitnessScheme") do
-    scheme = float_vector_scheme_max()
+    scheme = vector_fitness_scheme_max(2)
+    @fact BlackBoxOptim.is_minimizing(scheme) => false
 
     @fact hat_compare([-1.0, 0.0], [1.0, 0.0], scheme) => 1
     @fact hat_compare([0.0, -1.0], [0.3, 1.0], scheme) => 1
@@ -101,7 +105,7 @@ facts("Fitness") do
   end
 
   context("is_better/is_worse/same_fitness in a minimizing FitnessScheme") do
-    scheme = float_vector_scheme_min()
+    scheme = vector_fitness_scheme_min(2)
 
     @fact is_better([-1.0, 0.0], [1.0, 0.0], scheme) => true
     @fact is_better([0.0, 0.0], [1.0, 0.0], scheme) => true
@@ -125,7 +129,7 @@ facts("Fitness") do
   end
 
   context("is_better/is_worse/same_fitness in a maximizing FitnessScheme") do
-    scheme = float_vector_scheme_max()
+    scheme = vector_fitness_scheme_max(2)
 
     @fact is_better([-1.0, 0.0], [1.0, 0.0], scheme) => false
     @fact is_better([0.0, 0.0], [1.0, 0.0], scheme) => false

--- a/test/test_population.jl
+++ b/test/test_population.jl
@@ -1,20 +1,34 @@
 facts("Population") do
 
-  context("FloatVectorPopulation constructor") do
-    p1 = FloatVectorPopulation(10, 2)
-    @fact typeof(p1) => FloatVectorPopulation
+  context("FitPopulation") do
+    fs = ScalarFitness{true}()
+    p1 = FitPopulation(fs, 10, 2)
+    @fact isa(p1, FitPopulation) => true
 
-    @fact size(p1.individuals, 1) => 10
-    @fact size(p1.individuals, 2) => 2
+    @fact popsize(p1) => 10
+    @fact numdims(p1) => 2
 
-    @fact size(p1.fitness, 1) => 10
-    @fact size(p1.fitness, 2) => 2 # This is a bug since we cannot now the size of the fitness vectors before we have evaluated one...
+    @fact isnafitness(fitness(p1, 1), fs) => true
+    @fact isnafitness(fitness(p1, 4), fs) => true
 
-    @fact size(p1.top, 1) => 10
-    @fact size(p1.top, 2) => 2
+    @fact BlackBoxOptim.candi_pool_size(p1) => 0
+    candi1 = BlackBoxOptim.acquire_candi(p1, 1)
+    @fact BlackBoxOptim.candi_pool_size(p1) => 0
+    @fact candi1.index => 1
+    @fact isnafitness(candi1.fitness, fs) => true
 
-    @fact size(p1.top_fitness, 1) => 10
-    @fact size(p1.top_fitness, 2) => 2 # This is a bug since we cannot now the size of the fitness vectors before we have evaluated one...
+    candi2 = BlackBoxOptim.acquire_candi(p1, 2)
+    @fact BlackBoxOptim.candi_pool_size(p1) => 0
+    @fact candi2.index => 2
+    @fact isnafitness(candi2.fitness, fs) => true
+
+    BlackBoxOptim.release_candi(p1, candi2)
+    @fact BlackBoxOptim.candi_pool_size(p1) => 1
+
+    candi1.fitness = 5.0
+    BlackBoxOptim.accept_candi!(p1, candi1)
+    @fact BlackBoxOptim.candi_pool_size(p1) => 2
+    @fact fitness(p1, 1) => 5.0
   end
 
 end

--- a/test/test_search_space.jl
+++ b/test/test_search_space.jl
@@ -36,7 +36,7 @@ facts("Search space") do
     end
   end
 
-  context("SymmetricSearchSpace with given range") do  
+  context("SymmetricSearchSpace with given range") do
     ss1 = symmetric_search_space(1, (-1.0, 1.0))
     @fact numdims(ss1) => 1
     @fact ranges(ss1) => [(-1.0, 1.0)]
@@ -80,7 +80,7 @@ facts("Search space") do
   end
 
   context("rand_individuals correctly handles column-wise generation in assymetric search spaces") do
-    for(i in 1:ifloor(NumTestRepetitions/10))
+    for(i in 1:NumTestRepetitions÷10)
       numdims = rand(1:13)
       minbounds = rand(numdims)
       ds = rand(1:10, numdims) .* rand(numdims)


### PR DESCRIPTION
The major goal of the patch is ```FitPopulation{F}``` type that allows storing fitness values within the population and ```rank_by_fitness!()``` that skips the candidates with the defined fitness, which should double the performance of DE.

The PR is quite invasive (mostly motivated by the need to have fitness value type known by the population and fitness schema known by the optimization problem) and touches a few core classes:
  * ```FitnessScheme``` is parameterized by fitness value type. The available schemes are ```ScalarFitness{true/false}``` and ```VectorFitness{true/false}``` (this one untested)
  * ```FitnessScheme``` is now accessible from ```OptimizationProblem``` as well as the ```SearchSpace```
  * ```FixedDimProblem``` renamed into ```FunctionBasedProblem``` and ```AnyDimProblem``` into ```FunctionBasedProbelmFamily```. The latter is also not an ```OptimizationProblem``` anymore  --- that's because all the problems the optimizers could solve [currently] are finite dimensional
  * ```FunctionBasedProblem``` is subclassed into ```Bounded``` (optimum is known) and ```Unbounded``` -- the required subtype is determined automatically
  * ```AskTellOptimizer``` abstract type
  * ```Optimizer``` constructors now have access to the ```OptimizationProblem```, therefore passing ```search_space``` through dictionary no longer needed
  * to reduce the GC overhead ```FitPopulation``` maintains a pool of candidates -- no memory allocation in ```ask()/tell!()```, just copying.