### PR TITLE
DX-NES fixes

### DIFF
--- a/src/dx_nes.jl
+++ b/src/dx_nes.jl
@@ -116,6 +116,7 @@ function calculate_evol_path_params(n::Int64, u::Vector{Float64})
   lambda = length(u)
   mu = 1/sum(i -> (u[i]+1/lambda)^2, 1:(lambda÷2))
   c = (mu + 2.0)/(sqrt(n)*(n+mu+5.0))
+  #info("DX-NES params: μ=", mu, " c=", c, " discount=", 1-c, " Zscale=", sqrt(c*(2-c)*mu))
   return (1-c), sqrt(c*(2-c)*mu)
 end
 

--- a/src/dx_nes.jl
+++ b/src/dx_nes.jl
@@ -7,6 +7,7 @@ type DXNESOpt{F,E<:EmbeddingOperator} <: ExponentialNaturalEvolutionStrategyOpt
   x_learnrate::Float64
   B_learnrate::Float64
   sigma_learnrate::Float64
+  max_sigma::Float64
   moving_threshold::Float64       # threshold of evolutionary path movement
   evol_discount::Float64
   evol_Zscale::Float64
@@ -28,7 +29,8 @@ type DXNESOpt{F,E<:EmbeddingOperator} <: ExponentialNaturalEvolutionStrategyOpt
 
   function DXNESOpt(embed::E; lambda::Int = 0,
                    mu_learnrate::Float64 = 1.0,
-                   ini_x = nothing, ini_sigma::Float64 = 1.0)
+                   ini_x = nothing, ini_sigma::Float64 = 1.0,
+                   max_sigma::Float64 = 1.0E+10)
     iseven(lambda) || throw(ArgumentError("lambda needs to be even"))
     d = numdims(search_space(embed))
     if lambda == 0
@@ -43,7 +45,7 @@ type DXNESOpt{F,E<:EmbeddingOperator} <: ExponentialNaturalEvolutionStrategyOpt
     evol_discount, evol_Zscale = calculate_evol_path_params(d, u)
 
     new(embed, lambda, u, @compat(Vector{Float64}(lambda)),
-      mu_learnrate, 0.0, 0.0,
+      mu_learnrate, 0.0, 0.0, max_sigma,
       mean(Chi(d)), evol_discount, evol_Zscale, zeros(d),
       ini_xnes_B(search_space(embed)), ini_sigma, ini_x,
       zeros(d, lambda),
@@ -78,7 +80,8 @@ function dxnes(problem::OptimizationProblem, parameters)
   embed = RandomBound(search_space(problem))
   DXNESOpt{fitness_type(problem), typeof(embed)}(embed; lambda = params[:lambda],
                                                  ini_x = params[:ini_x],
-                                                 ini_sigma = params[:ini_sigma])
+                                                 ini_sigma = params[:ini_sigma],
+                                                 max_sigma = params[:max_sigma])
 end
 
 function ask(dxnes::DXNESOpt)

--- a/src/dx_nes.jl
+++ b/src/dx_nes.jl
@@ -42,6 +42,7 @@ type DXNESOpt{F,E<:EmbeddingOperator} <: ExponentialNaturalEvolutionStrategyOpt
       ini_x = rand_individual(search_space(embed))
     else
       ini_x = copy(ini_x::Individual)
+      apply!(embed, ini_x, rand_individual(search_space(embed)))
     end
     u = fitness_shaping_utilities_log(lambda)
     evol_discount, evol_Zscale = calculate_evol_path_params(d, u)

--- a/src/dx_nes.jl
+++ b/src/dx_nes.jl
@@ -128,9 +128,13 @@ function calculate_evol_path_params(n::Int64, u::Vector{Float64})
   lambda = length(u)
   mu = 1/sum(i -> (u[i]+1/lambda)^2, 1:(lambda÷2))
   c = (mu + 2.0)/(sqrt(n)*(n+mu+5.0))
-  threshold = mean(Chi(n))
   discount = 1-c
   Zscale = sqrt(c*(2-c)*mu)
+  # Expected length of evol.path, if uZ ~ α N(0,I), based on AR model:
+  # E|path|^2 = α*Zscale^2 / (1-discount^2),
+  # where α ≈ 1 if the population does not cover the minimum and lies on the slope
+  # (so that |uZ| is large), but σ is too large and the method is diverging
+  threshold = Zscale*sqrt(n/(1-discount^2))
   #info("DX-NES params: moving_threshold=", threshold,
   #     " μ=", mu, " c=", c, " discount=", discount, " Zscale=", Zscale)
   return threshold, discount, Zscale

--- a/src/natural_evolution_strategies.jl
+++ b/src/natural_evolution_strategies.jl
@@ -231,6 +231,7 @@ type XNESOpt{F,E<:EmbeddingOperator} <: ExponentialNaturalEvolutionStrategyOpt
       ini_x = rand_individual(search_space(embed))
     else
       ini_x = copy(ini_x::Individual)
+      apply!(embed, ini_x, rand_individual(search_space(embed)))
     end
 
     new(embed, lambda, fitness_shaping_utilities_log(lambda), @compat(Vector{Float64}(lambda)),

--- a/src/natural_evolution_strategies.jl
+++ b/src/natural_evolution_strategies.jl
@@ -8,6 +8,8 @@ type SeparableNESOpt{F,E<:EmbeddingOperator} <: NaturalEvolutionStrategyOpt
   distr::Distribution             # Distribution we sample the step sizes from
   mu_learnrate::Float64
   sigma_learnrate::Float64
+  max_sigma::Float64
+
   last_s::Array{Float64,2}        # The s values sampled in the last call to ask
   candidates::Vector{Candidate{F}}# The last sampled values, now being evaluated
   sortedUtilities::Vector{Float64}# The fitness shaping utility vector
@@ -17,7 +19,7 @@ type SeparableNESOpt{F,E<:EmbeddingOperator} <: NaturalEvolutionStrategyOpt
     lambda::Int = 0,
     mu_learnrate::Float64 = 1.0,
     sigma_learnrate::Float64 = 0.0,
-    ini_x = nothing)
+    ini_x = nothing, max_sigma::Float64 = 1.0E+10)
     d = numdims(search_space(embed))
 
     if lambda == 0
@@ -35,7 +37,7 @@ type SeparableNESOpt{F,E<:EmbeddingOperator} <: NaturalEvolutionStrategyOpt
     new(embed, lambda,
       ini_x, ones(d),
       Normal(0, 1),
-      mu_learnrate, sigma_learnrate,
+      mu_learnrate, sigma_learnrate, max_sigma,
       zeros(d, lambda),
       Candidate{F}[Candidate{F}(Array(Float64, d), i) for i in 1:lambda],
       # Most modern NES papers use log rather than linear fitness shaping.
@@ -52,6 +54,7 @@ const NES_DefaultOptions = @compat Dict{Symbol,Any}(
   :ini_x => nothing,         # starting point, "nothing" generates random point in a search space
   :mu_learnrate => 1.0,
   :sigma_learnrate => 0.0,   # If 0.0 it will be set based on the number of dimensions
+  :max_sigma => 1.0E+10       # Maximal sigma
 )
 
 function separable_nes(problem::OptimizationProblem, parameters)
@@ -61,7 +64,8 @@ function separable_nes(problem::OptimizationProblem, parameters)
     lambda = params[:lambda],
     mu_learnrate = params[:mu_learnrate],
     sigma_learnrate = params[:sigma_learnrate],
-    ini_x = params[:ini_x])
+    ini_x = params[:ini_x],
+    max_sigma = params[:max_sigma])
 end
 
 calc_sigma_learnrate_for_snes(d) = (3 + log(d)) / (5 * sqrt(d))
@@ -97,6 +101,7 @@ function tell!{F}(snes::SeparableNESOpt{F}, rankedCandidates::Vector{Candidate{F
   old_mu = copy(snes.mu)
   snes.mu += snes.mu_learnrate * (snes.sigma .* gradient_mu)
   snes.sigma .*= exp(snes.sigma_learnrate / 2 * gradient_sigma)
+  clamp!(snes.sigma, 0.0, snes.max_sigma)
   apply!(snes.embed, snes.mu, old_mu)
 
   # There is no notion of how many was better in NES so return 0
@@ -167,7 +172,7 @@ function update_parameters!(exnes::ExponentialNaturalEvolutionStrategyOpt, u::Ve
 
   new_sigma = exnes.sigma * exp(0.5 * exnes.sigma_learnrate * dSigma)
   if isfinite(new_sigma) && new_sigma > 0
-    exnes.sigma = new_sigma
+    exnes.sigma = min(new_sigma, exnes.max_sigma)
   end
   exnes
 end
@@ -191,6 +196,8 @@ type XNESOpt{F,E<:EmbeddingOperator} <: ExponentialNaturalEvolutionStrategyOpt
   x_learnrate::Float64
   sigma_learnrate::Float64
   B_learnrate::Float64
+  max_sigma::Float64
+
   # TODO use Symmetric{Float64} to improve exponent etc calculation
   ln_B::Array{Float64,2}          # log of "covariation" matrix
   sigma::Float64                  # step size
@@ -208,7 +215,8 @@ type XNESOpt{F,E<:EmbeddingOperator} <: ExponentialNaturalEvolutionStrategyOpt
 
   function XNESOpt(embed::E; lambda::Int = 0, mu_learnrate::Float64 = 1.0,
                    sigma_learnrate = 0.0, B_learnrate::Float64 = 0.0,
-                   ini_x = nothing, ini_sigma::Float64 = 1.0)
+                   ini_x = nothing, ini_sigma::Float64 = 1.0,
+                   max_sigma::Float64 = 1.0E+10)
     d = numdims(search_space(embed))
     if lambda == 0
       lambda = 4 + 3*floor(Int, log(d))
@@ -226,7 +234,7 @@ type XNESOpt{F,E<:EmbeddingOperator} <: ExponentialNaturalEvolutionStrategyOpt
     end
 
     new(embed, lambda, fitness_shaping_utilities_log(lambda), @compat(Vector{Float64}(lambda)),
-      mu_learnrate, sigma_learnrate, B_learnrate,
+      mu_learnrate, sigma_learnrate, B_learnrate, max_sigma,
       ini_xnes_B(search_space(embed)), ini_sigma, ini_x, zeros(d, lambda),
       Candidate{F}[Candidate{F}(Array(Float64, d), i) for i in 1:lambda],
       # temporaries
@@ -250,7 +258,8 @@ function xnes(problem::OptimizationProblem, parameters)
                                                 sigma_learnrate = params[:sigma_learnrate],
                                                 B_learnrate = params[:B_learnrate],
                                                 ini_x = params[:ini_x],
-                                                ini_sigma = params[:ini_sigma])
+                                                ini_sigma = params[:ini_sigma],
+                                                max_sigma = params[:max_sigma])
 end
 
 function ask(xnes::XNESOpt)

--- a/src/natural_evolution_strategies.jl
+++ b/src/natural_evolution_strategies.jl
@@ -215,7 +215,7 @@ type XNESOpt{F,E<:EmbeddingOperator} <: ExponentialNaturalEvolutionStrategyOpt
 
   function XNESOpt(embed::E; lambda::Int = 0, mu_learnrate::Float64 = 1.0,
                    sigma_learnrate = 0.0, B_learnrate::Float64 = 0.0,
-                   ini_x = nothing, ini_sigma::Float64 = 1.0,
+                   ini_x = nothing, ini_sigma::Float64 = 1.0, ini_lnB = nothing,
                    max_sigma::Float64 = 1.0E+10)
     d = numdims(search_space(embed))
     if lambda == 0
@@ -235,7 +235,7 @@ type XNESOpt{F,E<:EmbeddingOperator} <: ExponentialNaturalEvolutionStrategyOpt
 
     new(embed, lambda, fitness_shaping_utilities_log(lambda), @compat(Vector{Float64}(lambda)),
       mu_learnrate, sigma_learnrate, B_learnrate, max_sigma,
-      ini_xnes_B(search_space(embed)), ini_sigma, ini_x, zeros(d, lambda),
+      ini_lnB === nothing ? ini_xnes_B(search_space(embed)) : ini_lnB, ini_sigma, ini_x, zeros(d, lambda),
       Candidate{F}[Candidate{F}(Array(Float64, d), i) for i in 1:lambda],
       # temporaries
       zeros(d), zeros(d), zeros(d),
@@ -247,7 +247,8 @@ end
 
 const XNES_DefaultOptions = chain(NES_DefaultOptions, @compat Dict{Symbol,Any}(
   :B_learnrate => 0.0,   # If 0.0 it will be set based on the number of dimensions
-  :ini_sigma => 1.0      # Initial sigma (step size)
+  :ini_sigma => 1.0,     # Initial sigma (step size)
+  :ini_lnB => nothing    # Initial log(B)
 ))
 
 function xnes(problem::OptimizationProblem, parameters)
@@ -259,6 +260,7 @@ function xnes(problem::OptimizationProblem, parameters)
                                                 B_learnrate = params[:B_learnrate],
                                                 ini_x = params[:ini_x],
                                                 ini_sigma = params[:ini_sigma],
+                                                ini_lnB = params[:ini_lnB],
                                                 max_sigma = params[:max_sigma])
 end
 


### PR DESCRIPTION
Some small NES enhancements (`:ini_x` checks and introduction of `:ini_lnB` parameter) plus an attempt to fix failing DX-NES tests (#36):
 * step size (`sigma`) is limited by `max_sigma` (defaults to 1E10) to avoid floating point overflows
 * scale distance (in the original paper the algorithm pseudocode has some differences from the description in the text; the fix makes it as discussed in the text)
 * change how the moving threshold is calculated. See below the explanations (keeping in mind that I'm not a population methods expert).

For my optimization problems (that have >100 dimensions) the last point was critical. In fact, the evolutionary path and moving threshold is not a DX-NES novelty, it came from CMA-ES. It's assumed there that if the population is not moving as the whole, the evolutionary path should be a random N-dimensional vector and so the moving threshold is `E|path|`, `|path| ~ Chi(N)` (in fact, `E|path|^2 = N`, `|path|^2 ~ ChiSqr(N)` is even simpler). But, actually, there should be at least 3 possibilities:
 * `deterministic movement` The population lies "on the same slope" and is moving as the whole towards minimum. Hence `u*Z` is big, and evol. path grows as at every iteration the population moves in the same direction. The step (sigma) should be increased to facilitate convergence.
 * `refining minimum` The population covers minimum (hence "natural gradient" `u*Z` is small). The step should be decreased to locate the minimum more precisely.
 * `chaotic movement`. The population is on the slope (so `u*Z` is large), but the step size (`sigma`) is too large, and the new population at next iteration misses the minimum, i.e. the method is diverging. Logically, the step size should be reduced. But in this situation `|path| ~ Chi(N)` is no longer true, because `u*Z` is large. In fact, evolutionary path is a simple autoregressive process, not `~N(0,I)`, and the moving threshold should be set accordingly (see 8649447), otherwise the method thinks it's in `deterministic movement` state and increases `sigma`, which leads to divergence.