### PR TITLE
Fix the parallel Rosenbrock example

### DIFF
--- a/examples/rosenbrock_parallel.jl
+++ b/examples/rosenbrock_parallel.jl
@@ -1,20 +1,22 @@
+# Now add 2 procs that can exec in parallel (obviously it depends on your CPU
+# what you actually gain from this though)
+addprocs(2)
+
+# note that BlackBoxOptim gets automatically used on all workers
 using BlackBoxOptim
 
-function rosenbrock(x)
+# define the function to optimize on all workers
+@everywhere function rosenbrock(x)
   return( sum( 100*( x[2:end] - x[1:end-1].^2 ).^2 + ( x[1:end-1] - 1 ).^2 ) )
 end
 
 # First run without any parallel procs used in eval
-opt1 = bbsetup(rosenbrock; SearchRange = (-5.0, 5.0),
-  NumDimensions = 100, MaxSteps = 500000)
+opt1 = bbsetup(rosenbrock; Method=:xnes, SearchRange = (-5.0, 5.0),
+               NumDimensions = 100, MaxSteps = 5000)
 res1 = bboptimize(opt1)
 
-# Now add 2 procs that can exec in parallel (obviously it depends on your CPU
-# what you actually gain from this though)
-addprocs(2)
-# You need to make sure BlackBoxOptim is loaded an all procs:
-@everywhere using BlackBoxOptim
-# Now we can setup a new opt and run the optimization:
-opt2 = bbsetup(rosenbrock; SearchRange = (-5.0, 5.0),
-  NumDimensions = 100, MaxSteps = 500000, Workers = workers())
+# When Workers= option is given, BlackBoxOptim enables parallel
+# evaluation of fitness using the specified worker processes
+opt2 = bbsetup(rosenbrock; Method=:xnes, SearchRange = (-5.0, 5.0),
+               NumDimensions = 100, MaxSteps = 5000, Workers = workers())
 res2 = bboptimize(opt2)


### PR DESCRIPTION
This fix works for me. `rosenbrock()` should be defined `@everywhere`, OTOH `@everywhere` is not required for `using`. I guess there was also a problem of first using BlackBoxOptim on the master, and then adding the workers, so the workers are initialized in the very beginning.

Actually for me the performance of this example for the parallel method is 3 times lower than serial. Perhaps the function is too simple and there's more communication slowdowns than gain from parallel evaluation. Probably, instead of giving candidates to worker one-by-one, it should be given a population subset at once.