### PR TITLE
add ParallelEvaluator

### DIFF
--- a/src/BlackBoxOptim.jl
+++ b/src/BlackBoxOptim.jl
@@ -4,6 +4,12 @@ module BlackBoxOptim
 
 using Distributions, StatsBase, Compat
 
+# selectively enable parallel evaluation:
+# - Julia v0.3: no RemoteChannel
+# + Julia v0.4
+# - Julia v0.5: incompatible changes in parallel API
+enable_parallel_methods = VERSION >= v"0.4.0" && VERSION < v"0.5.0-"
+
 export  Optimizer, AskTellOptimizer, SteppingOptimizer, PopulationOptimizer,
         bboptimize, bbsetup, compare_optimizers,
 
@@ -110,7 +116,9 @@ include(joinpath("problems", "all_problems.jl"))
 include(joinpath("problems", "problem_family.jl"))
 
 include("evaluator.jl")
+if enable_parallel_methods
 include("parallel_evaluator.jl")
+end
 
 function setup!(o::SteppingOptimizer)
   # Do nothing, override if you need to setup prior to the optimization loop

--- a/src/BlackBoxOptim.jl
+++ b/src/BlackBoxOptim.jl
@@ -110,6 +110,7 @@ include(joinpath("problems", "all_problems.jl"))
 include(joinpath("problems", "problem_family.jl"))
 
 include("evaluator.jl")
+include("parallel_evaluator.jl")
 
 function setup!(o::SteppingOptimizer)
   # Do nothing, override if you need to setup prior to the optimization loop

--- a/src/evaluator.jl
+++ b/src/evaluator.jl
@@ -88,7 +88,7 @@ function Base.copy!{F}(c::Candidate{F}, o::Candidate{F})
   return c
 end
 
-function rank_by_fitness!{F,P<:OptimizationProblem}(e::Evaluator{P}, candidates::Vector{Candidate{F}})
+function update_fitness!{F}(e::ProblemEvaluator{F}, candidates::Vector{Candidate{F}})
   fs = fitness_scheme(e)
   for i in eachindex(candidates)
       # evaluate fitness if not known yet
@@ -96,8 +96,13 @@ function rank_by_fitness!{F,P<:OptimizationProblem}(e::Evaluator{P}, candidates:
           candidates[i].fitness = fitness(candidates[i].params, e)
       end
   end
+  candidates
+end
 
-  sort!(candidates; by = fitness, lt = (x, y) -> is_better(x, y, fs))
+function rank_by_fitness!{F,P<:OptimizationProblem}(e::Evaluator{P}, candidates::Vector{Candidate{F}})
+  fs = fitness_scheme(e)
+  sort!(update_fitness!(e, candidates);
+        by = fitness, lt = (x, y) -> is_better(x, y, fs))
 end
 
 fitness_is_within_ftol(e::Evaluator, atol) = fitness_is_within_ftol(problem(e), best_fitness(e.archive), atol)

--- a/src/evaluator.jl
+++ b/src/evaluator.jl
@@ -75,6 +75,7 @@ type Candidate{F}
 end
 
 fitness(cand::Candidate) = cand.fitness
+index(cand::Candidate) = cand.index
 
 Base.copy{F}(c::Candidate{F}) = Candidate{F}(copy(c.params), c.index, c.fitness, c.op, c.tag)
 

--- a/src/opt_controller.jl
+++ b/src/opt_controller.jl
@@ -42,10 +42,19 @@ function OptRunController{O<:Optimizer, E<:Evaluator}(optimizer::O, evaluator::E
         0, 0, 0, 0, 0, 0, 0.0, 0.0, 0.0, "")
 end
 
+function make_evaluator(problem::OptimizationProblem, params)
+  workers = get(params, :Workers, Vector{Int}())
+  if length(workers) > 0
+    return ParallelEvaluator(problem, workers)
+  else
+    return ProblemEvaluator(problem)
+  end
+end
+
 # stepping optimizer has it's own evaluator, get a reference
 OptRunController(optimizer::SteppingOptimizer, problem::OptimizationProblem, params) = OptRunController(optimizer, evaluator(optimizer), params)
 # all other optimizers are using ProblemEvaluator by default
-OptRunController(optimizer::Optimizer, problem::OptimizationProblem, params) = OptRunController(optimizer, ProblemEvaluator(problem), params)
+OptRunController(optimizer::Optimizer, problem::OptimizationProblem, params) = OptRunController(optimizer, make_evaluator(problem, params), params)
 
 # logging/tracing
 function tr(ctrl::OptRunController, msg::AbstractString, obj = nothing)

--- a/src/opt_controller.jl
+++ b/src/opt_controller.jl
@@ -45,7 +45,11 @@ end
 function make_evaluator(problem::OptimizationProblem, params)
   workers = get(params, :Workers, Vector{Int}())
   if length(workers) > 0
-    return ParallelEvaluator(problem, workers)
+    if BlackBoxOptim.enable_parallel_methods
+      return ParallelEvaluator(problem, workers)
+    else
+      throw(SystemError("Parallel evaluation disabled"))
+    end
   else
     return ProblemEvaluator(problem)
   end

--- a/src/parallel_evaluator.jl
+++ b/src/parallel_evaluator.jl
@@ -1,0 +1,160 @@
+# Internal data for the worker process of the parallel evaluator
+immutable ParallelEvaluatorWorker{P<:OptimizationProblem}
+  problem::P
+
+  Base.call{P}(::Type{ParallelEvaluatorWorker}, problem::P) = new{P}(problem)
+end
+
+fitness(params::Individual, worker::ParallelEvaluatorWorker) =
+  fitness(params, worker.problem)
+
+typealias ParallelEvaluatorWorkerRef{P} RemoteRef{Channel{ParallelEvaluatorWorker{P}}}
+
+fitness{P}(params::Individual, worker_ref::ParallelEvaluatorWorkerRef{P}) =
+  fitness(params, fetch(fetch(worker_ref))::ParallelEvaluatorWorker{P})
+
+# Current state of fitness evaluation
+# for the vector of candidates
+type ParallelEvaluationState{F, FS}
+  fitness_scheme::FS
+  candidates::Vector{Candidate{F}}  # candidates to calculate fitness for
+
+  worker_busy::Vector{Bool}         # if the worker is busy calculating
+  retry_queue::Vector{Int}          # queue to candidate indices to retry
+
+  worker_finished::Condition        # gets notified each time worker is done
+                                    # fitness calculation
+  next_index::Int                   # index of the next candidate to calculate fitness
+
+  function Base.call{FS<:FitnessScheme}(::Type{ParallelEvaluationState}, fitness_scheme::FS, nworkers::Int)
+    F = fitness_type(fitness_scheme)
+    new{F,FS}(fitness_scheme, Vector{Candidate{F}}(),
+              fill(false, nworkers), Vector{Int}(), Condition(), 0)
+  end
+end
+
+is_stopped(estate::ParallelEvaluationState) = estate.next_index == 0
+
+abort!(estate::ParallelEvaluationState) = (estate.next_index = 0)
+
+# reset evaluation state for the new vector of candidates
+function reset!{F}(estate::ParallelEvaluationState{F}, candidates::Vector{Candidate{F}})
+  estate.candidates = candidates
+  fill!(estate.worker_busy, false)
+  empty!(estate.retry_queue)
+  estate.next_index = 1
+  return estate
+end
+
+# get index of the next candidate for evaluation
+# based on the Base.pmap() code
+function next_candidate!(estate::ParallelEvaluationState, worker_ix::Int)
+    @assert !estate.worker_busy[worker_ix]
+
+    task_ix = 0
+    if !is_stopped(estate) && estate.next_index <= length(estate.candidates)
+        # find the next candidate with unevaluated fitness
+        while !is_stopped(estate) && estate.next_index <= length(estate.candidates)
+          if isnafitness(estate.candidates[estate.next_index].fitness, estate.fitness_scheme)
+            task_ix = estate.next_index
+            estate.next_index += 1
+            break;
+          else
+            estate.next_index += 1
+          end
+        end
+    end
+    if task_ix == 0
+      if !isempty(estate.retry_queue)
+        task_ix = shift!(estate.retry_queue)
+      else
+        # Handles the condition where we have finished processing the requested
+        # lsts as well as any retryqueue entries, but there are still some jobs
+        # active that may result in an error and have to be retried.
+        while any(estate.worker_busy)
+            wait(estate.worker_finished)
+            if !isempty(estate.retry_queue)
+                task_ix = shift!(estate.retry_queue)
+                break
+            end
+        end
+      end
+    end
+    estate.worker_busy[worker_ix] = task_ix != 0
+    return task_ix
+end
+
+# notify that the worker is finished and reset busy flag
+function worker_finished!(estate::ParallelEvaluationState, worker_ix::Int)
+  @assert estate.worker_busy[worker_ix]
+  estate.worker_busy[worker_ix] = false
+  notify(estate.worker_finished; all=true)
+  return estate
+end
+
+# Fitness evaluator that
+# distributes candidates fitness calculation
+# among worker processes
+type ParallelEvaluator{F, FS, P<:OptimizationProblem} <: Evaluator{P}
+  problem::P
+  archive::Archive
+  num_evals::Int
+  last_fitness::F
+
+  worker_refs::Vector{ParallelEvaluatorWorkerRef{P}}
+  eval_state::ParallelEvaluationState{F, FS}
+end
+
+function ParallelEvaluator{P<:OptimizationProblem}(
+        problem::P, pids::Vector{Int} = workers();
+        archiveCapacity::Int = 10)
+    fs = fitness_scheme(problem)
+    ParallelEvaluator{fitness_type(fs), typeof(fs), P}(problem,
+        TopListArchive(fs, numdims(problem), archiveCapacity),
+        0, nafitness(fs),
+        [RemoteRef(function ()
+                     # create fake channel and put problem there
+                     ch = Channel{ParallelEvaluatorWorker{P}}(1)
+                     put!(ch, ParallelEvaluatorWorker(copy(problem)))
+                     ch
+                   end, pid) for pid in pids],
+        ParallelEvaluationState(fs, length(pids))
+    )
+end
+
+num_evals(e::ParallelEvaluator) = e.num_evals
+
+function update_fitness!{F}(e::ParallelEvaluator{F}, candidates::Vector{Candidate{F}})
+    reset!(e.eval_state, candidates)
+
+    # based on pmap() code
+    @sync begin
+        for (widx, wref) in enumerate(e.worker_refs)
+            @async begin
+                while (candi_ix = next_candidate!(e.eval_state, widx)) != 0
+                    try
+                        candi = candidates[candi_ix]
+                        candi.fitness = remotecall_fetch(wref.where, fitness, candi.params, wref)
+                        e.last_fitness = candi.fitness
+                        e.num_evals += 1
+                        add_candidate!(e.archive, candi.fitness, candi.params, e.num_evals)
+                    catch ex
+                        abort!(e.eval_state) # when one worker fails, the whole process is aborted
+                        rethrow(ex)
+                    finally
+                        worker_finished!(e.eval_state, widx)
+                    end
+                end
+            end
+        end
+    end
+
+    candidates
+end
+
+# it's not efficient to calculate fitness like that with ParallelEvaluator
+function fitness{F}(params::Individual, e::ParallelEvaluator{F})
+  candi = Candidate{F}(params)
+  update_fitness!(e, [candi])
+  candi.fitness
+end

--- a/src/problems/all_problems.jl
+++ b/src/problems/all_problems.jl
@@ -34,6 +34,9 @@ type UnboundedProblem{FS<:FitnessScheme, SS<:SearchSpace} <: FunctionBasedProble
   end
 end
 
+Base.copy{FS,SS}(p::UnboundedProblem{FS,SS}) =
+  UnboundedProblem{FS,SS}(p.objfunc, copy(p.name), p.fitness_scheme, p.ss)
+
 # problem with known global optimum,
 # a wrapper around Julia objective function
 type BoundedProblem{F, FS<:FitnessScheme, SS<:SearchSpace} <: FunctionBasedProblem{FS}
@@ -50,6 +53,9 @@ type BoundedProblem{F, FS<:FitnessScheme, SS<:SearchSpace} <: FunctionBasedProbl
     new(objfunc, name, fitness_scheme, ss, opt_value)
   end
 end
+
+Base.copy{F,FS,SS}(p::BoundedProblem{F,FS,SS}) =
+  BoundedProblem{F,FS,SS}(p.objfunc, copy(p.name), p.fitness_scheme, p.ss, p.opt_value)
 
 opt_value(p::BoundedProblem) = p.opt_value
 fitness_is_within_ftol(p::BoundedProblem, fitness, atol::Number) = norm(opt_value(p) - fitness) < atol

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,6 +7,7 @@ my_tests = [
 
   "test_parameters.jl",
   "test_fitness.jl",
+  "test_evaluator.jl",
   "test_population.jl",
   "test_bimodal_cauchy_distribution.jl",
   "test_search_space.jl",

--- a/test/test_evaluator.jl
+++ b/test/test_evaluator.jl
@@ -2,38 +2,57 @@ facts("Evaluator") do
 
   # Set up a small example problem
   f(x) = sum(x.^2)
-  P = BlackBoxOptim.fixeddim_problem(f; dims = 2)
+  p = minimization_problem(f, "", (-1.0, 1.0), 2)
 
   context("Basic evaluation with a single-objective function to be minimized") do
-
-    e = ProblemEvaluator(P)
-
+    e = BlackBoxOptim.ProblemEvaluator(p)
     @fact BlackBoxOptim.num_evals(e) --> 0
 
-    f = BlackBoxOptim.evaluate(e, [0.0, 1.0])
+    fit1 = fitness([0.0, 1.0], e)
     @fact BlackBoxOptim.num_evals(e) --> 1
-    @fact BlackBoxOptim.last_fitness(e) --> f
+    @fact BlackBoxOptim.last_fitness(e) --> fit1
 
-    f2 = BlackBoxOptim.evaluate(e, [2.0, 1.0])
+    fit2 = fitness([2.0, 1.0], e)
     @fact BlackBoxOptim.num_evals(e) --> 2
-    @fact BlackBoxOptim.last_fitness(e) --> f2
+    @fact BlackBoxOptim.last_fitness(e) --> fit2
 
     @fact BlackBoxOptim.numdims(e) --> 2
 
-    @fact BlackBoxOptim.is_better(e, 0.0, 1.0) --> true
-    @fact BlackBoxOptim.is_better(e, 0.0, -1.0) --> false
+    @fact BlackBoxOptim.is_better(0.0, 1.0, e) --> true
+    @fact BlackBoxOptim.is_better(0.0, -1.0, e) --> false
 
-    a, b = [0, 0.5], [1, 1]
+    a, b = [0.0, 0.5], [1.0, 1.0]
 
-    @fact BlackBoxOptim.is_better(e, a, 1.0) --> true
+    @fact BlackBoxOptim.is_better(a, 1.0, e) --> true
     @fact BlackBoxOptim.last_fitness(e) --> 0.25
 
-    @fact BlackBoxOptim.is_better(e, b, 1.0) --> false
+    @fact BlackBoxOptim.is_better(b, 1.0, e) --> false
     @fact BlackBoxOptim.last_fitness(e) --> 2.0
 
-    @fact BlackBoxOptim.best_of(e, a, b) --> (a, 0.25)
-    @fact BlackBoxOptim.best_of(e, b, a) --> (a, 0.25)
+    @fact BlackBoxOptim.best_of(a, b, e) --> (a, 0.25)
+    @fact BlackBoxOptim.best_of(b, a, e) --> (a, 0.25)
 
   end
 
+  context("update_fitness!()") do
+    e = BlackBoxOptim.ProblemEvaluator(p)
+
+    candidates = BlackBoxOptim.Candidate{Float64}[BlackBoxOptim.Candidate{Float64}(clamp(randn(2), -1.0, 1.0)) for i in 1:10]
+    BlackBoxOptim.update_fitness!(e, candidates)
+    @fact BlackBoxOptim.num_evals(e) --> length(candidates)
+    @fact all(c -> isfinite(c.fitness), candidates) --> true
+  end
+
+  context("rank_by_fitness!()") do
+    e = BlackBoxOptim.ProblemEvaluator(p)
+
+    candidates = BlackBoxOptim.Candidate{Float64}[BlackBoxOptim.Candidate{Float64}(clamp(randn(2), -1.0, 1.0)) for i in 1:10]
+    # partially evaluate fitness
+    BlackBoxOptim.update_fitness!(e, candidates[1:5])
+    @fact BlackBoxOptim.num_evals(e) --> 5
+    # complete fitness evaluation and sort by it
+    BlackBoxOptim.rank_by_fitness!(e, candidates)
+    @fact BlackBoxOptim.num_evals(e) --> 10
+    @fact sortperm(candidates, by = fitness) --> collect(1:10)
+  end
 end

--- a/test/test_evaluator.jl
+++ b/test/test_evaluator.jl
@@ -59,7 +59,11 @@ facts("Evaluator") do
   context("ProblemEvaluator") do
     evaluator_tests(() -> BlackBoxOptim.ProblemEvaluator(p))
   end
+
+if BlackBoxOptim.enable_parallel_methods
   context("ParallelEvaluator") do
     evaluator_tests(() -> BlackBoxOptim.ParallelEvaluator(p, workers()))
   end
+end
+
 end

--- a/test/test_toplevel_bboptimize.jl
+++ b/test/test_toplevel_bboptimize.jl
@@ -55,6 +55,7 @@ facts("Top-level interface") do
       @fact numdims(xpop) --> 2
     end
 
+if BlackBoxOptim.enable_parallel_methods
     context("using population optimizer and parallel evaluator") do
       opt = bbsetup(rosenbrock; Method=:adaptive_de_rand_1_bin,
                     SearchRange = (-5.0, 5.0), NumDimensions = 2,
@@ -62,6 +63,8 @@ facts("Top-level interface") do
       res = bboptimize(opt)
       @fact isa(BlackBoxOptim.evaluator(lastrun(opt)), BlackBoxOptim.ParallelEvaluator) --> true
     end
+end
+
   end
 
   context("continue running an optimization after it finished") do

--- a/test/test_toplevel_bboptimize.jl
+++ b/test/test_toplevel_bboptimize.jl
@@ -54,6 +54,14 @@ facts("Top-level interface") do
       @fact popsize(xpop) --> greater_than(0)
       @fact numdims(xpop) --> 2
     end
+
+    context("using population optimizer and parallel evaluator") do
+      opt = bbsetup(rosenbrock; Method=:adaptive_de_rand_1_bin,
+                    SearchRange = (-5.0, 5.0), NumDimensions = 2,
+                    MaxSteps = 2000, TraceMode = :silent, Workers=workers())
+      res = bboptimize(opt)
+      @fact isa(BlackBoxOptim.evaluator(lastrun(opt)), BlackBoxOptim.ParallelEvaluator) --> true
+    end
   end
 
   context("continue running an optimization after it finished") do


### PR DESCRIPTION
Implements `ParallelEvaluator <: Evaluator` that distributes the calculation of candidates' fitnesses across the worker processes. Should be beneficial for NES family of optimizers that regenerate the population at each step.

It does require channels from Julia 0.4, but unlike `ParallelOptimizer` from #25 communication between the processes is much more straighforward (it's very similar to `pmap()`, except that the `problem` object needs to be sent to the workers only once at `ParallelEvaluator` creation).

To use it, simply add `Workers=` parameter to `bbsetup/bboptimize(problem)` call. E.g.
```julia
addprocs(2)
bbsetup(problem, Workers=workers())
```