### PR TITLE
Fix Archive

### DIFF
--- a/src/BlackBoxOptim.jl
+++ b/src/BlackBoxOptim.jl
@@ -17,7 +17,8 @@ export  Optimizer, AskTellOptimizer, SteppingOptimizer, PopulationOptimizer,
 
         # Fitness
         FitnessScheme,
-        ScalarFitness, ComplexFitness, VectorFitness,
+        ScalarFitnessScheme, ComplexFitnessScheme, VectorFitnessScheme,
+        MinimizingFitnessScheme, MaximizingFitnessScheme,
         fitness_type, numobjectives,
         is_minimizing, nafitness, isnafitness,
         hat_compare, is_better, is_worse, same_fitness,

--- a/src/BlackBoxOptim.jl
+++ b/src/BlackBoxOptim.jl
@@ -39,7 +39,7 @@ export  Optimizer, AskTellOptimizer, SteppingOptimizer, PopulationOptimizer,
         save_fitness_history_to_csv_file,
 
         # Archive
-        TopListArchive, best_fitness, add_candidate!, best_candidate,
+        TopListArchive, best_fitness, best_candidate,
         last_top_fitness, delta_fitness, capacity,
         width_of_confidence_interval, fitness_improvement_potential,
 

--- a/src/archive.jl
+++ b/src/archive.jl
@@ -53,13 +53,13 @@ best_candidate(a::TopListArchive) = a.candidates[1].params
 best_fitness(a::TopListArchive) = !isempty(a.candidates) ? fitness(a.candidates[1]) : Inf
 last_top_fitness(a::TopListArchive) = !isempty(a.candidates) ? fitness(a.candidates[end]) : Inf
 
-# Delta fitness is the difference between the top two candidates found so far.
-#
+# Delta fitness is the difference between the best fitness and the former
+# best fitness
 function delta_fitness(a::TopListArchive)
   if length(a.fitness_history) < 2
     Inf
   else
-    abs(a.fitness_history[2].fitness - a.fitness_history[1].fitness)
+    abs(a.fitness_history[end].fitness - a.fitness_history[end-1].fitness)
   end
 end
 

--- a/src/archive.jl
+++ b/src/archive.jl
@@ -22,7 +22,7 @@ immutable ArchivedIndividual
     fitness::Float64
 end
 
-fitness( a::ArchivedIndividual ) = a.fitness
+fitness(a::ArchivedIndividual) = a.fitness
 
 # A top list archive saves a top list of the best performing (best fitness)
 # candidates/individuals seen.
@@ -74,7 +74,7 @@ function add_candidate!(a::TopListArchive, fitness, candidate, num_fevals = -1)
 
   if length(a) < capacity(a) || !isempty(a.candidates) && fitness < last_top_fitness(a)
     if length(a) >= capacity(a) pop!(a.candidates) end # pop the last candidate, the new one has better fitness
-    new_cand = ArchivedIndividual(candidate, fitness)
+    new_cand = ArchivedIndividual(copy(candidate), fitness)
     ix = searchsortedfirst( a.candidates, new_cand, by = BlackBoxOptim.fitness )
     insert!(a.candidates, ix, new_cand)
   end

--- a/src/bboptimize.jl
+++ b/src/bboptimize.jl
@@ -84,7 +84,7 @@ function setup_problem(func::Function, parameters = @compat Dict{Symbol,Any}())
   # Now create an optimization problem with the given information. We currently reuse the type
   # from our pre-defined problems so some of the data for the constructor is dummy.
 
-  problem = convert(FunctionBasedProblem, func, "", ScalarFitness{true}(), ss) # FIXME v0.3 workaround
+  problem = convert(FunctionBasedProblem, func, "", MinimizingFitnessScheme, ss) # FIXME v0.3 workaround
 
   return problem, params
 end

--- a/src/differential_evolution.jl
+++ b/src/differential_evolution.jl
@@ -74,7 +74,8 @@ function ask(de::DiffEvoOpt)
 
   # Return the candidates that should be ranked as tuples including their
   # population indices.
-  return Candidate{Float64}[trial, target]
+  T = candidate_type(de.population)
+  return T[trial, target]
 end
 
 # Tell the optimizer about the ranking of candidates. Returns the number of

--- a/src/evaluator.jl
+++ b/src/evaluator.jl
@@ -23,7 +23,7 @@ function ProblemEvaluator{P<:OptimizationProblem}(
         problem::P;
         archiveCapacity::Int = 10 )
     ProblemEvaluator{fitness_type(fitness_scheme(problem)), P}(problem,
-        TopListArchive(numdims(problem), archiveCapacity),
+        TopListArchive(fitness_scheme(problem), numdims(problem), archiveCapacity),
         0, nafitness(fitness_scheme(problem)))
 end
 

--- a/src/fitness.jl
+++ b/src/fitness.jl
@@ -12,6 +12,9 @@ fitness_type{F}(::FitnessScheme{F}) = F
 
 if VERSION >= v"0.4.0-dev+1258" # FIXME remove version check once v0.4 is released
 Base.call{F}(fs::FitnessScheme{F}, x::F, y::F) = is_better(x, y, fs)
+fitness_scheme_lt(fs::FitnessScheme) = fs
+else
+fitness_scheme_lt(fs::FitnessScheme) = (x,y) -> is_better(x, y, fs)
 end
 
 # In a RatioFitnessScheme the fitness values can be ranked on a ratio scale so

--- a/src/fitness.jl
+++ b/src/fitness.jl
@@ -10,6 +10,10 @@ fitness_type{F}(::FitnessScheme{F}) = F
 #fitness_type{FS<:FitnessScheme}(::Type{FS}) = fitness_type(super(FS))
 #fitness_type{FS<:FitnessScheme}(::FS) = fitness_type(FS)
 
+if VERSION >= v"0.4.0-dev+1258" # FIXME remove version check once v0.4 is released
+Base.call{F}(fs::FitnessScheme{F}, x::F, y::F) = is_better(x, y, fs)
+end
+
 # In a RatioFitnessScheme the fitness values can be ranked on a ratio scale so
 # we need not rank them based on pairwise comparisons. The default scale used
 # is the aggregate of the fitness values.

--- a/src/fitness.jl
+++ b/src/fitness.jl
@@ -26,25 +26,29 @@ abstract RatioFitnessScheme{F} <: FitnessScheme{F}
 # Fitness using a single floating value.
 # The boolean type parameter specifies if smaller fitness is better (MIN=true)
 # or worse (MIN=false).
-immutable ScalarFitness{MIN} <: RatioFitnessScheme{Float64}
+immutable ScalarFitnessScheme{MIN} <: RatioFitnessScheme{Float64}
 end
 
-is_minimizing{MIN}(::ScalarFitness{MIN}) = MIN
-nafitness(::ScalarFitness) = NaN
-isnafitness(f::Float64, ::ScalarFitness) = isnan(f)
-numobjectives(::ScalarFitness) = 1
+const MinimizingFitnessScheme = ScalarFitnessScheme{true}()
+const MaximizingFitnessScheme = ScalarFitnessScheme{false}()
+
+is_minimizing{MIN}(::ScalarFitnessScheme{MIN}) = MIN
+nafitness(::ScalarFitnessScheme) = NaN
+isnafitness(f::Float64, ::ScalarFitnessScheme) = isnan(f)
+numobjectives(::ScalarFitnessScheme) = 1
 
 # Aggregation is just the identity function for scalar fitness
-aggregate(fitness, ::ScalarFitness) = fitness
+aggregate(fitness, ::ScalarFitnessScheme) = fitness
 
-is_better(f1::Float64, f2::Float64, scheme::ScalarFitness{true}) = f1 < f2
-is_better(f1::Float64, f2::Float64, scheme::ScalarFitness{false}) = f1 > f2
+is_better(f1::Float64, f2::Float64, scheme::ScalarFitnessScheme{true}) = f1 < f2
+is_better(f1::Float64, f2::Float64, scheme::ScalarFitnessScheme{false}) = f1 > f2
 
 # Complex-valued fitness
-# FIXME what is isbetter() for ComplexFitness
-immutable ComplexFitness <: FitnessScheme{Complex128}
+# FIXME what is isbetter() for ComplexFitnessScheme
+immutable ComplexFitnessScheme <: FitnessScheme{Complex128}
 end
 
+# FIXME do we need it? it might be confused with problem's fitness bounds 
 worst_fitness(fs::FitnessScheme) = is_minimizing(fs) ? Inf : (-Inf)
 best_fitness(fs::FitnessScheme) = -worst_fitness(fs)
 
@@ -68,29 +72,29 @@ same_fitness(f1, f2, scheme::FitnessScheme) = hat_compare(f1, f2, scheme) == 0
 # All VectorFitness scheme has N individual fitness scores (at least 1) in
 # an array and could be aggregated to a float value.
 # FIXME
-immutable VectorFitness{MIN,N,AGG} <: RatioFitnessScheme{Vector{Float64}}
+immutable VectorFitnessScheme{MIN,N,AGG} <: RatioFitnessScheme{Vector{Float64}}
   # Function mapping a fitness array to a single numerical value. Might be used
   # for comparisons (or not, depending on setup). Always used when printing
   # fitness vectors though.
   aggregate::AGG
 end
 
-numobjectives{MIN,N}(::VectorFitness{MIN,N}) = N
-is_minimizing{MIN,N}(fs::VectorFitness{MIN,N}) = MIN
+numobjectives{MIN,N}(::VectorFitnessScheme{MIN,N}) = N
+is_minimizing{MIN,N}(fs::VectorFitnessScheme{MIN,N}) = MIN
 
-nafitness{MIN,N}(::VectorFitness{MIN,N}) = fill(NaN, N)
-isnafitness{MIN,N}(f::Vector{Float64}, ::VectorFitness{MIN,N}) = any(isnan(f)) # or all?
+nafitness{MIN,N}(::VectorFitnessScheme{MIN,N}) = fill(NaN, N)
+isnafitness{MIN,N}(f::Vector{Float64}, ::VectorFitnessScheme{MIN,N}) = any(isnan(f)) # or all?
 
-aggregate(fitness, fs::VectorFitness) = fs.aggregate(fitness)
+aggregate(fitness, fs::VectorFitnessScheme) = fs.aggregate(fitness)
 
 # Fitness scheme that minimizes the sum of objectives
 function vector_fitness_scheme_min(nobjectives::Int, aggregate = sum)
-  VectorFitness{true, nobjectives, Function}(aggregate)
+  VectorFitnessScheme{true, nobjectives, Function}(aggregate)
 end
 
 # Fitness scheme that maximizes the sum of objectives
 function vector_fitness_scheme_max(nobjectives::Int, aggregate = sum)
-  VectorFitness{false, nobjectives, Function}(aggregate)
+  VectorFitnessScheme{false, nobjectives, Function}(aggregate)
 end
 
 # FIXME now it's here just to avoid undeclared types

--- a/src/population.jl
+++ b/src/population.jl
@@ -46,6 +46,8 @@ getindex(pop::FitPopulation, rows, cols) = pop.individuals[rows, cols]
 getindex(pop::FitPopulation, ::Colon, cols) = pop.individuals[:, cols] # FIXME remove v0.3 workaround
 getindex(pop::FitPopulation, indi_ixs) = pop.individuals[:, indi_ixs]
 
+candidate_type{F}(pop::FitPopulation{F}) = Candidate{F}
+
 # get unitialized individual from a pool, or create one, if it's empty
 acquire_candi{F}(pop::FitPopulation{F}) = isempty(pop.candi_pool) ? Candidate{F}(@compat(Vector{Float64}(numdims(pop))), -1, pop.nafitness) : pop!(pop.candi_pool)
 

--- a/src/problems/problem_family.jl
+++ b/src/problems/problem_family.jl
@@ -28,11 +28,11 @@ end
 fixed_dim_problem{FS<:FitnessScheme}(prob::OptimizationProblem{FS}, ndim::Int) = prob
 
 function MinimizationProblemFamily(f::Function, name::ASCIIString, range::ParamBounds, fmin::Float64)
-  convert(FunctionBasedProblemFamily, f, name, ScalarFitness{true}(), range, convert(Nullable{Float64}, fmin))
+  convert(FunctionBasedProblemFamily, f, name, MinimizingFitnessScheme, range, convert(Nullable{Float64}, fmin))
 end
 
 function MinimizationProblemFamily(f::Function, name::ASCIIString, range::ParamBounds)
-  convert(FunctionBasedProblemFamily, f, name, ScalarFitness{true}(), range, Nullable{Float64}())
+  convert(FunctionBasedProblemFamily, f, name, MinimizingFitnessScheme, range, Nullable{Float64}())
 end
 
 function minimization_problem(f::Function, name::ASCIIString, range::ParamBounds, ndim::Int)

--- a/test/test_adaptive_differential_evolution.jl
+++ b/test/test_adaptive_differential_evolution.jl
@@ -3,7 +3,7 @@ NumTestRepetitions = 100
 facts("Adaptive differential evolution optimizer") do
 
 ss = symmetric_search_space(1, (0.0, 10.0))
-fake_problem = convert(FunctionBasedProblem, x -> 0.0, "test_problem", ScalarFitness{true}(), ss) # FIXME v0.3 workaround
+fake_problem = convert(FunctionBasedProblem, x -> 0.0, "test_problem", MinimizingFitnessScheme, ss) # FIXME v0.3 workaround
 
 ade = adaptive_de_rand_1_bin(fake_problem, @compat Dict{Symbol,Any}(
   :Population => rand(1, 100)))

--- a/test/test_archive.jl
+++ b/test/test_archive.jl
@@ -98,4 +98,18 @@ facts("TopListArchive") do
 
   end
 
+  context("archive copies the individuals") do
+    a = TopListArchive(2, 3)
+
+    indiv = [0.0, 2.0]
+    add_candidate!(a, 1.0, indiv)
+    # equal but not identical
+    @fact best_candidate(a) == indiv => true
+    @fact best_candidate(a) === indiv => false
+
+    # modify the vector
+    indiv[1] = 5.0
+    # test that archived version is still the same
+    @fact best_candidate(a) => [0.0, 2.0]
+  end
 end

--- a/test/test_archive.jl
+++ b/test/test_archive.jl
@@ -2,10 +2,11 @@ facts("TopListArchive") do
 
   context("Constructing a small archive and adding to it") do
 
-    a = TopListArchive(1, 3)
+    a = TopListArchive(ScalarFitness{true}(), 1, 3)
 
     @fact capacity(a) => 3
     @fact length(a)   => 0
+    @fact best_fitness(a) => isnan
 
     add_candidate!(a, 1.0, [0.0])
     @fact capacity(a)         => 3
@@ -99,7 +100,7 @@ facts("TopListArchive") do
   end
 
   context("archive copies the individuals") do
-    a = TopListArchive(2, 3)
+    a = TopListArchive(ScalarFitness{true}(), 2, 3)
 
     indiv = [0.0, 2.0]
     add_candidate!(a, 1.0, indiv)
@@ -111,5 +112,39 @@ facts("TopListArchive") do
     indiv[1] = 5.0
     # test that archived version is still the same
     @fact best_candidate(a) => [0.0, 2.0]
+  end
+
+  context("for maximizing fitness") do
+    a = TopListArchive(ScalarFitness{false}(), 1, 3)
+
+    add_candidate!(a, 1.0, [0.0])
+    @fact best_fitness(a)     => 1.0
+    @fact best_candidate(a)   => [0.0]
+    @fact last_top_fitness(a) => 1.0
+    @fact delta_fitness(a)    => Inf
+
+    add_candidate!(a, 2.0, [1.0])
+    @fact best_fitness(a)   => 2.0
+    @fact best_candidate(a) => [1.0]
+    @fact last_top_fitness(a) => 1.0
+    @fact delta_fitness(a)    => 1.0
+
+    add_candidate!(a, 0.5, [2.0])
+    @fact best_fitness(a)   => 2.0
+    @fact best_candidate(a) => [1.0]
+    @fact last_top_fitness(a) => 0.5
+    @fact delta_fitness(a)    => 1.0
+
+    add_candidate!(a, 1.5, [4.0])
+    @fact best_fitness(a)   => 2.0
+    @fact best_candidate(a) => [1.0]
+    @fact last_top_fitness(a) => 1.0
+    @fact delta_fitness(a)    => 1.0
+
+    add_candidate!(a, 2.5, [5.0])
+    @fact best_fitness(a)   => 2.5
+    @fact best_candidate(a) => [5.0]
+    @fact last_top_fitness(a) => 1.5
+    @fact delta_fitness(a)    => 0.5
   end
 end

--- a/test/test_archive.jl
+++ b/test/test_archive.jl
@@ -37,6 +37,7 @@ facts("TopListArchive") do
     @fact best_fitness(a)   => 0.5
     @fact best_candidate(a) => [2.0]
     @fact last_top_fitness(a) => 1.0
+    @fact delta_fitness(a)    => 0.5
 
     expected = ((0.8 - 0.5) / ((1 - 0.05)^(-2/1) - 1))
     @fact width_of_confidence_interval(a, 0.05) => expected
@@ -48,6 +49,7 @@ facts("TopListArchive") do
     @fact best_fitness(a)   => 0.4
     @fact best_candidate(a) => [1.9]
     @fact last_top_fitness(a) => 0.8
+    @fact delta_fitness(a)    => roughly(0.1)
 
     expected = ((0.5 - 0.4) / ((1 - 0.05)^(-2/1) - 1))
     @fact width_of_confidence_interval(a, 0.05) => expected

--- a/test/test_archive.jl
+++ b/test/test_archive.jl
@@ -2,7 +2,7 @@ facts("TopListArchive") do
 
   context("Constructing a small archive and adding to it") do
 
-    a = TopListArchive(ScalarFitness{true}(), 1, 3)
+    a = TopListArchive(MinimizingFitnessScheme, 1, 3)
 
     @fact capacity(a) => 3
     @fact length(a)   => 0
@@ -100,7 +100,7 @@ facts("TopListArchive") do
   end
 
   context("archive copies the individuals") do
-    a = TopListArchive(ScalarFitness{true}(), 2, 3)
+    a = TopListArchive(MinimizingFitnessScheme, 2, 3)
 
     indiv = [0.0, 2.0]
     BlackBoxOptim.add_candidate!(a, 1.0, indiv)
@@ -115,7 +115,7 @@ facts("TopListArchive") do
   end
 
   context("for maximizing fitness") do
-    a = TopListArchive(ScalarFitness{false}(), 1, 3)
+    a = TopListArchive(MaximizingFitnessScheme, 1, 3)
 
     BlackBoxOptim.add_candidate!(a, 1.0, [0.0])
     @fact best_fitness(a)     => 1.0

--- a/test/test_archive.jl
+++ b/test/test_archive.jl
@@ -8,7 +8,7 @@ facts("TopListArchive") do
     @fact length(a)   => 0
     @fact best_fitness(a) => isnan
 
-    add_candidate!(a, 1.0, [0.0])
+    BlackBoxOptim.add_candidate!(a, 1.0, [0.0])
     @fact capacity(a)         => 3
     @fact length(a)           => 1
     @fact best_fitness(a)     => 1.0
@@ -16,7 +16,7 @@ facts("TopListArchive") do
     @fact last_top_fitness(a) => 1.0
     @fact delta_fitness(a)    => Inf
 
-    add_candidate!(a, 2.0, [1.0])
+    BlackBoxOptim.add_candidate!(a, 2.0, [1.0])
     @fact capacity(a)       => 3
     @fact length(a)         => 2
     @fact best_fitness(a)   => 1.0
@@ -24,7 +24,7 @@ facts("TopListArchive") do
     @fact last_top_fitness(a) => 2.0
     @fact delta_fitness(a)    => Inf
 
-    add_candidate!(a, 0.5, [2.0])
+    BlackBoxOptim.add_candidate!(a, 0.5, [2.0])
     @fact capacity(a)         => 3
     @fact length(a)           => 3
     @fact best_fitness(a)   => 0.5
@@ -32,7 +32,7 @@ facts("TopListArchive") do
     @fact last_top_fitness(a) => 2.0
     @fact delta_fitness(a)    => 0.5
 
-    add_candidate!(a, 0.8, [4.0])
+    BlackBoxOptim.add_candidate!(a, 0.8, [4.0])
     @fact capacity(a)         => 3
     @fact length(a)           => 3
     @fact best_fitness(a)   => 0.5
@@ -44,7 +44,7 @@ facts("TopListArchive") do
     @fact width_of_confidence_interval(a, 0.05) => expected
     @fact fitness_improvement_potential(a, 0.05) => (expected / 0.50)
 
-    add_candidate!(a, 0.4, [1.9])
+    BlackBoxOptim.add_candidate!(a, 0.4, [1.9])
     @fact capacity(a)       => 3
     @fact length(a)         => 3
     @fact best_fitness(a)   => 0.4
@@ -103,7 +103,7 @@ facts("TopListArchive") do
     a = TopListArchive(ScalarFitness{true}(), 2, 3)
 
     indiv = [0.0, 2.0]
-    add_candidate!(a, 1.0, indiv)
+    BlackBoxOptim.add_candidate!(a, 1.0, indiv)
     # equal but not identical
     @fact best_candidate(a) == indiv => true
     @fact best_candidate(a) === indiv => false
@@ -117,31 +117,31 @@ facts("TopListArchive") do
   context("for maximizing fitness") do
     a = TopListArchive(ScalarFitness{false}(), 1, 3)
 
-    add_candidate!(a, 1.0, [0.0])
+    BlackBoxOptim.add_candidate!(a, 1.0, [0.0])
     @fact best_fitness(a)     => 1.0
     @fact best_candidate(a)   => [0.0]
     @fact last_top_fitness(a) => 1.0
     @fact delta_fitness(a)    => Inf
 
-    add_candidate!(a, 2.0, [1.0])
+    BlackBoxOptim.add_candidate!(a, 2.0, [1.0])
     @fact best_fitness(a)   => 2.0
     @fact best_candidate(a) => [1.0]
     @fact last_top_fitness(a) => 1.0
     @fact delta_fitness(a)    => 1.0
 
-    add_candidate!(a, 0.5, [2.0])
+    BlackBoxOptim.add_candidate!(a, 0.5, [2.0])
     @fact best_fitness(a)   => 2.0
     @fact best_candidate(a) => [1.0]
     @fact last_top_fitness(a) => 0.5
     @fact delta_fitness(a)    => 1.0
 
-    add_candidate!(a, 1.5, [4.0])
+    BlackBoxOptim.add_candidate!(a, 1.5, [4.0])
     @fact best_fitness(a)   => 2.0
     @fact best_candidate(a) => [1.0]
     @fact last_top_fitness(a) => 1.0
     @fact delta_fitness(a)    => 1.0
 
-    add_candidate!(a, 2.5, [5.0])
+    BlackBoxOptim.add_candidate!(a, 2.5, [5.0])
     @fact best_fitness(a)   => 2.5
     @fact best_candidate(a) => [5.0]
     @fact last_top_fitness(a) => 1.5

--- a/test/test_archive.jl
+++ b/test/test_archive.jl
@@ -1,4 +1,12 @@
 facts("TopListArchive") do
+  context("ArchivedIndividual") do
+    # test equality
+    @fact isequal(BlackBoxOptim.ArchivedIndividual([3.0, 2.0], 2.0), BlackBoxOptim.ArchivedIndividual([3.0, 2.0], 2.0)) => true
+    @fact BlackBoxOptim.ArchivedIndividual([3.0, 2.0], 2.0) == BlackBoxOptim.ArchivedIndividual([3.0, 2.0], 2.0) => true
+    @fact BlackBoxOptim.ArchivedIndividual([3.0, 2.0], 2.0) != BlackBoxOptim.ArchivedIndividual([3.0, 2.0], 2.0) => false
+    @fact BlackBoxOptim.ArchivedIndividual([3.0, 2.0], 1.0) != BlackBoxOptim.ArchivedIndividual([3.0, 2.0], 2.0) => true
+    @fact BlackBoxOptim.ArchivedIndividual([1.0, 2.0], 2.0) != BlackBoxOptim.ArchivedIndividual([3.0, 2.0], 2.0) => true
+  end
 
   context("Constructing a small archive and adding to it") do
 
@@ -55,6 +63,17 @@ facts("TopListArchive") do
     expected = ((0.5 - 0.4) / ((1 - 0.05)^(-2/1) - 1))
     @fact width_of_confidence_interval(a, 0.05) => expected
     @fact fitness_improvement_potential(a, 0.05) => (expected / 0.40)
+
+    # identical candidate is not inserted
+    BlackBoxOptim.add_candidate!(a, 0.5, [2.0])
+    @fact capacity(a)       => 3
+    @fact length(a)         => 3
+    @fact last_top_fitness(a)   => 0.8
+
+    # different candidates with the same fitness are inserted
+    BlackBoxOptim.add_candidate!(a, 0.5, [3.0])
+    @fact length(a)             => 3
+    @fact last_top_fitness(a)   => 0.5
   end
 
   context("magnitude_class for positive fitness values") do

--- a/test/test_differential_evolution.jl
+++ b/test/test_differential_evolution.jl
@@ -1,7 +1,8 @@
 facts("Differential evolution optimizer") do
 
 ss = symmetric_search_space(1, (0.0, 10.0))
-fake_problem = convert(FunctionBasedProblem, x -> 0.0, "test_problem", ScalarFitness{true}(), ss) # FIXME v0.3 workaround
+fake_problem = convert(FunctionBasedProblem, x -> 0.0, "test_problem",
+                       MinimizingFitnessScheme, ss) # FIXME v0.3 workaround
 DE = de_rand_1_bin(fake_problem, @compat Dict{Symbol,Any}(
   :Population => collect(1.0:10.0)',
   :f => 0.4, :cr => 0.5, :NumParents => 3))

--- a/test/test_fitness.jl
+++ b/test/test_fitness.jl
@@ -13,15 +13,15 @@ facts("Fitness") do
   end
 
   context("is_minimizing in ScalarFitness schemes") do
-    mins = BlackBoxOptim.ScalarFitness{true}()
+    mins = MinimizingFitnessScheme
     @fact BlackBoxOptim.is_minimizing(mins) => true
 
-    maxs = BlackBoxOptim.ScalarFitness{false}()
+    maxs = MaximizingFitnessScheme
     @fact BlackBoxOptim.is_minimizing(maxs) => false
   end
 
   context("hat_compare floats in a minimizing fitness scheme") do
-    scheme = BlackBoxOptim.ScalarFitness{true}()
+    scheme = MinimizingFitnessScheme
 
     @fact hat_compare(1.0, 2.0, scheme) => -1
     @fact hat_compare(2.0, 1.0, scheme) => 1
@@ -29,7 +29,7 @@ facts("Fitness") do
   end
 
   context("hat_compare floats in a maximizing fitness scheme") do
-    scheme = BlackBoxOptim.ScalarFitness{false}()
+    scheme = MaximizingFitnessScheme
 
     @fact hat_compare(1.0, 2.0, scheme) => 1
     @fact hat_compare(2.0, 1.0, scheme) => -1
@@ -154,11 +154,11 @@ facts("Fitness") do
 
   if VERSION >= v"0.4.0-dev+1258" # FIXME remove version check once v0.4 is released
     context("fitness_scheme(x, y)") do
-      mins = BlackBoxOptim.ScalarFitness{true}()
+      mins = MinimizingFitnessScheme
       @fact mins(5.0, 3.0) => false
       @fact mins(1.0, 2.0) => true
 
-      maxs = BlackBoxOptim.ScalarFitness{false}()
+      maxs = MaximizingFitnessScheme
       @fact maxs(3.0, 5.0) => false
       @fact maxs(2.0, 1.0) => true
     end

--- a/test/test_fitness.jl
+++ b/test/test_fitness.jl
@@ -152,4 +152,15 @@ facts("Fitness") do
     @fact same_fitness([0.0], [0.0], scheme) => true
   end
 
+  if VERSION >= v"0.4.0-dev+1258" # FIXME remove version check once v0.4 is released
+    context("fitness_scheme(x, y)") do
+      mins = BlackBoxOptim.ScalarFitness{true}()
+      @fact mins(5.0, 3.0) => false
+      @fact mins(1.0, 2.0) => true
+
+      maxs = BlackBoxOptim.ScalarFitness{false}()
+      @fact maxs(3.0, 5.0) => false
+      @fact maxs(2.0, 1.0) => true
+    end
+  end
 end

--- a/test/test_population.jl
+++ b/test/test_population.jl
@@ -1,7 +1,7 @@
 facts("Population") do
 
   context("FitPopulation") do
-    fs = ScalarFitness{true}()
+    fs = MinimizingFitnessScheme
     p1 = FitPopulation(fs, 10, 2)
     @fact isa(p1, FitPopulation) => true
 


### PR DESCRIPTION
After the last update ```TopListArchive``` was badly broken: it stored the references to candidate parameters, but since they were returned to the pool and reused, the archive contents were totally wrong. Also the archive was not respecting the fitness scheme. This should be fixed now.

I've also renamed the fitness scheme types, e.g. ```ScalarFitness``` to ```ScalarFitnessScheme``` otherwise someone might confuse it with the actual fitness values. Now there's also ```MinimizingFitnessScheme``` and ```MaximizingFitnessScheme``` constants for readability.

