### PR TITLE
Parameters enhancements

### DIFF
--- a/src/BlackBoxOptim.jl
+++ b/src/BlackBoxOptim.jl
@@ -13,7 +13,7 @@ export  Optimizer, AskTellOptimizer, SteppingOptimizer, PopulationOptimizer,
         XNESOpt, xnes,
 
         # Parameters
-        Parameters, mergeparam,
+        DictChain, Parameters, mergeparam,
 
         # Fitness
         FitnessScheme,

--- a/src/BlackBoxOptim.jl
+++ b/src/BlackBoxOptim.jl
@@ -13,7 +13,8 @@ export  Optimizer, AskTellOptimizer, SteppingOptimizer, PopulationOptimizer,
         XNESOpt, xnes,
 
         # Parameters
-        DictChain, Parameters, mergeparam,
+        DictChain, Parameters,
+        chain,
 
         # Fitness
         FitnessScheme,

--- a/src/adaptive_differential_evolution.jl
+++ b/src/adaptive_differential_evolution.jl
@@ -1,6 +1,6 @@
 include("bimodal_cauchy_distribution.jl")
 
-ADE_DefaultOptions = mergeparam(DE_DefaultOptions, @compat Dict{Symbol,Any}(
+ADE_DefaultOptions = chain(DE_DefaultOptions, @compat Dict{Symbol,Any}(
   # Distributions we will use to generate new F and CR values.
   :fdistr => bimodal_cauchy(0.65, 0.1, 1.0, 0.1),
   :crdistr => bimodal_cauchy(0.1, 0.1, 0.95, 0.1),

--- a/src/bboptimize.jl
+++ b/src/bboptimize.jl
@@ -48,14 +48,13 @@ DefaultParameters = @compat Dict{Symbol,Any}(
 
 # Setup a fixed-dimensional problem
 function setup_problem(problem::OptimizationProblem, parameters = @compat Dict{Symbol,Any}())
-  params = Parameters(parameters, DefaultParameters)
-  return problem, params
+  return problem, chain(DefaultParameters, parameters)
 end
 
 # Create a fixed-dimensional problem given
 #   any-dimensional problem and a number of dimensions as a parameter
 function setup_problem(family::FunctionBasedProblemFamily, parameters = @compat Dict{Symbol,Any}())
-  params = Parameters(parameters, DefaultParameters)
+  params = chain(DefaultParameters, parameters)
 
   # If an anydim problem was given the dimension param must have been specified.
   if params[:NumDimensions] == :NotSpecified
@@ -69,7 +68,7 @@ end
 # Create a fixed-dimensional problem given
 #   a function and a search range + number of dimensions.
 function setup_problem(func::Function, parameters = @compat Dict{Symbol,Any}())
-  params = Parameters(parameters, DefaultParameters)
+  params = chain(DefaultParameters, parameters)
   # Check that a valid search space has been stated and create the search_space
   # based on it, or bail out.
   if typeof(params[:SearchRange]) == typeof((0.0, 1.0))
@@ -85,9 +84,7 @@ function setup_problem(func::Function, parameters = @compat Dict{Symbol,Any}())
 
   # Now create an optimization problem with the given information. We currently reuse the type
   # from our pre-defined problems so some of the data for the constructor is dummy.
-
   problem = convert(FunctionBasedProblem, func, "", MinimizingFitnessScheme, ss) # FIXME v0.3 workaround
-
   return problem, params
 end
 
@@ -188,7 +185,7 @@ function setup_bboptimize(functionOrProblem; max_time = false,
   method = :adaptive_de_rand_1_bin_radiuslimited,
   parameters = @compat Dict{Symbol,Any}())
 
-  params = Parameters(parameters, DefaultParameters)
+  params = chain(DefaultParameters, parameters)
   params[:MaxTime] = max_time
   params[:SearchSpace] = search_space
   params[:SearchRange] = search_range
@@ -495,7 +492,7 @@ function repeated_bboptimize(numrepeats, problem, dim, methods, max_time, ftol =
   # Just so they are declared
   ps = best_so_far = nothing
 
-  params = Parameters(parameters, @compat Dict{Symbol,Any}(:FitnessTolerance => ftol))
+  params = chain(parameters, @compat Dict{Symbol,Any}(:FitnessTolerance => ftol))
 
   for m in methods
 

--- a/src/experiments/parameter_experiment.jl
+++ b/src/experiments/parameter_experiment.jl
@@ -105,7 +105,7 @@ function run_based_on_design_matrix_in_file_while_saving_results_to_csvfile(runf
   for(i in 1:length(pvs))
     param_dict = pvs[i]
     # Add other arguments.
-    param_dict = mergeparam(param_dict, fixed_params)
+    param_dict = chain(param_dict, fixed_params)
     print("params: "); show(param_dict); println("")
 
     # Set up for saving results

--- a/src/natural_evolution_strategies.jl
+++ b/src/natural_evolution_strategies.jl
@@ -50,7 +50,7 @@ NES_DefaultOptions = @compat Dict{Symbol,Any}(
 )
 
 function separable_nes(problem::OptimizationProblem, parameters)
-  params = mergeparam(NES_DefaultOptions, parameters)
+  params = chain(NES_DefaultOptions, parameters)
   SeparableNESOpt(search_space(problem),
     lambda = params[:lambda],
     mu_learnrate = params[:mu_learnrate],
@@ -135,7 +135,7 @@ type XNESOpt <: NaturalEvolutionStrategyOpt
 end
 
 function xnes(problem::OptimizationProblem, parameters)
-  params = mergeparam(NES_DefaultOptions, parameters)
+  params = chain(NES_DefaultOptions, parameters)
   XNESOpt(search_space(problem); lambda = params[:lambda])
 end
 

--- a/src/natural_evolution_strategies.jl
+++ b/src/natural_evolution_strategies.jl
@@ -43,18 +43,18 @@ end
 # We use a different ordering of the dimensions than other optimizers, so transpose.
 population(o::NaturalEvolutionStrategyOpt) = o.population
 
-NES_DefaultOptions = @compat Dict{String,Any}(
-  "lambda" => 0,              # If 0.0 it will be set based on the number of dimensions
-  "mu_learnrate" => 1.0,
-  "sigma_learnrate" => 0.0,   # If 0.0 it will be set based on the number of dimensions
+NES_DefaultOptions = @compat Dict{Symbol,Any}(
+  :lambda => 0,              # If 0.0 it will be set based on the number of dimensions
+  :mu_learnrate => 1.0,
+  :sigma_learnrate => 0.0,   # If 0.0 it will be set based on the number of dimensions
 )
 
 function separable_nes(problem::OptimizationProblem, parameters)
   params = mergeparam(NES_DefaultOptions, parameters)
   SeparableNESOpt(search_space(problem),
-    lambda = params["lambda"],
-    mu_learnrate = params["mu_learnrate"],
-    sigma_learnrate = params["sigma_learnrate"])
+    lambda = params[:lambda],
+    mu_learnrate = params[:mu_learnrate],
+    sigma_learnrate = params[:sigma_learnrate])
 end
 
 calc_sigma_learnrate_for_snes(d) = (3 + log(d)) / (5 * sqrt(d))
@@ -136,7 +136,7 @@ end
 
 function xnes(problem::OptimizationProblem, parameters)
   params = mergeparam(NES_DefaultOptions, parameters)
-  XNESOpt(search_space(problem); lambda = params["lambda"])
+  XNESOpt(search_space(problem); lambda = params[:lambda])
 end
 
 function ask(xnes::XNESOpt)

--- a/src/parameters.jl
+++ b/src/parameters.jl
@@ -1,39 +1,42 @@
 # An ordered set of dicts which we traverse to find the parameter value.
 # Returns nothing if no param setting is found in any of the dicts.
-type Parameters
-  dicts  # First hash is searched first and then in order until the last
+type DictChain{K,V} <: Associative{K,V}
+  dicts::Vector{Associative{K,V}}  # First dict is searched first and then in order until the last
 
-  Parameters(dicts...) = begin
-    # Ensure we have at least one hash there if none are given
-    if length(dicts) == 0
-      dicts = Dict{Any,Any}[Dict{Any, Any}()]
-    end
+  DictChain(dicts::Vector{Associative{K,V}}) = new(dicts)
 
-    new(dicts)
-  end
+  # empty dicts vector
+  DictChain() = new(Array(Associative{K,V}, 0))
+
+  DictChain(dicts::Associative{K,V}...) = new(Associative{K,V}[dict for dict in dicts])
 end
 
-function getindex(p::Parameters, key)
-  stringkey = string(key)
-  symbolkey = symbol(key)
+# (Associative{K,V}...) ctor is not triggered, so here's 1-, 2- and 3-argument
+# versions of it, until there's a better way
+DictChain{K,V}(dict::Associative{K,V}) = DictChain{K,V}(dict)
+DictChain{K,V}(dict1::Associative{K,V}, dict2::Associative{K,V}) = DictChain{K,V}(dict1, dict2)
+DictChain{K,V}(dict1::Associative{K,V}, dict2::Associative{K,V}, dict3::Associative{K,V}) = DictChain{K,V}(dict1, dict2, dict3)
+
+function Base.getindex{K,V}(p::DictChain{K,V}, key::K)
   for d in p.dicts
-    if haskey(d, symbolkey)
-      return getindex(d, symbolkey)
-    elseif haskey(d, stringkey)
-      return getindex(d, stringkey)
+    if haskey(d, key)
+      return getindex(d, key)
     end
   end
-  return nothing
+  throw(KeyError(key))
 end
 
-function setindex!(p::Parameters, value, key)
+# FIXME no type declaration for value due to 0.3 compatibility
+function Base.setindex!{K,V}(p::DictChain{K,V}, value, key::K)
+  if isempty(p.dicts)
+    push!(p.dicts, Dict{K,V}()) # add new dictionary on top
+  end
   setindex!(first(p.dicts), value, key)
 end
 
 import Base.haskey, Base.get, Base.delete!
 
-
-function haskey(p::Parameters, key)
+function Base.haskey{K,V}(p::DictChain{K,V}, key::K)
   for d in p.dicts
     if haskey(d, key)
       return true
@@ -42,17 +45,21 @@ function haskey(p::Parameters, key)
   return false
 end
 
-function get(p::Parameters, key, default = nothing)
-  value = getindex(p, key)
-  return (value == nothing ? default : value)
+# FIXME no type declaration for default due to 0.3 compatibility
+function get{K,V}(p::DictChain{K,V}, key::K, default = nothing)
+  return haskey(p, key) ? getindex(p, key) : default
 end
 
 # In a merge the last parameter should be prioritized since this is the way
 # the normal Julia merge of dicts works.
-mergeparam(p1::Union(Dict, Parameters), p2::Union(Dict, Parameters)) = Parameters(p2, p1)
+mergeparam{K,V}(p1::Union(Dict{K,V}, DictChain{K,V}), p2::Union(Dict{K,V}, DictChain{K,V})) = DictChain(p2, p1)
 
-function delete!(p::Parameters, key)
+function delete!{K,V}(p::DictChain{K,V}, key::K)
   for d in p.dicts
     delete!(d, key)
   end
+  p
 end
+
+# The default parameters storage in BlackBoxOptim
+typealias Parameters DictChain{Symbol,Any}

--- a/test/test_parameters.jl
+++ b/test/test_parameters.jl
@@ -1,10 +1,41 @@
+facts("DictChain") do
+  context("Matching keys and type parameters") do
+    dc1 = DictChain{Int,ASCIIString}()
+
+    @fact_throws (dc1[:NotThere] = 3) KeyError
+    @fact_throws (dc1[:NotThere] = "abc") KeyError
+    @fact_throws (dc1[3] = 3) MethodError
+    dc1[3] = "abc"
+    @fact dc1[3] => "abc"
+  end
+
+  context("merging and chaining") do
+    dc1 = DictChain{Symbol,ASCIIString}()
+
+    d1 = @compat Dict{Symbol, Int}(:a => 1)
+    d2 = @compat Dict{Symbol, Int}(:a => 2, :b => 4)
+    d3 = @compat Dict{Symbol, Int}(:b => 3, :c => 5)
+
+    context("using constructor") do
+      dc = DictChain(d1, d2, d3)
+      @fact typeof(dc) => DictChain{Symbol,Int}
+      @fact dc[:a], dc[:b], dc[:c] => 1, 4, 5
+
+      dc = DictChain(d2, d1, d3)
+      @fact dc[:a], dc[:b], dc[:c] => 2, 4, 5
+
+      dc = DictChain(DictChain(d3, d1), d2)
+      @fact dc[:a], dc[:b], dc[:c] => 1, 3, 5
+    end
+end
+
 facts("Parameters") do
 
-  context("When no parameters") do
+  context("When no parameters or key type doesn't match") do
 
     ps = Parameters()
-    @fact ps[:NotThere] => nothing
-    @fact ps["Neither there"] => nothing
+    @fact_throws ps[:NotThere] KeyError
+    @fact_throws ps["Neither there"] MethodError
 
     ps[:a] = 1
     @fact ps[:a] => 1
@@ -13,86 +44,84 @@ facts("Parameters") do
 
   context("With one parameter in one set") do
 
-    ps = Parameters({:a => 1})
+    ps = Parameters(@compat Dict{Symbol,Any}(:a => 1))
 
     @fact ps[:a] => 1
-    @fact ps["a"] => 1
+    @fact_throws ps["a"] MethodError # incorrect key type
 
-    @fact ps[:A] => nothing
-    @fact ps["A"] => nothing
-    @fact ps[:B] => nothing
-    @fact ps["B"] => nothing
+    @fact_throws ps[:A] KeyError
+    @fact_throws ps[:B] KeyError
 
   end
 
   context("With parameters in multiple sets") do
 
-    ps = Parameters({:a => 1, "c" => 4}, {:a => 2, :b => 3}, {:c => 5})
+    ps = Parameters(@compat(Dict{Symbol,Any}(:a => 1, :c => 4)),
+                    @compat(Dict{Symbol,Any}(:a => 2, :b => 3)),
+                    @compat(Dict{Symbol,Any}(:c => 5)))
 
     @fact ps[:a] => 1
-    @fact ps["a"] => 1
 
     @fact ps[:c] => 4
-    @fact ps["c"] => 4
 
     @fact ps[:b] => 3
-    @fact ps["b"] => 3
 
-    @fact ps[:A] => nothing
-    @fact ps["A"] => nothing
-    @fact ps[:B] => nothing
-    @fact ps["B"] => nothing
-
+    @fact_throws ps[:A] KeyError
+    @fact_throws ps[:B] KeyError
   end
 
   context("Updating parameters after construction") do
 
-    ps = Parameters({:a => 1, "c" => 4}, {:a => 2, :b => 3}, {:c => 5})
+    ps = Parameters(@compat(Dict{Symbol,Any}(:a => 1, :c => 4)),
+                    @compat(Dict{Symbol,Any}(:a => 2, :b => 3)),
+                    @compat(Dict{Symbol,Any}(:c => 5)))
 
     ps[:c] = 6
-    ps["b"] = 7
+    ps[:b] = 7
 
     @fact ps[:a] => 1
-    @fact ps["a"] => 1
 
     @fact ps[:c] => 6
-    @fact ps["c"] => 6
 
     @fact ps[:b] => 7
-    @fact ps["b"] => 7
 
   end
 
   context("Constructing from another parameters object") do
 
-    ps1 = Parameters({:a => 1, "c" => 4}, {:a => 2, :b => 3})
-    ps2 = Parameters({:a => 5}, ps1, {:c => 6})
+    ps1 = Parameters(@compat(Dict{Symbol,Any}(:a => 1, :c => 4)),
+                     @compat(Dict{Symbol,Any}(:a => 2, :b => 3)))
+    ps2 = Parameters(@compat(Dict{Symbol,Any}(:a => 5)), ps1,
+                     @compat(Dict{Symbol,Any}(:c => 6)))
 
+    @fact ps1[:a] => 1
     @fact ps2[:a] => 5
     @fact ps2[:c] => 4
-
   end
 
   context("Get key without default") do
 
-    ps = Parameters({:a => 1, "c" => 4}, {:a => 2, :b => 3})
+    ps = Parameters(@compat(Dict{Symbol,Any}(:a => 1, :c => 4)),
+                    @compat(Dict{Symbol,Any}(:a => 2, :b => 3)))
     @fact get(ps, :a) => 1
     @fact get(ps, :b) => 3
     @fact get(ps, :d) => nothing
 
   end
 
-  context("Get key without default") do
+  context("Get key with default") do
 
-    ps = Parameters({:a => 1, "c" => 4}, {:a => 2, :b => 3})
+    ps = Parameters(@compat(Dict{Symbol,Any}(:a => 1, :c => 4)),
+                    @compat(Dict{Symbol,Any}(:a => 2, :b => 3)))
     @fact get(ps, :d, 10) => 10
 
   end
 
   context("Merge with Parameters or Dict") do
 
-    ps = Parameters({:a => 1, "c" => 4}, {:a => 2, :b => 3})
-    ps2 = mergeparam(ps, {:d => 5, :a => 20})
+    ps = Parameters(@compat(Dict{Symbol,Any}(:a => 1, :c => 4)),
+                    @compat(Dict{Symbol,Any}(:a => 2, :b => 3)))
+    ps2 = mergeparam(ps, @compat(Dict{Symbol,Any}(:d => 5, :a => 20)))
     @fact ps2[:d] => 5
     @fact ps2[:b] => 3
     @fact ps2[:a] => 20


### PR DESCRIPTION
Some cleaning up for the Dictionary-based parameters.
 * ```Parameters``` class renamed into ```DictChain``` and parameterized by key and value types. ```Parameters``` now is an alias to ```DictChain{Symbol,Any}``` (so all method parameters must be symbols). This should help identifying the issues with incorrect key types at compile time.
 * ```mergeparam()``` renamed into ```chain()```, but there's also ```Base.merge()``` methods
 * ```getindex()``` throws ```KeyError``` if the key is missing. Since we should have the default value for every method parameter in ```DictChain```, any request of a missing key is actually a bug.
 * ```convert(Dict, DictChain)``` method. I had some obscure problems with Parameters type serialization (for parallelization), using dict solved it.