### PR TITLE
Fix NES

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ The section above described the basic API for the BlackBoxOptim package. We empl
 In addition to the `Method` parameters, there are many other parameters you can change.
 
 * `MaxTime`: For how long can the optimization run? Defaults to false which means that number of iterations is the given budget, rather than time.
-* `ShowTrace`: Should a trace of the optimization be shown on `STDOUT`? Defaults to `false`.
+* `TraceMode`: How optimization progress should be displayed. Defaults to `:compact` that outputs current number of fitness evaluations and best value each `TraceInterval` seconds.
 * `PopulationSize`: How large is the initial population for population-based optimizers? Defaults to `50`.
 
 You can also have detailed control over the optimization byt giving a Dict mapping named parameters to their values. Most optimizers have specific options that can be specified in the `parameters` dict.

--- a/design/design_by_testcode/test_bboptimize_toplevel_interface.jl
+++ b/design/design_by_testcode/test_bboptimize_toplevel_interface.jl
@@ -1,7 +1,7 @@
 facts("Top-level interface") do
   context("run a simple optimization with mostly defaults") do
     res = bboptimize(rosenbrock; SearchRange = (-5.0, 5.0), NumDimensions = 2,
-      MaxTime = 0.5, ShowTrace = false)
+      MaxTime = 0.5, TraceMode = :silent)
     @fact bestfitness(res) < 0.01 => true
     xbest = best(res)
     @fact typeof(xbest) => Vector{Float64}
@@ -10,7 +10,7 @@ facts("Top-level interface") do
 
   context("continue running an optimization after it finished") do
     optctrl = bbsetup(rosenbrock; SearchRange = (-5.0, 5.0), NumDimensions = 2,
-      MaxTime = 0.5, ShowTrace = false)
+      MaxTime = 0.5, TraceMode = :silent)
     res1 = bboptimize(optctrl)
     @fact numruns(optctrl) => 1
 
@@ -31,7 +31,7 @@ facts("Top-level interface") do
 
   context("continue running an optimization after serializing to disc") do
     optctrl = bbsetup(rosenbrock; SearchRange = (-5.0, 5.0), NumDimensions = 2,
-      MaxTime = 0.5, ShowTrace = false)
+      MaxTime = 0.5, TraceMode = :silent)
     res1 = bboptimize(optctrl)
 
     tempfilename = "./temp" * string(rand(1:int(1e8))) * ".tmp"
@@ -58,13 +58,13 @@ facts("Top-level interface") do
     # an OptimizationAction (such as, for example, StopOptimization) or just nothing for no action.
     terminate_func = (optstate) -> numsteps(optstate) >= 100 ? BlackBoxOptim.StopOptimization : nothing
     res = bboptimize(rosenbrock; MaxSteps = 500, SearchRange = (-5.0, 5.0), NumDimensions = 2,
-      ShowTrace = false, StepCallback => terminate_func)
+      TraceMode = :silent, StepCallback => terminate_func)
     @fact numsteps(res) => 100
   end
 
   context("accessing the trace of the optimization") do
     res = bboptimize(rosenbrock; SearchRange = (-5.0, 5.0), NumDimensions = 2,
-      MaxTime = 0.5, ShowTrace = false)
+      MaxTime = 0.5, TraceMode = :silent)
     tr = trace(res)
     numimprovs = length(tr)
     # Last fitness value in trace is the best fitness achieved

--- a/examples/benchmarking/compare_optimizers.jl
+++ b/examples/benchmarking/compare_optimizers.jl
@@ -200,16 +200,16 @@ increase_runs_per_problem(problemname, numdims) = begin
   RunsPerProblem[k] = get(RunsPerProblem, k, 0) + 1
 end
 
-function fitness_for_opt(family::FunctionBasedProblemFamily, numDimensions::Int, populationSize::Int, numFuncEvals::Int,
-    method::Symbol, showtrace::Bool = true)
+function fitness_for_opt(family::FunctionBasedProblemFamily, NumDimensions::Int, PopulationSize::Int, MaxFuncEvals::Int,
+    Method::Symbol, TraceMode::Symbol = :compact)
 
-  problem = BlackBoxOptim.fixed_dim_problem(family, numDimensions)
+  problem = BlackBoxOptim.fixed_dim_problem(family, NumDimensions)
 
-  res = bboptimize(problem; Method = method,
-    NumDimensions = numDimensions,
-    PopulationSize = populationSize,
-    ShowTrace = showtrace,
-    MaxFuncEvals = numFuncEvals
+  res = bboptimize(problem; Method = Method,
+    NumDimensions = NumDimensions,
+    PopulationSize = PopulationSize,
+    TraceMode = TraceMode,
+    MaxFuncEvals = MaxFuncEvals
   )
 
   best_fitness(res)
@@ -234,7 +234,7 @@ function multitest_opt(problemDescriptions, method; NumRepetitions = 3)
 
       # Ensure everything is compiled before we start measuring the 1st time.
       if runs_per_problem(probname, numdims) == 0
-        fitness_for_opt(prob, numdims, popsize, 100, method, false)
+        fitness_for_opt(prob, numdims, popsize, 100, method, :silent)
         increase_runs_per_problem(probname, numdims)
       end
 

--- a/examples/restarting_optimization.jl
+++ b/examples/restarting_optimization.jl
@@ -10,9 +10,9 @@ end
 # to the optimizer, problem and params. Use the function
 # setup_bboptimize instead of bboptimize, but with the same
 # parameters. We just run it for 10 steps though:
-optimizer, problem, params = BlackBoxOptim.setup_bboptimize(rosenbrock2d; 
-  search_range = (-5.0, 5.0), dimensions = 2, 
-  parameters = {:MaxSteps => 10, :ShowTrace => false});
+optimizer, problem, params = BlackBoxOptim.setup_bboptimize(rosenbrock2d;
+  search_range = (-5.0, 5.0), dimensions = 2,
+  parameters = {:MaxSteps => 10, :TraceMode => :silent});
 
 # Now we can run it:
 best10, fitness10, termination_reason10, elapsed_time10, params, num_evals10 = BlackBoxOptim.run_optimizer_on_problem(optimizer, problem; parameters = params);

--- a/examples/save_and_load_optimization_state_to_disc.jl
+++ b/examples/save_and_load_optimization_state_to_disc.jl
@@ -1,7 +1,7 @@
 using BlackBoxOptim
 
 # Lets start an optimization of 2D rosenbrock
-# as in the README, then save its state to disc, 
+# as in the README, then save its state to disc,
 # read it back in and continue optimization.
 function rosenbrock2d(x)
   return (1.0 - x[1])^2 + 100.0 * (x[2] - x[1]^2)^2
@@ -11,9 +11,9 @@ end
 # to the optimizer, problem and params. Use the function
 # setup_bboptimize instead of bboptimize, but with the same
 # parameters. We just run it for 10 steps though:
-optimizer, problem, params = BlackBoxOptim.setup_bboptimize(rosenbrock2d; 
-  search_range = (-5.0, 5.0), dimensions = 2, 
-  parameters = {:MaxSteps => 100, :ShowTrace => false});
+optimizer, problem, params = BlackBoxOptim.setup_bboptimize(rosenbrock2d;
+  search_range = (-5.0, 5.0), dimensions = 2,
+  parameters = {:MaxSteps => 100, :TraceMode => :silent});
 
 # Now we can run it:
 b100, f100, tr100, time100, params, ne100 = BlackBoxOptim.run_optimizer_on_problem(

--- a/spikes/optim_highdim.jl
+++ b/spikes/optim_highdim.jl
@@ -17,7 +17,7 @@ function compare_algs(funcToOpt, dim;
   HighBound = 10.0,
   NumReps = 3,
   NumIterations = 2000,
-  ShowTrace = true,
+  TraceMode = :compact,
   Algs = OptimAlgs)
 
   global tf
@@ -35,14 +35,14 @@ function compare_algs(funcToOpt, dim;
     for rep in 1:NumReps
       global tf = xrotatedandshifted(dim, funcToOpt)
       global numfevals = 0
-      if ShowTrace
+      if TraceMode != :silent
         println("\nSolving...")
       end
       try
         tic()
         res = optimize(objfunc, randn(dim), method = alg, iterations = NumIterations)
         t = toq()
-        if ShowTrace
+        if TraceMode != :silent
           println("  Dims = ", dim)
           println("  Alg = ", alg)
           println("  time taken = ", t, " seconds")
@@ -60,7 +60,7 @@ function compare_algs(funcToOpt, dim;
 end
 
 # Short one so things are compiled
-compare_algs(rastrigin, 2; NumReps = 1, ShowTrace = false);
+compare_algs(rastrigin, 2; NumReps = 1, TraceMode = :silent);
 
 # They use a very uneven num of fevals though...
 BestAlgs = [:bfgs, :nelder_mead, :simulated_annealing]

--- a/src/BlackBoxOptim.jl
+++ b/src/BlackBoxOptim.jl
@@ -137,6 +137,11 @@ function name(o::Optimizer)
   end
 end
 
+# trace current optimization state,
+# Called by OptRunController trace_progress()
+function trace_state(io::IO, optimizer::Optimizer)
+end
+
 # Population
 include("population.jl")
 

--- a/src/BlackBoxOptim.jl
+++ b/src/BlackBoxOptim.jl
@@ -11,7 +11,7 @@ export  Optimizer, AskTellOptimizer, SteppingOptimizer, PopulationOptimizer,
         adaptive_de_rand_1_bin, adaptive_de_rand_1_bin_radiuslimited,
 
         SeparableNESOpt, separable_nes,
-        XNESOpt, xnes,
+        XNESOpt, xnes, dxnes,
 
         # Parameters
         DictChain, Parameters, ParamsDictChain, ParamsDict,
@@ -175,6 +175,7 @@ include("random_search.jl")
 include("differential_evolution.jl")
 include("adaptive_differential_evolution.jl")
 include("natural_evolution_strategies.jl")
+include("dx_nes.jl")
 include("resampling_memetic_search.jl")
 include("simultaneous_perturbation_stochastic_approximation.jl")
 include("generating_set_search.jl")

--- a/src/compare_optimizers.jl
+++ b/src/compare_optimizers.jl
@@ -12,7 +12,7 @@ function compare_optimizers(functionOrProblem, parameters::Associative = @compat
 
   sorted = sort( results, by = (t) -> t[3] )
 
-  if parameters[:ShowTrace]
+  if parameters[:TraceMode] != :silent
     println("\n********************************************************************************")
     #println(describe(evaluator))
     for(i in 1:length(sorted))

--- a/src/default_parameters.jl
+++ b/src/default_parameters.jl
@@ -16,7 +16,7 @@ const DefaultParameters = @compat Dict{Symbol,Any}(
 
   :NumRepetitions => 1,     # Number of repetitions to run for each optimizer for each problem
 
-  :ShowTrace      => true,  # Print tracing information during the optimization
+  :TraceMode      => :compact,  # Print tracing information during the optimization
   :TraceInterval  => 0.50,  # Minimum number of seconds between consecutive trace messages printed to STDOUT
   :SaveTrace      => false,
   :SaveFitnessTraceToCsv => false, # Save a csv file with information about the major fitness improvement events (only the first event in each fitness magnitude class is saved)

--- a/src/differential_evolution.jl
+++ b/src/differential_evolution.jl
@@ -27,6 +27,13 @@ function DiffEvoOpt{P<:Population, S<:IndividualsSelector,
   DiffEvoOpt{P,S,M,E}(name, pop, select, modify, embed)
 end
 
+# trace current optimization state,
+# Called by OptRunController trace_progress()
+function trace_state(io::IO, de::DiffEvoOpt)
+    println(io, "DE modify state:")
+    trace_state(io, de.modify)
+end
+
 # Ask for a new candidate object to be evaluated, and a list of individuals
 # it should be ranked with. The individuals are supplied as an array of tuples
 # with the individual and its index.

--- a/src/dx_nes.jl
+++ b/src/dx_nes.jl
@@ -1,0 +1,138 @@
+# DX-NES: distance-weighted extensions of xNES by Fukushima et al
+type DXNESOpt{F,E<:EmbeddingOperator} <: ExponentialNaturalEvolutionStrategyOpt
+  embed::E                        # operator embedding into the search space
+  lambda::Int                     # Number of samples to take per iteration
+  sortedUtilities::Vector{Float64}# Fitness utility to give to each rank
+  tmp_Utilities::Vector{Float64}   # Fitness utilities assigned to current population
+  x_learnrate::Float64
+  B_learnrate::Float64
+  sigma_learnrate::Float64
+  moving_threshold::Float64       # threshold of evolutionary path movement
+  evol_path::Vector{Float64}      # evolution path, discounted coordinates of population center
+  # TODO use Symmetric{Float64} to inmprove exponent etc calculation
+  ln_B::Array{Float64,2}          # exponential of lnB
+  sigma::Float64                  # step size
+  x::Individual                   # The current incumbent (aka most likely value, mu etc)
+  Z::Array{Float64,2}             # current N(0,I) samples
+  candidates::Vector{Candidate{F}}# The last sampled values, now being evaluated
+
+  # temporary variables to minimize GC overhead
+  tmp_x::Individual
+  tmp_dz::Individual
+  tmp_dx::Individual
+  tmp_lndB::Matrix{Float64}
+  tmp_Zu::Matrix{Float64}
+  tmp_sBZ::Matrix{Float64}
+
+  function DXNESOpt(embed::E; lambda::Int = 0,
+                   mu_learnrate::Float64 = 1.0,
+                   ini_x = nothing, ini_sigma::Float64 = 1.0)
+    iseven(lambda) || throw(ArgumentError("lambda needs to be even"))
+    d = numdims(search_space(embed))
+    if lambda == 0
+      lambda = 4 + 3*floor(Int, log(d))
+    end
+    if ini_x === nothing
+      ini_x = rand_individual(search_space(embed))
+    else
+      ini_x = copy(ini_x::Individual)
+    end
+
+    new(embed, lambda, fitness_shaping_utilities_log(lambda), @compat(Vector{Float64}(lambda)),
+      mu_learnrate, 0.0, 0.0,
+      mean(Chi(d)), zeros(d),
+      ini_xnes_B(search_space(embed)), ini_sigma, ini_x,
+      zeros(d, lambda),
+      Candidate{F}[Candidate{F}(Array(Float64, d), i) for i in 1:lambda],
+      # temporaries
+      zeros(d), zeros(d), zeros(d),
+      zeros(d, d),
+      zeros(d, lambda), zeros(d, lambda)
+    )
+  end
+end
+
+
+const DXNES_DefaultOptions = chain(NES_DefaultOptions, @compat Dict{Symbol,Any}(
+  :ini_sigma => 1.0      # Initial sigma (step size)
+))
+
+function dxnes(problem::OptimizationProblem, parameters)
+  params = chain(DXNES_DefaultOptions, parameters)
+  embed = RandomBound(search_space(problem))
+  DXNESOpt{fitness_type(problem), typeof(embed)}(embed; lambda = params[:lambda],
+                                                 ini_x = params[:ini_x],
+                                                 ini_sigma = params[:ini_sigma])
+end
+
+function ask(dxnes::DXNESOpt)
+  hlambda = dxnes.lambda÷2
+  for i in 1:hlambda
+    for j in 1:size(dxnes.Z, 1)
+      dxnes.Z[j, i] = randn()
+      dxnes.Z[j, i+hlambda] = -dxnes.Z[j, i]
+    end
+  end
+  update_candidates!(dxnes, dxnes.Z)
+end
+
+function tell!{F}(dxnes::DXNESOpt{F}, rankedCandidates::Vector{Candidate{F}})
+  u = assign_weights!(dxnes.tmp_Utilities, rankedCandidates, dxnes.sortedUtilities)
+  update_evol_path!(dxnes, u)
+  if is_moving(dxnes)
+    u = assign_distance_weights!(dxnes.tmp_Utilities, rankedCandidates, dxnes.Z)
+  end
+  update_learning_rates!(dxnes)
+  update_parameters!(dxnes, u)
+
+  return 0
+end
+
+is_moving(dxnes::DXNESOpt) = norm(dxnes.evol_path) > dxnes.moving_threshold
+
+function update_evol_path!(dxnes::DXNESOpt, u::Vector{Float64})
+  mu = sum(i -> (u[i]+1/dxnes.lambda)^2, 1:(length(u)÷2))
+  n = numdims(dxnes)
+  if mu > eps()
+    mu = 1/mu
+    c = (mu + 2.0)/(sqrt(n)*(n+mu+5.0))
+  else
+    c = 0.4/sqrt(n)
+    mu = 0.0
+  end
+  dxnes.evol_path *= (1-c)
+  dxnes.evol_path += sqrt(c*(2-c)*mu)*squeeze(wsum(dxnes.Z, u, 2), 2)
+  dxnes
+end
+
+function assign_distance_weights!{F}(weights::Vector{Float64}, rankedCandidates::Vector{Candidate{F}}, Z::Matrix{Float64})
+  @assert length(weights) == length(rankedCandidates) == size(Z, 2)
+  # the center is moving, adjust weights
+  lambda = size(Z, 2)
+  u0 = log(0.5*lambda+1)
+  for i in 1:lambda
+    cand_ix = rankedCandidates[i].index
+    weights[cand_ix] = max(u0-log(i), 0) * exp(norm(Z[:,cand_ix]))
+  end
+  wsum = sum(weights)
+  for i in 1:lambda
+    weights[i] = weights[i]/wsum - 1/lambda
+  end
+  return weights
+end
+
+function update_learning_rates!(dxnes::DXNESOpt)
+  n = numdims(dxnes)
+  if is_moving(dxnes)
+    dxnes.sigma_learnrate = 1.0
+    dxnes.B_learnrate = (dxnes.lambda + 2n)/(dxnes.lambda+2*n^2+100) *
+                        min(1, sqrt(dxnes.lambda/numdims(dxnes)))
+  else
+    dxnes.sigma_learnrate = 1.0 + dxnes.lambda/(dxnes.lambda+2*n)
+    if norm(dxnes.evol_path) > 0.1*dxnes.moving_threshold
+      dxnes.sigma_learnrate *= 0.5
+    end
+    dxnes.B_learnrate = dxnes.lambda/(dxnes.lambda+2*n^2+100)
+  end
+  dxnes
+end

--- a/src/dx_nes.jl
+++ b/src/dx_nes.jl
@@ -52,6 +52,18 @@ type DXNESOpt{F,E<:EmbeddingOperator} <: ExponentialNaturalEvolutionStrategyOpt
   end
 end
 
+# trace current optimization state,
+# Called by OptRunController trace_progress()
+function trace_state(io::IO, dxnes::DXNESOpt)
+    println(io,
+            "σ=", dxnes.sigma,
+            " η[x]=", dxnes.x_learnrate,
+            " η[σ]=", dxnes.sigma_learnrate,
+            " η[B]=", dxnes.B_learnrate,
+            " |tr(ln_B)|=", abs(trace(dxnes.ln_B)),
+            " |path|=", norm(dxnes.evol_path),
+            " (", is_moving(dxnes) ? "moving" : "stopped", ")")
+end
 
 const DXNES_DefaultOptions = chain(NES_DefaultOptions, @compat Dict{Symbol,Any}(
   :ini_sigma => 1.0      # Initial sigma (step size)

--- a/src/genetic_operators/genetic_operator.jl
+++ b/src/genetic_operators/genetic_operator.jl
@@ -32,6 +32,11 @@ const NO_GEN_OP = NoMutation()
 # default implementation does nothing
 function adjust!{F}(op::GeneticOperator, tag::Int, indi_index::Int, new_fitness::F, old_fitness::F, is_improved::Bool) end
 
+# trace the state of the operator, called by trace_progress()
+# of the OptRunController by some of the genetic optimizers
+# override if you need to trace the state of your genetic operator
+function trace_state(io::IO, op::GeneticOperator) end
+
 # a mixture of genetic operators,
 # use next() to choose the next operator from the mixture
 abstract GeneticOperatorsMixture <: GeneticOperator

--- a/src/genetic_operators/operators_mixture.jl
+++ b/src/genetic_operators/operators_mixture.jl
@@ -49,3 +49,11 @@ function adjust!{F}(opmix::FAGeneticOperatorsMixture, op_index::Int, candi_index
   # also adjust the actual operator
   adjust!(opmix.operators[op_index], 0, candi_index, new_fitness, old_fitness, is_improved)
 end
+
+function trace_state(io::IO, fa::FAGeneticOperatorsMixture)
+  println(io, "FrequencyAdapting mixture rates:")
+  for i in eachindex(fa.operators)
+    @printf(io, " %s=%.2f", typeof(fa.operators[i]), fa.fa.p[i])
+  end
+  println(io)
+end

--- a/src/natural_evolution_strategies.jl
+++ b/src/natural_evolution_strategies.jl
@@ -113,6 +113,12 @@ function assign_weights!{F}(weights::Vector{Float64}, rankedCandidates::Vector{C
   return weights
 end
 
+# trace current optimization state,
+# Called by OptRunController trace_progress()
+function trace_state(io::IO, snes::SeparableNESOpt)
+    println(io, "|σ|=", norm(snes.sigma))
+end
+
 # Abstract type for a family of NES methods that represent population as
 # x = μ + σ B⋅Z,
 # where B is an exponential of some symmetric matrix lnB, tr(lnB)==0.0
@@ -254,6 +260,13 @@ function tell!{F}(xnes::XNESOpt{F}, rankedCandidates::Vector{Candidate{F}})
 
   update_parameters!(xnes, u)
   return 0
+end
+
+# trace current optimization state,
+# Called by OptRunController trace_progress()
+function trace_state(io::IO, xnes::XNESOpt)
+    println(io, "sigma=", xnes.sigma,
+                " |trace(ln_B)|=", trace(xnes.ln_B))
 end
 
 # Calculate the fitness shaping utilities vector using the log method.

--- a/src/natural_evolution_strategies.jl
+++ b/src/natural_evolution_strategies.jl
@@ -165,7 +165,10 @@ function update_parameters!(exnes::ExponentialNaturalEvolutionStrategyOpt, u::Ve
 
   exnes.ln_B += ln_dB
 
-  exnes.sigma *= exp(0.5 * exnes.sigma_learnrate * dSigma)
+  new_sigma = exnes.sigma * exp(0.5 * exnes.sigma_learnrate * dSigma)
+  if isfinite(new_sigma) && new_sigma > 0
+    exnes.sigma = new_sigma
+  end
   exnes
 end
 

--- a/src/natural_evolution_strategies.jl
+++ b/src/natural_evolution_strategies.jl
@@ -73,6 +73,7 @@ function ask(snes::SeparableNESOpt)
 
   for i in eachindex(snes.candidates)
     candi = snes.candidates[i]
+    candi.index = i # reset ordering
     @inbounds for j in 1:length(candi.params)
       candi.params[j] = snes.mu[j] + snes.sigma[j] * snes.last_s[j, i]
     end
@@ -169,6 +170,7 @@ function ask(xnes::XNESOpt)
 
   for i in eachindex(xnes.candidates)
     candi = xnes.candidates[i]
+    candi.index = i # reset ordering
     @inbounds for j in 1:length(candi.params)
       candi.params[j] = xnes.x[j] + expAZ[j, i]
     end

--- a/src/opt_controller.jl
+++ b/src/opt_controller.jl
@@ -4,7 +4,8 @@ type OptRunController{O<:Optimizer, E<:Evaluator}
   optimizer::O   # optimization algorithm
   evaluator::E   # problem evaluator
 
-  show_trace::Bool # if controller should trace its execution (false makes tr() generate no output)
+  trace_mode::Symbol # controller state trace mode (:verbose, :compact, :silent)
+                     # :silent makes tr() generate no output, :verbose calls trace_state(optimizer) within trace_progress())
   save_trace::Bool # FIXME if traces should be saved to a file
   trace_interval::Float64 # periodicity of calling trace_progress()
 
@@ -35,7 +36,7 @@ end
 
 function OptRunController{O<:Optimizer, E<:Evaluator}(optimizer::O, evaluator::E, params)
   OptRunController{O,E}(optimizer, evaluator,
-        [params[key] for key in Symbol[:ShowTrace, :SaveTrace, :TraceInterval,
+        [params[key] for key in Symbol[:TraceMode, :SaveTrace, :TraceInterval,
                       :MaxSteps, :MaxFuncEvals, :MaxNumStepsWithoutFuncEvals, :MaxTime,
                       :MinDeltaFitnessTolerance, :FitnessTolerance]]...,
         0, 0, 0, 0, 0, 0, 0.0, 0.0, 0.0, "")
@@ -48,7 +49,7 @@ OptRunController(optimizer::Optimizer, problem::OptimizationProblem, params) = O
 
 # logging/tracing
 function tr(ctrl::OptRunController, msg::AbstractString, obj = nothing)
-  if ctrl.show_trace
+  if ctrl.trace_mode != :silent
     print(msg)
     if obj != nothing
       showcompact(obj)
@@ -244,7 +245,7 @@ function update_parameters!{O<:Optimizer, P<:OptimizationProblem}(oc::OptControl
   # Most parameters cannot be changed since the problem and optimizer has already
   # been setup.
   for k in keys(parameters)
-    if k ∉ [:MaxTime, :MaxSteps, :MaxFuncEvals, :ShowTrace]
+    if k ∉ [:MaxTime, :MaxSteps, :MaxFuncEvals, :TraceMode]
       throw(ArgumentError("It is currently not supported to change parameters that can affect the original opt problem or optimizer (here: $(k))"))
     end
   end

--- a/src/opt_controller.jl
+++ b/src/opt_controller.jl
@@ -4,8 +4,8 @@ type OptRunController{O<:Optimizer, E<:Evaluator}
   optimizer::O   # optimization algorithm
   evaluator::E   # problem evaluator
 
-  trace_mode::Symbol # controller state trace mode (:verbose, :compact, :silent)
-                     # :silent makes tr() generate no output, :verbose calls trace_state(optimizer) within trace_progress())
+  trace_mode::Symbol # controller state trace mode (:compact, :silent)
+                     # :silent makes tr() generate no output)
   save_trace::Bool # FIXME if traces should be saved to a file
   trace_interval::Float64 # periodicity of calling trace_progress()
 
@@ -126,6 +126,10 @@ function trace_progress(ctrl::OptRunController)
   end
 
   tr(ctrl, "\n")
+
+  if ctrl.trace_mode == :verbose
+    trace_state(STDOUT, ctrl.optimizer)
+  end
 end
 
 # The ask and tell interface is more general since you can mix and max

--- a/src/optimization_methods.jl
+++ b/src/optimization_methods.jl
@@ -9,6 +9,7 @@ const ValidMethods = @compat Dict{Symbol,Union(Any,Function)}(
   :adaptive_de_rand_1_bin_radiuslimited => adaptive_de_rand_1_bin_radiuslimited,
   :separable_nes => separable_nes,
   :xnes => xnes,
+  :dxnes => dxnes,
   :resampling_memetic_search => resampling_memetic_searcher,
   :resampling_inheritance_memetic_search => resampling_inheritance_memetic_searcher,
   :simultaneous_perturbation_stochastic_approximation => SimultaneousPerturbationSA2,

--- a/test/test_bboptimize.jl
+++ b/test/test_bboptimize.jl
@@ -8,40 +8,40 @@ end
 
 facts("bboptimize") do
   context("example 1 from README") do
-    res = bboptimize(rosenbrock2d; SearchRange = (-5.0, 5.0), NumDimensions = 2, ShowTrace = false)
+    res = bboptimize(rosenbrock2d; SearchRange = (-5.0, 5.0), NumDimensions = 2, TraceMode = :silent)
     @fact best_fitness(res) < 0.001 => true
   end
 
   context("example 2 from README") do
-    res = bboptimize(rosenbrock2d; SearchRange = [(-5.0, 5.0), (-2.0, 2.0)], ShowTrace = false)
+    res = bboptimize(rosenbrock2d; SearchRange = [(-5.0, 5.0), (-2.0, 2.0)], TraceMode = :silent)
     @fact best_fitness(res) < 0.001 => true
   end
 
   context("example 3 from README") do
-    res = bboptimize(rosenbrock2d; SearchRange = (-5.0, 5.0), NumDimensions = 2, method = :de_rand_1_bin, ShowTrace = false)
+    res = bboptimize(rosenbrock2d; SearchRange = (-5.0, 5.0), NumDimensions = 2, method = :de_rand_1_bin, TraceMode = :silent)
     @fact best_fitness(res) < 0.001 => true
   end
 
   context("example 4 from README") do
     res = bboptimize(rosenbrock2d; SearchRange = (-5.0, 5.0), NumDimensions = 2,
-      Method = :random_search, MaxTime = 10.0, ShowTrace = false)
+      Method = :random_search, MaxTime = 10.0, TraceMode = :silent)
     @fact best_fitness(res) < 0.2 => true
   end
 
   context("example 5 from README") do
     BlackBoxOptim.compare_optimizers(rosenbrock; SearchRange = (-5.0, 5.0), NumDimensions = 3,
-      MaxTime = 2.0, ShowTrace = true)
+      MaxTime = 2.0, TraceMode = :compact)
   end
 
   context("run one longer example in case there is problem with the reporting in long runs") do
     res = bboptimize(rosenbrock2d; SearchRange = (-5.0, 5.0), NumDimensions = 2,
-      Method = :de_rand_1_bin, ShowTrace = false, MaxSteps = 25001)
+      Method = :de_rand_1_bin, TraceMode = :silent, MaxSteps = 25001)
     @fact best_fitness(res) < 0.001 => true
   end
 
   context("Fixed-dimensional problem takes precedence over search range and related params") do
     prob = BlackBoxOptim.minimization_problem((x) -> sum(x), "no name", (10.0, 20.0), 3)
-    res = bboptimize(prob; SearchRange = (0.0, 2.0), NumDimensions = 2, ShowTrace = false)
+    res = bboptimize(prob; SearchRange = (0.0, 2.0), NumDimensions = 2, TraceMode = :silent)
     xbest = best_candidate(res)
     @fact length(xbest) => 3
     @fact xbest[1] >= 10.0 => true
@@ -60,7 +60,7 @@ facts("bboptimize") do
 #  context("restarting an optimizer again and again should gradually improve") do
 #    optimizer, problem, params = BlackBoxOptim.setup_bboptimize(rosenbrock2d,
 #      {:SearchRange => (-5.0, 5.0), :NumDimensions => 2,
-#        :MaxSteps => 10, :ShowTrace => false})
+#        :MaxSteps => 10, :TraceMode => :silent})
 #    best10, fitness10, termination_reason10, elapsed_time10, params, num_evals10 = #BlackBoxOptim.run_optimizer(optimizer, problem, params);
 #    best20, fitness20, termination_reason20, elapsed_time20, params, num_evals20 = #BlackBoxOptim.run_optimizer(optimizer, problem, params);
 #    params[:MaxSteps] = 980

--- a/test/test_natural_evolution_strategies.jl
+++ b/test/test_natural_evolution_strategies.jl
@@ -2,20 +2,20 @@ using FactCheck
 
 facts("sNES") do
 
-function assign_weights_wrapper{F}(fitnesses::Vector{F})
-  candidates = BlackBoxOptim.Candidate{F}[BlackBoxOptim.Candidate{F}([0.0], -1, f) for f in fitnesses]
-  u = BlackBoxOptim.fitness_shaping_utilities_linear(length(candidates))
-  BlackBoxOptim.assign_weights(candidates, u)
+function assign_weights_wrapper(candi_ixs::Vector{Int})
+  candidates = BlackBoxOptim.Candidate{Float64}[BlackBoxOptim.Candidate{Float64}([0.0], i, NaN) for i in candi_ixs]
+  u = BlackBoxOptim.fitness_shaping_utilities_linear(length(candi_ixs))
+  BlackBoxOptim.assign_weights!(similar(u), candidates, u)
 end
 
 context("assign_weights") do
   context("when indices are already ordered") do
-    u = assign_weights_wrapper([1.0, 2.0])
+    u = assign_weights_wrapper([1, 2])
     @fact length(u) => 2
     @fact u[1] => 1.0
     @fact u[2] => 0.0
 
-    u = assign_weights_wrapper([1.0, 2.0, 3.0])
+    u = assign_weights_wrapper([1, 2, 3])
     @fact length(u) => 3
     @fact u[1] => 1.0
     @fact u[2] => 0.0

--- a/test/test_natural_evolution_strategies.jl
+++ b/test/test_natural_evolution_strategies.jl
@@ -8,50 +8,56 @@ function assign_weights_wrapper(candi_ixs::Vector{Int})
   BlackBoxOptim.assign_weights!(similar(u), candidates, u)
 end
 
-context("assign_weights") do
+context("assign_weights!()") do
   context("when indices are already ordered") do
     u = assign_weights_wrapper([1, 2])
     @fact length(u) => 2
-    @fact u[1] => 1.0
-    @fact u[2] => 0.0
+    @fact sum(u) => roughly(0.0, atol=1E-10)
+    @fact u[1] => 0.5
+    @fact u[2] => -0.5
 
     u = assign_weights_wrapper([1, 2, 3])
     @fact length(u) => 3
-    @fact u[1] => 1.0
-    @fact u[2] => 0.0
-    @fact u[3] => 0.0
+    @fact sum(u) => roughly(0.0, atol=1E-10)
+    @fact u[1] => 1.0 - 1/3
+    @fact u[2] => -1/3
+    @fact u[3] => -1/3
 
     u = assign_weights_wrapper([1, 2, 3, 4])
     @fact length(u) => 4
-    @fact u[1] => roughly(2/3)
-    @fact u[2] => roughly(1/3)
-    @fact u[3] => 0.0
-    @fact u[4] => 0.0
+    @fact sum(u) => roughly(0.0, atol=1E-10)
+    @fact u[1] => roughly(2/3-1/4)
+    @fact u[2] => roughly(1/3-1/4)
+    @fact u[3] => -1/4
+    @fact u[4] => -1/4
 
     u = assign_weights_wrapper([1, 2, 3, 4, 5])
     @fact length(u) => 5
-    @fact u[1] => roughly(2/3)
-    @fact u[2] => roughly(1/3)
-    @fact u[3] => 0.0
-    @fact u[4] => 0.0
-    @fact u[5] => 0.0
+    @fact sum(u) => roughly(0.0, atol=1E-10)
+    @fact u[1] => roughly(2/3-1/5)
+    @fact u[2] => roughly(1/3-1/5)
+    @fact u[3] => -1/5
+    @fact u[4] => -1/5
+    @fact u[5] => -1/5
 
     u = assign_weights_wrapper([1, 2, 3, 4, 5, 6])
     @fact length(u) => 6
-    @fact u[1] => roughly((3/3)/(3/3+2/3+1/3))
-    @fact u[2] => roughly((2/3)/(3/3+2/3+1/3))
-    @fact u[3] => roughly((1/3)/(3/3+2/3+1/3))
-    @fact u[4] => 0.0
-    @fact u[5] => 0.0
-    @fact u[6] => 0.0
+    @fact sum(u) => roughly(0.0, atol=1E-10)
+    @fact u[1] => roughly((3/3)/(3/3+2/3+1/3)-1/6)
+    @fact u[2] => roughly((2/3)/(3/3+2/3+1/3)-1/6)
+    @fact u[3] => roughly((1/3)/(3/3+2/3+1/3)-1/6)
+    @fact u[4] => -1/6
+    @fact u[5] => -1/6
+    @fact u[6] => -1/6
   end
 
   context("when indices are not ordered") do
     u = assign_weights_wrapper([4, 1, 2, 3])
-    @fact u[4] => roughly(2/3)
-    @fact u[1] => roughly(1/3)
-    @fact u[2] => 0.0
-    @fact u[3] => 0.0
+    @fact sum(u) => roughly(0.0, atol=1E-10)
+    @fact u[4] => roughly(2/3-1/4)
+    @fact u[1] => roughly(1/3-1/4)
+    @fact u[2] => -1/4
+    @fact u[3] => -1/4
   end
 end
 

--- a/test/test_smoketest_bboptimize.jl
+++ b/test/test_smoketest_bboptimize.jl
@@ -6,7 +6,7 @@ facts("bboptimize smoketest") do
   for(m in keys(BlackBoxOptim.ValidMethods))
     context("testing $(m) method to ensure it works") do
       ctrl = bbsetup(rosenbrock2d; Method = m,
-        SearchRange = [(-5.0, 5.0), (-2.0, 2.0)], ShowTrace = false)
+        SearchRange = [(-5.0, 5.0), (-2.0, 2.0)], TraceMode = :silent)
       # run first iteration before the main run to exclude compilation from timing
       bboptimize(ctrl, MaxSteps = 1)
       res = bboptimize(ctrl, MaxTime = 0.3)

--- a/test/test_toplevel_bboptimize.jl
+++ b/test/test_toplevel_bboptimize.jl
@@ -6,7 +6,7 @@ facts("Top-level interface") do
   context("run a simple optimization") do
     context("using bboptimize() with mostly defaults") do
       res = bboptimize(rosenbrock; SearchRange = (-5.0, 5.0), NumDimensions = 2,
-        MaxSteps = 2000, ShowTrace = false)
+        MaxSteps = 2000, TraceMode = :silent)
       @fact best_fitness(res) => less_than(0.1)
       xbest = best_candidate(res)
       @fact typeof(xbest) => Vector{Float64}
@@ -20,7 +20,7 @@ facts("Top-level interface") do
 
     context("using bbsetup()/bboptimize() with mostly defaults") do
       opt = bbsetup(rosenbrock; SearchRange = (-5.0, 5.0), NumDimensions = 2,
-        MaxSteps = 2000, ShowTrace = false)
+        MaxSteps = 2000, TraceMode = :silent)
       @fact numruns(opt) --> 0
       @fact isa(problem(opt), BlackBoxOptim.FunctionBasedProblem) --> true
       res = bboptimize(opt)
@@ -34,7 +34,7 @@ facts("Top-level interface") do
     context("using non-population optimizer") do
       res = bboptimize(rosenbrock; Method=:generating_set_search,
                        SearchRange = (-5.0, 5.0), NumDimensions = 2,
-                       MaxSteps = 2000, ShowTrace = false)
+                       MaxSteps = 2000, TraceMode = :silent)
       @fact isa(res, BlackBoxOptim.SimpleOptimizationResults) --> true
       @fact best_fitness(res) => less_than(1.0)
       xbest = best_candidate(res)
@@ -44,7 +44,7 @@ facts("Top-level interface") do
     context("using population optimizer") do
       res = bboptimize(rosenbrock; Method=:adaptive_de_rand_1_bin,
                        SearchRange = (-5.0, 5.0), NumDimensions = 2,
-                       MaxSteps = 2000, ShowTrace = false)
+                       MaxSteps = 2000, TraceMode = :silent)
       @fact isa(res, BlackBoxOptim.PopulationOptimizationResults) --> true
       @fact best_fitness(res) => less_than(0.1)
       xbest = best_candidate(res)
@@ -58,7 +58,7 @@ facts("Top-level interface") do
 
   context("continue running an optimization after it finished") do
     optctrl = bbsetup(rosenbrock; SearchRange = (-5.0, 5.0), NumDimensions = 100,
-      MaxTime = 0.5, ShowTrace = false)
+      MaxTime = 0.5, TraceMode = :silent)
 
     res1 = bboptimize(optctrl)
     @fact numruns(optctrl) => 1
@@ -80,7 +80,7 @@ facts("Top-level interface") do
 
   context("continue running an optimization after serializing to disc") do
     optctrl = bbsetup(rosenbrock; SearchRange = (-5.0, 5.0), NumDimensions = 100,
-      MaxTime = 0.5, ShowTrace = false)
+      MaxTime = 0.5, TraceMode = :silent)
     res1 = bboptimize(optctrl)
 
     local tempfilename = "./temp" * string(rand(1:10^8)) * ".tmp"


### PR DESCRIPTION
This should hopefully fix #26.

There were two overlayed bugs related to `assign_weights()`:
  * instead of `u[sortperm(...)]` it should have done `u[invperm(sortperm(...))]` as utility weights are applied not to the ranked candidates, but to the original random samples 
  * `assign_weights()` received candidates already sorted by fitness, so `sortperm()` was useless

Unfortunately, besides generic convergence test, there's no test that would detect such bug. Probably, there should be a test checking the properties of a natural gradient at each step or something like that.