### PR TITLE
Small cleanups after interface update 

### DIFF
--- a/src/BlackBoxOptim.jl
+++ b/src/BlackBoxOptim.jl
@@ -108,11 +108,19 @@ include(joinpath("problems", "problem_family.jl"))
 
 include("evaluator.jl")
 
-function setup!(o::Optimizer, evaluator::Evaluator)
+function setup!(o::SteppingOptimizer)
   # Do nothing, override if you need to setup prior to the optimization loop
 end
 
-function finalize!(o::Optimizer, evaluator::Evaluator)
+function finalize!(o::SteppingOptimizer)
+  # Do nothing, override if you need to finalize something after the optimization loop
+end
+
+function setup!(o::AskTellOptimizer, evaluator::Evaluator)
+  # Do nothing, override if you need to setup prior to the optimization loop
+end
+
+function finalize!(o::AskTellOptimizer, evaluator::Evaluator)
   # Do nothing, override if you need to finalize something after the optimization loop
 end
 

--- a/src/adaptive_differential_evolution.jl
+++ b/src/adaptive_differential_evolution.jl
@@ -1,6 +1,6 @@
 include("bimodal_cauchy_distribution.jl")
 
-ADE_DefaultOptions = chain(DE_DefaultOptions, @compat Dict{Symbol,Any}(
+const ADE_DefaultOptions = chain(DE_DefaultOptions, @compat Dict{Symbol,Any}(
   # Distributions we will use to generate new F and CR values.
   :fdistr => bimodal_cauchy(0.65, 0.1, 1.0, 0.1),
   :crdistr => bimodal_cauchy(0.1, 0.1, 0.95, 0.1),

--- a/src/bboptimize.jl
+++ b/src/bboptimize.jl
@@ -10,7 +10,7 @@ function setup_problem(family::FunctionBasedProblemFamily, parameters::Parameter
 
   # If an anydim problem was given the dimension param must have been specified.
   if params[:NumDimensions] == :NotSpecified
-    throw(ArgumentError("You MUST specify the number of dimensions in a solution when a problem family is given"))
+    throw(ArgumentError("You MUST specify NumDimensions= when a problem family is given"))
   end
   problem = fixed_dim_problem(family, parameters[:NumDimensions])
 
@@ -22,17 +22,19 @@ end
 function setup_problem(func::Function, parameters::Parameters = EMPTY_PARAMS)
   params = chain(DefaultParameters, parameters)
 
-  ss = check_and_create_search_space_from_parameters(params)
+  ss = check_and_create_search_space(params)
 
   # Now create an optimization problem with the given information. We currently reuse the type
   # from our pre-defined problems so some of the data for the constructor is dummy.
   problem = convert(FunctionBasedProblem, func, "", MinimizingFitnessScheme, ss) # FIXME v0.3 workaround
 
-  # Create a random solution from the search space and ensure that the given function returns a Number.
-  ind = rand_individual(BlackBoxOptim.search_space(problem))
+  # validate fitness: create a random solution from the search space and ensure that fitness(problem) returns fitness_type(problem).
+  ind = rand_individual(search_space(problem))
   res = fitness(ind, problem)
   if !isa(res, fitness_type(problem))
-    throw(ArgumentError("The supplied function does NOT return the expected fitness type when called with a potential solution (when called with $(ind) it returned $(res)) so we cannot optimize it!"))
+    throw(ArgumentError("The supplied fitness function does NOT return the expected fitness type "*
+                        "when called with a potential solution "*
+                        "(when called with $(ind) it returned $(res)) so we cannot optimize it!"))
   end
 
   return problem, params

--- a/src/bboptimize.jl
+++ b/src/bboptimize.jl
@@ -1,28 +1,24 @@
 # Setup a fixed-dimensional problem
-function setup_problem(problem::OptimizationProblem, parameters::Parameters = EMPTY_PARAMS)
-  return problem, chain(DefaultParameters, parameters)
+function setup_problem(problem::OptimizationProblem, parameters::Parameters)
+  return problem, parameters
 end
 
 # Create a fixed-dimensional problem given
 #   any-dimensional problem and a number of dimensions as a parameter
-function setup_problem(family::FunctionBasedProblemFamily, parameters::Parameters = EMPTY_PARAMS)
-  params = chain(DefaultParameters, parameters)
-
+function setup_problem(family::FunctionBasedProblemFamily, parameters::Parameters)
   # If an anydim problem was given the dimension param must have been specified.
   if params[:NumDimensions] == :NotSpecified
     throw(ArgumentError("You MUST specify NumDimensions= when a problem family is given"))
   end
   problem = fixed_dim_problem(family, parameters[:NumDimensions])
 
-  return problem, params
+  return problem, parameters
 end
 
 # Create a fixed-dimensional problem given
 #   a function and a search range + number of dimensions.
-function setup_problem(func::Function, parameters::Parameters = EMPTY_PARAMS)
-  params = chain(DefaultParameters, parameters)
-
-  ss = check_and_create_search_space(params)
+function setup_problem(func::Function, parameters::Parameters)
+  ss = check_and_create_search_space(parameters)
 
   # Now create an optimization problem with the given information. We currently reuse the type
   # from our pre-defined problems so some of the data for the constructor is dummy.
@@ -37,7 +33,7 @@ function setup_problem(func::Function, parameters::Parameters = EMPTY_PARAMS)
                         "(when called with $(ind) it returned $(res)) so we cannot optimize it!"))
   end
 
-  return problem, params
+  return problem, parameters
 end
 
 function bboptimize(optctrl::OptController; kwargs...)

--- a/src/default_parameters.jl
+++ b/src/default_parameters.jl
@@ -1,5 +1,5 @@
 # Default parameters for all convenience methods that are exported to the end user.
-DefaultParameters = @compat Dict{Symbol,Any}(
+const DefaultParameters = @compat Dict{Symbol,Any}(
   :NumDimensions  => :NotSpecified, # Dimension of problem to be optimized
   :SearchRange    => (-1.0, 1.0), # Default search range to use per dimension unless specified
   :SearchSpace    => false, # Search space can be directly specified and will then take precedence over NumDimensions and SearchRange.

--- a/src/differential_evolution.jl
+++ b/src/differential_evolution.jl
@@ -1,6 +1,6 @@
 using Distributions
 
-DE_DefaultOptions = @compat Dict{Symbol,Any}(
+const DE_DefaultOptions = @compat Dict{Symbol,Any}(
   :f => 0.6,
   :cr => 0.7,
   :SamplerRadius => 8,

--- a/src/direct_search_with_probabilistic_descent.jl
+++ b/src/direct_search_with_probabilistic_descent.jl
@@ -42,7 +42,7 @@ function directions_for_k(rdg::MirroredRandomDirectionGen, k)
   [r -r]
 end
 
-DirectSearchProbabilisticDescentDefaultParameters = @compat Dict{Symbol,Any}(
+const DirectSearchProbabilisticDescentDefaultParameters = @compat Dict{Symbol,Any}(
   :NumDirections => 2, # This should be a function of Gamma and Phi for the GSS but 2 is often enough
 )
 

--- a/src/generating_set_search.jl
+++ b/src/generating_set_search.jl
@@ -27,7 +27,7 @@ end
 # individually (+ and -) for each coordinate.
 compass_search_directions(n) = ConstantDirectionGen([eye(n,n) -eye(n, n)])
 
-GSSDefaultParameters = @compat Dict{Symbol,Any}(
+const GSSDefaultParameters = @compat Dict{Symbol,Any}(
   :DeltaTolerance => 1e-10,       # GSS has converged if the StepSize drops below this tolerance level
   :InitialStepSizeFactor => 0.50,        # Factor times the minimum search space diameter to give the initial StepSize
   :RandomDirectionOrder => true,  # Randomly shuffle the order in which the directions are used for each step

--- a/src/natural_evolution_strategies.jl
+++ b/src/natural_evolution_strategies.jl
@@ -43,7 +43,7 @@ end
 # We use a different ordering of the dimensions than other optimizers, so transpose.
 population(o::NaturalEvolutionStrategyOpt) = o.population
 
-NES_DefaultOptions = @compat Dict{Symbol,Any}(
+const NES_DefaultOptions = @compat Dict{Symbol,Any}(
   :lambda => 0,              # If 0.0 it will be set based on the number of dimensions
   :mu_learnrate => 1.0,
   :sigma_learnrate => 0.0,   # If 0.0 it will be set based on the number of dimensions

--- a/src/opt_controller.jl
+++ b/src/opt_controller.jl
@@ -139,9 +139,19 @@ function step!{O<:SteppingOptimizer}(ctrl::OptRunController{O})
   return 0
 end
 
+setup_optimizer!{O<:SteppingOptimizer}(ctrl::OptRunController{O}) =
+  setup!(ctrl.optimizer)
+setup_optimizer!{O<:AskTellOptimizer}(ctrl::OptRunController{O}) =
+  setup!(ctrl.optimizer, ctrl.evaluator)
+
+finalize_optimizer!{O<:SteppingOptimizer}(ctrl::OptRunController{O}) =
+  finalize!(ctrl.optimizer)
+finalize_optimizer!{O<:AskTellOptimizer}(ctrl::OptRunController{O}) =
+  finalize!(ctrl.optimizer, ctrl.evaluator)
+
 function run!(ctrl::OptRunController)
   tr(ctrl, "Starting optimization with optimizer $(name(ctrl.optimizer))\n")
-  setup!(ctrl.optimizer, evaluator(ctrl))
+  setup_optimizer!(ctrl)
 
   ctrl.start_time = time()
   ctrl.num_steps = 0
@@ -166,7 +176,7 @@ function run!(ctrl::OptRunController)
   ctrl.stop_time = time()
   ctrl.num_better += ctrl.num_better_since_last_report
   ctrl.num_better_since_last_report = 0
-  finalize!(ctrl.optimizer, evaluator(ctrl))
+  finalize_optimizer!(ctrl)
   tr(ctrl, "\nOptimization stopped after $(ctrl.num_steps) steps and $(elapsed_time(ctrl)) seconds\n")
 end
 

--- a/src/optimization_methods.jl
+++ b/src/optimization_methods.jl
@@ -1,5 +1,5 @@
 # FIXME replace Any with Type{Optimizer} when the support for Julia v0.3 would be dropped
-ValidMethods = @compat Dict{Symbol,Union(Any,Function)}(
+const ValidMethods = @compat Dict{Symbol,Union(Any,Function)}(
   :random_search => random_search,
   :de_rand_1_bin => de_rand_1_bin,
   :de_rand_2_bin => de_rand_2_bin,
@@ -16,4 +16,4 @@ ValidMethods = @compat Dict{Symbol,Union(Any,Function)}(
   :probabilistic_descent => direct_search_probabilistic_descent,
 )
 
-MethodNames = sort!(collect(keys(ValidMethods)))
+const MethodNames = sort!(collect(keys(ValidMethods)))

--- a/src/problems/single_objective.jl
+++ b/src/problems/single_objective.jl
@@ -17,7 +17,7 @@ Hartman3 = minimization_problem(hartman3, "Hartman3", (0.0, 1.0), 3, -3.86003844
 # We skip (for now) f12 and f13 in the JADE paper since they are penalized
 # functions which are quite nonstandard. We also skip f8 since we are unsure
 # about its proper implementation.
-JadeFunctionSet = @compat Dict{Int,FunctionBasedProblemFamily}(
+const JadeFunctionSet = @compat Dict{Int,FunctionBasedProblemFamily}(
   1   => MinimizationProblemFamily(sphere, "Sphere", (-100.0, 100.0), 0.0),
   2   => MinimizationProblemFamily(schwefel2_22,  "Schwefel2.22",  ( -10.0,  10.0), 0.0),
   3   => MinimizationProblemFamily(schwefel1_2,   "Schwefel1.2",   (-100.0, 100.0), 0.0),
@@ -160,7 +160,7 @@ function xrotatedandshifted(n, f, shiftAmplitude = 1.0, rotateAmplitude = 1.0)
   transformed_f(x) = f(rotmatrix * (x .- shift))
 end
 
-example_problems = @compat Dict{String,Any}( #FIXME use Union{Optimization,FunctionBasedProblemFamily}
+const example_problems = @compat Dict{String,Any}( #FIXME use Union{Optimization,FunctionBasedProblemFamily}
   "Sphere" => JadeFunctionSet[1],
   "Rosenbrock" => JadeFunctionSet[5],
   "Schwefel2.22" => JadeFunctionSet[2],

--- a/src/resampling_memetic_search.jl
+++ b/src/resampling_memetic_search.jl
@@ -14,7 +14,7 @@
 #  Search: High Performance Despite the Simplicity", 2013.
 #
 
-RSDefaultParameters = @compat Dict{Symbol,Any}(
+const RSDefaultParameters = @compat Dict{Symbol,Any}(
   :PrecisionRatio    => 0.40, # 40% of the diameter is used as the initial step length
   :PrecisionTreshold => 1e-6  # They use 1e-6 in the paper.
 )
@@ -50,7 +50,7 @@ end
 
 name(rs::ResamplingMemeticSearcher) = rs.name
 
-RISDefaultParameters = @compat Dict{Symbol,Any}(
+const RISDefaultParameters = @compat Dict{Symbol,Any}(
   :InheritanceRatio => 0.30   # On average, 30% of positions are inherited when resampling in RIS
 )
 

--- a/src/simultaneous_perturbation_stochastic_approximation.jl
+++ b/src/simultaneous_perturbation_stochastic_approximation.jl
@@ -1,6 +1,6 @@
 abstract StochasticApproximationOptimizer <: AskTellOptimizer
 
-SPSADefaultParameters = @compat Dict{Symbol,Any}(
+const SPSADefaultParameters = @compat Dict{Symbol,Any}(
   :Alpha => 0.602,  # The optimal value is 1.0 but values down to 0.602 often can give faster convergence
   :Gamma => 0.101,  # The optimal value is 1/6 but values down to 0.101 often can give faster convergence
   :a     => 0.0017,

--- a/test/test_direct_search_with_probabilistic_descent.jl
+++ b/test/test_direct_search_with_probabilistic_descent.jl
@@ -32,7 +32,7 @@ facts("Random direction generator") do
   rdg2 = BlackBoxOptim.RandomDirectionGen(10, 17)
   ds2 = BlackBoxOptim.directions_for_k(rdg2, 1)
   @fact size(ds2) => (10, 17)
-  
+
 end
 
 facts("Mirrored random direction generator") do
@@ -40,16 +40,16 @@ facts("Mirrored random direction generator") do
   mrdg1 = BlackBoxOptim.MirroredRandomDirectionGen(2, 4)
   ds1 = BlackBoxOptim.directions_for_k(mrdg1, 1)
   @fact size(ds1) => (2, 4)
-  @fact ds1[:,3] == -ds1[:,1] => true
-  @fact ds1[:,4] == -ds1[:,2] => true
+  @fact ds1[:,3] => -ds1[:,1]
+  @fact ds1[:,4] => -ds1[:,2]
 
   mrdg2 = BlackBoxOptim.MirroredRandomDirectionGen(10, 6)
   ds2 = BlackBoxOptim.directions_for_k(mrdg2, 1)
   @fact size(ds2) => (10, 6)
-  @fact ds2[:,4] == -ds2[:,1] => true
-  @fact ds2[:,5] == -ds2[:,2] => true
-  @fact ds2[:,6] == -ds2[:,3] => true
-  
+  @fact ds2[:,4] => -ds2[:,1]
+  @fact ds2[:,5] => -ds2[:,2]
+  @fact ds2[:,6] => -ds2[:,3]
+
   # Must be even number of directions
   @fact_throws BlackBoxOptim.MirroredRandomDirectionGen(10, 1)
   @fact_throws BlackBoxOptim.MirroredRandomDirectionGen(10, 3)


### PR DESCRIPTION
Small cleanups here and there.
 * The most visible change is that `DefaultParameters` are not chained twice. It fixes the failing serialization test on nightlies. (Probably it hides the real issue related to serializing `DictChain` that references the same `Dict` twice, but I didn't manage to produce a minimal self-contained test to demonstrate the issue)
 * `finish!()` and `setup!()` methods of `SteppingOptimizer` do not need `evaluator` arg
 * all default parameter dictionaries are declared constant. It's safer and maybe better for packages precompilation feature coming in v0.4.