### PR TITLE
Travis-CI: allow failures on Julia nightlies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,13 @@ os:
 julia:
   - 0.4
   - nightly
+matrix:
+  allow_failures:
+    - julia: nightly
 notifications:
   email: false
-  script:
-    - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
-    - julia --check-bounds=yes -e 'Pkg.clone(pwd()); Pkg.build("BlackBoxOptim"); Pkg.test("BlackBoxOptim"; coverage=true)'
-  after_success:
-    - julia -e 'cd(Pkg.dir("BlackBoxOptim")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(Coveralls.process_folder())'
+script:
+  - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
+  - julia --check-bounds=yes -e 'Pkg.clone(pwd()); Pkg.build("BlackBoxOptim"); Pkg.test("BlackBoxOptim"; coverage=true)'
+after_success:
+  - julia -e 'cd(Pkg.dir("BlackBoxOptim")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(Coveralls.process_folder())'


### PR DESCRIPTION
Nightlies are frequently partially broken (e.g. ATM IntrinsicFunctions serialization is not supported, which doesn't allow the optimization state to be serialized), so it doesn't make sense to flag the package broken if it only fails on nightlies.

OTOH it's still nice to track the nightly builds. That's what the PR does.