### PR TITLE
Misc updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ os:
   - osx
 julia:
   - 0.4
+  - 0.5
   - nightly
 matrix:
   allow_failures:

--- a/README.md
+++ b/README.md
@@ -89,14 +89,14 @@ can apply different criteria to filter the solutions.
 For example, to find the solution with the minimal first objective:
 ```julia
 pf = pareto_frontier(res)
-best_obj1, idx_obj1 = findmin(map(i -> fitness(i).orig[1], pf))
+best_obj1, idx_obj1 = findmin(map(elm -> fitness(elm)[1], pf))
 bo1_solution = pf[idx_obj1].params
 ```
 or to use different weighted sums:
 ```julia
 weighedfitness(f, w) = f[1]*w + f[2]*(1.0-w)
 weight = 0.4 # Weight on first objective, so second objective will have weight 1-0.4=0.6
-best_wfitness, idx = findmin(map(i -> weighedfitness(fitness(i).orig, weight), pf))
+best_wfitness, idx = findmin(map(elm -> weighedfitness(fitness(elm), weight), pf))
 bsw = pf[idx].params
 ```
 

--- a/src/BlackBoxOptim.jl
+++ b/src/BlackBoxOptim.jl
@@ -59,7 +59,7 @@ export  Optimizer, AskTellOptimizer, SteppingOptimizer, PopulationOptimizer,
         width_of_confidence_interval, fitness_improvement_potential,
 
         # OptimizationResults
-        minimum, f_minimum, iteration_converged, parameters, population, pareto_frontier,
+        minimum, f_minimum, iteration_converged, parameters, population, pareto_frontier, params,
 
         # OptController
         numruns, lastrun, problem,
@@ -103,6 +103,8 @@ include("ntuple_fitness.jl")
 include("problem.jl")
 
 include("frequency_adaptation.jl")
+
+include("fit_individual.jl")
 include("archive.jl")
 include("archives/epsbox_archive.jl")
 

--- a/src/BlackBoxOptim.jl
+++ b/src/BlackBoxOptim.jl
@@ -34,6 +34,7 @@ export  Optimizer, AskTellOptimizer, SteppingOptimizer, PopulationOptimizer,
         fitness_type, fitness_eltype, numobjectives,
         is_minimizing, nafitness, isnafitness,
         hat_compare, is_better, is_worse, same_fitness,
+        aggregate,
 
         # Evaluator
         #ProblemEvaluator,

--- a/src/archive.jl
+++ b/src/archive.jl
@@ -37,8 +37,8 @@ end
 immutable TopListFitness{F<:Number}
     fitness::F            # current fitness
     fitness_improvement_ratio::Float64
-    timestamp::Float64    # when archived
     num_fevals::Int64     # number of fitness evaluations so far
+    timestamp::Float64    # when archived
 end
 
 fitness(f::TopListFitness) = f.fitness
@@ -119,7 +119,7 @@ function add_candidate!{F,FS<:FitnessScheme}(a::TopListArchive{F,FS}, fitness::F
 
   if isempty(a.fitness_history) || is_better(fitness, best_fitness(a), fitness_scheme(a))
     # Save fitness history so we can reconstruct the most important events later.
-    push!(a.fitness_history, TopListFitness{F}(fitness, fitness_improvement_ratio(a, fitness), time(), num_fevals))
+    push!(a.fitness_history, TopListFitness{F}(fitness, fitness_improvement_ratio(a, fitness), num_fevals, time()))
   end
 
   if length(a) < capacity(a) ||

--- a/src/archive.jl
+++ b/src/archive.jl
@@ -10,12 +10,10 @@ archived_fitness_type{F,FA}(a::Archive{F,FA}) = FA
 archived_fitness{F}(f::F, a::Archive{F,F}) = f
 
 """
-    Base class for individuals stored in different archives.
+    Base class for individuals stored in `Archive`.
 """
-abstract ArchivedIndividual{F}
+abstract ArchivedIndividual{F} <: FitIndividual{F}
 
-params(indi::ArchivedIndividual) = indi.params
-fitness(indi::ArchivedIndividual) = indi.fitness
 tag(indi::ArchivedIndividual) = indi.tag
 
 """

--- a/src/archive.jl
+++ b/src/archive.jl
@@ -2,12 +2,18 @@
   `Archive` saves information about promising solutions during an optimization
   run.
 """
-abstract Archive{F,FA,FS<:FitnessScheme}
+abstract Archive{F,FS<:FitnessScheme}
 
 numdims(a::Archive) = a.numdims
 fitness_type{F}(a::Archive{F}) = F
-archived_fitness_type{F,FA}(a::Archive{F,FA}) = FA
-archived_fitness{F}(f::F, a::Archive{F,F}) = f
+fitness_scheme(a::Archive) = a.fit_scheme
+
+"""
+    archived_fitness(fit, a::Archive)
+
+    Converts given fitness `fit` to the format used by the archive `a`.
+"""
+archived_fitness(fit::Any, a::Archive) = convert(fitness_type(a), fit, fitness_scheme(a))
 
 """
     Base class for individuals stored in `Archive`.
@@ -49,7 +55,7 @@ fitness(f::TopListFitness) = f.fitness
   The two last best fitness values could be used to estimate a confidence interval for how much improvement
   potential there is.
 """
-type TopListArchive{F<:Number,FS<:FitnessScheme} <: Archive{F,F,FS}
+type TopListArchive{F<:Number,FS<:FitnessScheme} <: Archive{F,FS}
   fit_scheme::FS        # Fitness scheme used
   start_time::Float64   # Time when archive created, we use this to approximate the starting time for the opt...
   numdims::Int          # Number of dimensions in the optimization problem. Needed for confidence interval estimation.

--- a/src/archive.jl
+++ b/src/archive.jl
@@ -71,7 +71,7 @@ type TopListArchive{F<:Number,FS<:FitnessScheme} <: Archive{F,FS}
   # class is: `(magnitude_class, time, num_fevals, fitness, width_of_confidence_interval)`
   fitness_history::Vector{TopListFitness{F}}
 
-  @compat function (::Type{TopListArchive}){FS}(fit_scheme::FS, numdims::Integer, capacity::Integer = 10)
+  @compat function (::Type{TopListArchive}){FS<:FitnessScheme}(fit_scheme::FS, numdims::Integer, capacity::Integer = 10)
     F = fitness_type(FS)
     new{F,FS}(fit_scheme, time(), numdims, 0, capacity, TopListIndividual{F}[], TopListFitness{F}[])
   end

--- a/src/archive.jl
+++ b/src/archive.jl
@@ -26,7 +26,7 @@ immutable TopListIndividual{F} <: ArchivedIndividual{F}
     fitness::F
     tag::Int
 
-   @compat (::Type{TopListIndividual}){F}(params::Individual, fitness::F, tag::Int) =
+    @compat (::Type{TopListIndividual}){F}(params::AbstractIndividual, fitness::F, tag::Int) =
         new{F}(params, fitness, tag)
 end
 
@@ -113,7 +113,7 @@ end
 
   Add a candidate with a fitness to the archive (if it is good enough).
 """
-function add_candidate!{F,FS<:FitnessScheme}(a::TopListArchive{F,FS}, fitness::F, candidate, tag::Int=0, num_fevals::Int=-1)
+function add_candidate!{F,FS<:FitnessScheme}(a::TopListArchive{F,FS}, fitness::F, candidate::AbstractIndividual, tag::Int=0, num_fevals::Int=-1)
   a.num_fitnesses += 1
   if (num_fevals == -1) num_fevals = a.num_fitnesses end
 

--- a/src/archives/epsbox_archive.jl
+++ b/src/archives/epsbox_archive.jl
@@ -1,18 +1,33 @@
 """
-    Individual stored in `EpsBoxArchive`.
+    Individual representing the solution from the Pareto set.
 """
-immutable EpsBoxFrontierIndividual{N,F<:Number} <: ArchivedIndividual{IndexedTupleFitness{N,F}}
-    fitness::IndexedTupleFitness{N,F}
+immutable FrontierIndividual{F} <: ArchivedIndividual{F}
+    fitness::F
     params::Individual
     tag::Int                            # tag of the individual (e.g. gen.op. ID)
     num_fevals::Int                     # number of fitness evaluations so far
     n_restarts::Int                     # the number of method restarts so far
     timestamp::Float64                  # when archived
 
-    @compat (::Type{EpsBoxFrontierIndividual}){N,F}(fitness::IndexedTupleFitness{N,F},
+    FrontierIndividual(fitness::F,
                    params, tag, num_fevals, n_restarts, timestamp=time()) =
-        new{N,F}(fitness, params, tag, num_fevals, n_restarts, timestamp)
+        new(fitness, params, tag, num_fevals, n_restarts, timestamp)
+
+    @compat (::Type{FrontierIndividual}){F}(fitness::F,
+                   params, tag, num_fevals, n_restarts, timestamp=time()) =
+        new{F}(fitness, params, tag, num_fevals, n_restarts, timestamp)
 end
+
+tag(indi::FrontierIndividual) = indi.tag
+
+"""
+    Individual stored in `EpsBoxArchive`.
+"""
+typealias EpsBoxFrontierIndividual{N,F<:Number} FrontierIndividual{IndexedTupleFitness{N,F}}
+
+@compat (::Type{EpsBoxFrontierIndividual}){N,F}(fitness::IndexedTupleFitness{N,F},
+               params, tag, num_fevals, n_restarts, timestamp=time()) =
+    FrontierIndividual(fitness, params, tag, num_fevals, n_restarts, timestamp)
 
 """
     ϵ-box archive saves only the solutions that are not ϵ-box

--- a/src/archives/epsbox_archive.jl
+++ b/src/archives/epsbox_archive.jl
@@ -21,7 +21,7 @@ end
     It also counts the number of candidate solutions that have been added
     and how many ϵ-box progresses have been made.
 """
-type EpsBoxArchive{N,F,FS<:EpsBoxDominanceFitnessScheme} <: Archive{NTuple{N,F},IndexedTupleFitness{N,F},FS}
+type EpsBoxArchive{N,F,FS<:EpsBoxDominanceFitnessScheme} <: Archive{IndexedTupleFitness{N,F},FS}
   fit_scheme::FS        # Fitness scheme used
   start_time::Float64   # Time when archive created, we use this to approximate the starting time for the opt...
 
@@ -52,8 +52,6 @@ const EpsBoxArchive_DefaultParameters = ParamsDict(
   :MaxArchiveSize => 10_000,
 )
 
-fitness_scheme(a::EpsBoxArchive) = a.fit_scheme
-# EpsBoxArchive stores indexed fitness
 Base.length(a::EpsBoxArchive) = a.len
 Base.isempty(a::EpsBoxArchive) = a.len == 0
 capacity(a::EpsBoxArchive) = a.max_size
@@ -239,9 +237,6 @@ function add_candidate!{N,F}(a::EpsBoxArchive{N,F}, cand_fitness::IndexedTupleFi
     end
     return a
 end
-
-archived_fitness{N,F}(fitness::NTuple{N,F}, a::EpsBoxArchive{N,F}) =
-    convert(IndexedTupleFitness, fitness, a.fit_scheme)
 
 # actually this methods should never be called because the fitness
 # is already indexes within the method

--- a/src/archives/epsbox_archive.jl
+++ b/src/archives/epsbox_archive.jl
@@ -246,7 +246,7 @@ archived_fitness{N,F}(fitness::NTuple{N,F}, a::EpsBoxArchive{N,F}) =
 # actually this methods should never be called because the fitness
 # is already indexes within the method
 add_candidate!{N,F}(a::EpsBoxArchive{N,F}, cand_fitness::NTuple{N,F},
-                    candidate, tag::Int=0, num_fevals::Int=-1) =
+                    candidate::AbstractIndividual, tag::Int=0, num_fevals::Int=-1) =
     add_candidate!(a, archived_fitness(cand_fitness, a), candidate, tag, num_fevals)
 
 # called by check_stop_condition(e::Evaluator, ctrl)

--- a/src/archives/epsbox_archive.jl
+++ b/src/archives/epsbox_archive.jl
@@ -5,13 +5,13 @@ immutable EpsBoxFrontierIndividual{N,F<:Number} <: ArchivedIndividual{IndexedTup
     fitness::IndexedTupleFitness{N,F}
     params::Individual
     tag::Int                            # tag of the individual (e.g. gen.op. ID)
-    timestamp::Float64                  # when archived
     num_fevals::Int                     # number of fitness evaluations so far
     n_restarts::Int                     # the number of method restarts so far
+    timestamp::Float64                  # when archived
 
     @compat (::Type{EpsBoxFrontierIndividual}){N,F}(fitness::IndexedTupleFitness{N,F},
-                   params, tag, num_fevals, n_restarts) =
-        new{N,F}(fitness, params, tag, time(), num_fevals, n_restarts)
+                   params, tag, num_fevals, n_restarts, timestamp=time()) =
+        new{N,F}(fitness, params, tag, num_fevals, n_restarts, timestamp)
 end
 
 """

--- a/src/borg_moea.jl
+++ b/src/borg_moea.jl
@@ -33,7 +33,7 @@ type BorgMOEA{FS<:FitnessScheme,V<:Evaluator,P<:Population,M<:GeneticOperator,E<
 
   # Set of operators that together define a specific DE strategy.
   select::TournamentSelector{HatCompare{FS}}         # random individuals selector
-  modify::M         # genetic operator
+  modify::M         # operator to mutate frontier element during restarts
   embed::E          # embedding operator
 
   @compat function (::Type{BorgMOEA}){O<:OptimizationProblem, P<:Population,

--- a/src/borg_moea.jl
+++ b/src/borg_moea.jl
@@ -141,7 +141,7 @@ end
 function process_candidate!(alg::BorgMOEA, candi::Candidate, recomb_op_ix::Int, ref_index::Int)
     apply!(alg.embed, candi.params, alg.population, ref_index)
     reset_fitness!(candi, alg.population)
-    candi.op = alg.recombinate[recomb_op_ix]
+    candi.extra = alg.recombinate[recomb_op_ix]
     candi.tag = recomb_op_ix
     ifitness = fitness(update_fitness!(alg.evaluator, candi)) # implicitly updates the archive
     # test the population

--- a/src/differential_evolution.jl
+++ b/src/differential_evolution.jl
@@ -41,7 +41,7 @@ function evolve(de::DiffEvoOpt, op::GeneticOperatorsMixture)
   candidates = evolve(de, sel_op) # use the selected operator of the mixture
   # override what was set by sel_op so that adjust!() gets called for the mixture op
   for candi in candidates
-    candi.op = op
+    candi.extra = op
     candi.tag = tag
   end
   return candidates
@@ -78,7 +78,7 @@ end
 function evolved_pair{F}(de::DiffEvoOpt, target::Candidate{F}, trial::Candidate{F}, op::GeneticOperator, tag::Int = 0)
   # embed the trial parameter vector into the search space
   apply!(de.embed, trial.params, de.population, target.index)
-  target.op = trial.op = op
+  target.extra = trial.extra = op
   target.tag = trial.tag = 0
   if trial.params != target.params
     reset_fitness!(trial, de.population)
@@ -126,7 +126,7 @@ function adjust!(de::DiffEvoOpt, candi::Candidate, is_improved::Bool)
     old_fitness = candi.fitness
   end
 
-  adjust!(candi.op, candi.tag, candi.index, candi.fitness,
+  adjust!(candi.extra::GeneticOperator, candi.tag, candi.index, candi.fitness,
           fitness(population(de), candi.index), is_improved)
 end
 

--- a/src/evaluator.jl
+++ b/src/evaluator.jl
@@ -12,6 +12,8 @@ search_space(e::Evaluator) = search_space(problem(e))
 describe(e::Evaluator) = "Problem: $(name(e.problem)) (dimensions = $(numdims(e)))"
 problem_summary(e::Evaluator) = "$(name(e.problem))_$(numdims(e))d"
 
+shutdown!(e::Evaluator) = e # do nothing
+
 """
   Default implementation of the `Evaluator`.
 

--- a/src/evaluator.jl
+++ b/src/evaluator.jl
@@ -17,8 +17,8 @@ shutdown!(e::Evaluator) = e # do nothing
 """
   Default implementation of the `Evaluator`.
 
-  `FP` is the problem's fitness type
-  `FA` is the archive's stored type
+  `FP` is the original problem's fitness type
+  `FA` is the fitness type actually stored by the archive.
 """
 # FIXME F is the fitness type of the problem, but with current Julia it's
 # not possible to get and use it at declaration type
@@ -30,7 +30,7 @@ type ProblemEvaluator{FP, FA, A<:Archive, P<:OptimizationProblem} <: Evaluator{P
 
   @compat (::Type{ProblemEvaluator}){P<:OptimizationProblem, A<:Archive}(
       problem::P, archive::A) =
-    new{fitness_type(fitness_scheme(problem)),archived_fitness_type(archive),A,P}(problem, archive,
+    new{fitness_type(fitness_scheme(problem)),fitness_type(archive),A,P}(problem, archive,
         0, nafitness(fitness_scheme(problem)))
 
   @compat (::Type{ProblemEvaluator}){P<:OptimizationProblem}(
@@ -50,12 +50,12 @@ num_evals(e::ProblemEvaluator) = e.num_evals
 
     Returns the fitness in the archived format.
 """
-function fitness{FP,FA}(params::Individual, e::ProblemEvaluator{FP,FA}, tag::Int=0)
-  e.last_fitness = fp = fitness(params, e.problem)
+function fitness(params::Individual, e::ProblemEvaluator, tag::Int=0)
+  e.last_fitness = fit = fitness(params, e.problem)
   e.num_evals += 1
-  fa = convert(FA, fp, fitness_scheme(e.archive))
-  add_candidate!(e.archive, fa, params, tag, e.num_evals)
-  fa
+  fita = archived_fitness(fit, e.archive)
+  candi = add_candidate!(e.archive, fita, params, tag, e.num_evals)
+  fita
 end
 
 """

--- a/src/evaluator.jl
+++ b/src/evaluator.jl
@@ -82,41 +82,6 @@ function best_of(candidate1::Individual, candidate2::Individual, e::Evaluator)
   end
 end
 
-"""
-  Candidate solution to the problem.
-
-  Could be either a member of the population (`index` > 0) or
-  a standalone solution (`index` == -1).
-"""
-type Candidate{F}
-    params::Individual
-    index::Int           # index of individual in the population, -1 if unassigned
-    fitness::F           # fitness
-
-    op::GeneticOperator  # genetic operator that was applied to the candidate
-    tag::Int             # additional information set by the genetic operator
-
-    Candidate(params::Individual, index::Int = -1,
-              fitness::F = NaN,
-              op::GeneticOperator = NO_GEN_OP,
-              tag::Int = 0) =
-        new(params, index, fitness, op, tag)
-end
-
-fitness(cand::Candidate) = cand.fitness
-index(cand::Candidate) = cand.index
-
-Base.copy{F}(c::Candidate{F}) = Candidate{F}(copy(c.params), c.index, c.fitness, c.op, c.tag)
-
-function Base.copy!{F}(c::Candidate{F}, o::Candidate{F})
-  copy!(c.params, o.params)
-  c.index = o.index
-  c.fitness = o.fitness # FIXME if vector?
-  c.op = o.op
-  c.tag = o.tag
-  return c
-end
-
 function update_fitness!{FP,FA}(e::ProblemEvaluator{FP,FA}, candidate::Candidate{FA})
   # evaluate fitness if not known yet
   if isnafitness(candidate.fitness, fitness_scheme(e.archive))

--- a/src/fit_individual.jl
+++ b/src/fit_individual.jl
@@ -1,0 +1,64 @@
+"""
+    A point in the problem's search space with the
+    corresponding fitness value.
+
+  `F` is the original problem's fitness type
+"""
+abstract FitIndividual{F}
+
+fitness_type{F}(indi::FitIndividual{F}) = F
+
+"""
+    Get the problem parameters (a point in the search space) of the individual.
+"""
+params(indi::FitIndividual) = indi.params
+
+"""
+    fitness(indi::FitIndividual)
+
+    Gets the fitness of the individual.
+"""
+fitness(indi::FitIndividual) = indi.fitness
+
+"""
+  Candidate solution to the problem.
+
+  Candidate can be either a member of the population (`index` > 0) or
+  a standalone solution (`index` == -1).
+  Can carry additional information, like the `tag` or the genetic operator applied (`extra`).
+"""
+type Candidate{F} <: FitIndividual{F}
+    params::Individual
+    index::Int          # index of individual in the population, -1 if unassigned
+    fitness::F          # fitness
+
+    extra::Any          # extra information
+    tag::Int            # additional information set by the genetic operator
+
+    Candidate(params::Individual, index::Int = -1,
+             fitness::F = NaN,
+             extra::Any = Void,
+             tag::Int = 0) =
+        new(params, index, fitness, extra, tag)
+
+    Base.call{F}(::Type{Candidate},
+                 params::Individual, index::Int = -1,
+                 fitness::F = NaN,
+                 extra::Any = Void,
+                 tag::Int = 0) =
+        new{F}(params, index, fitness, extra, tag)
+end
+
+index(cand::Candidate) = cand.index
+tag(cand::Candidate) = cand.tag
+
+Base.copy(c::Candidate) = Candidate(copy(c.params), c.index, c.fitness, c.extra, c.tag)
+
+function Base.copy!{F}(c::Candidate{F}, o::Candidate{F})
+    copy!(c.params, o.params)
+    c.index = o.index
+    c.fitness = o.fitness # FIXME if vector?
+    c.extra = o.extra
+    c.tag = o.tag
+    return c
+end

--- a/src/fit_individual.jl
+++ b/src/fit_individual.jl
@@ -41,11 +41,11 @@ type Candidate{F} <: FitIndividual{F}
              tag::Int = 0) =
         new(params, index, fitness, extra, tag)
 
-    Base.call{F}(::Type{Candidate},
-                 params::Individual, index::Int = -1,
-                 fitness::F = NaN,
-                 extra::Any = Void,
-                 tag::Int = 0) =
+    @compat (::Type{Candidate}){F}(
+            params::Individual, index::Int = -1,
+            fitness::F = NaN,
+            extra::Any = Void,
+            tag::Int = 0) =
         new{F}(params, index, fitness, extra, tag)
 end
 

--- a/src/fitness.jl
+++ b/src/fitness.jl
@@ -29,7 +29,7 @@ Base.convert{F}(::Type{F}, fit::F, fit_scheme::FitnessScheme{F}) = fit
 
 # ordering induced by the fitness scheme
 # FIXME enable once v0.5 issue #14919 is fixed
-# Base.call{F}(fs::FitnessScheme{F}, x::F, y::F) = is_better(x, y, fs)
+# @compat (fs::FitnessScheme{F}){F}(x::F, y::F) = is_better(x, y, fs)
 
 """
   In `RatioFitnessScheme` the fitness values can be ranked on a ratio scale so

--- a/src/fitness.jl
+++ b/src/fitness.jl
@@ -24,6 +24,9 @@ fitness_eltype{F<:Number}(::Type{FitnessScheme{F}}) = F
 fitness_eltype{F<:Number}(::FitnessScheme{F}) = F
 #fitness_type{FS<:FitnessScheme}(::FS) = fitness_type(FS)
 
+# trivial convert() between calculated and archived fitness
+Base.convert{F}(::Type{F}, fit::F, fit_scheme::FitnessScheme{F}) = fit
+
 # ordering induced by the fitness scheme
 # FIXME enable once v0.5 issue #14919 is fixed
 # Base.call{F}(fs::FitnessScheme{F}, x::F, y::F) = is_better(x, y, fs)
@@ -43,9 +46,6 @@ abstract RatioFitnessScheme{F} <: FitnessScheme{F}
 """
 immutable ScalarFitnessScheme{MIN} <: RatioFitnessScheme{Float64}
 end
-
-# trivial convert() between calculated and archived fitness
-Base.convert{F}(::Type{F}, f::F, ::ScalarFitnessScheme) = f
 
 const MinimizingFitnessScheme = ScalarFitnessScheme{true}()
 const MaximizingFitnessScheme = ScalarFitnessScheme{false}()

--- a/src/genetic_operators/crossover/mutation_wrapper.jl
+++ b/src/genetic_operators/crossover/mutation_wrapper.jl
@@ -1,0 +1,20 @@
+"""
+    Wraps the mutation operator, so that it could
+    be used as crossover operator.
+"""
+immutable MutationWrapper{OP<:MutationOperator} <: CrossoverOperator{1,1}
+    inner::OP
+
+    Base.call{OP<:MutationOperator}(::Type{MutationWrapper}, mutation::OP) =
+        new{OP}(mutation)
+end
+
+function apply!(wrapper::MutationWrapper, target::Individual, targetIndex::Int, pop, parentIndices)
+    @assert length(parentIndices) == 1
+    apply!(wrapper.inner, copy!(target, view(pop, parentIndices[1])), targetIndex)
+end
+
+Base.show(io::IO, xover::MutationWrapper) = print(io, "MutationWrapper(", xover.inner, ")")
+
+# convert mutation to crossover by wrapping it in `MutationWrapper`
+Base.convert(::Type{CrossoverOperator}, op::MutationOperator) = MutationWrapper(op)

--- a/src/genetic_operators/crossover/mutation_wrapper.jl
+++ b/src/genetic_operators/crossover/mutation_wrapper.jl
@@ -5,7 +5,7 @@
 immutable MutationWrapper{OP<:MutationOperator} <: CrossoverOperator{1,1}
     inner::OP
 
-    Base.call{OP<:MutationOperator}(::Type{MutationWrapper}, mutation::OP) =
+    @compat (::Type{MutationWrapper}){OP<:MutationOperator}(mutation::OP) =
         new{OP}(mutation)
 end
 

--- a/src/genetic_operators/embedding/random_bound.jl
+++ b/src/genetic_operators/embedding/random_bound.jl
@@ -3,8 +3,8 @@
   between parent's value and the nearest parameter boundary
   to get the new valid value if target's parameter is out-of-bounds.
 """
-type RandomBound{S<:SearchSpace} <: EmbeddingOperator
-    searchSpace::SearchSpace
+immutable RandomBound{S<:SearchSpace} <: EmbeddingOperator
+    searchSpace::S
 end
 
 # outer ctors

--- a/src/genetic_operators/embedding/random_bound.jl
+++ b/src/genetic_operators/embedding/random_bound.jl
@@ -5,10 +5,11 @@
 """
 immutable RandomBound{S<:SearchSpace} <: EmbeddingOperator
     searchSpace::S
+
+    @compat (::Type{RandomBound}){S<:SearchSpace}(searchSpace::S) = new{S}(searchSpace)
 end
 
 # outer ctors
-RandomBound{S<:SearchSpace}(searchSpace::S) = RandomBound{S}(searchSpace)
 RandomBound(dimBounds::Vector{ParamBounds}) = RandomBound(RangePerDimSearchSpace(dimBounds))
 
 search_space(rb::RandomBound) = rb.searchSpace

--- a/src/genetic_operators/embedding/random_bound.jl
+++ b/src/genetic_operators/embedding/random_bound.jl
@@ -13,7 +13,7 @@ RandomBound(dimBounds::Vector{ParamBounds}) = RandomBound(RangePerDimSearchSpace
 
 search_space(rb::RandomBound) = rb.searchSpace
 
-function apply!(eo::RandomBound, target::Individual, ref::AbstractVector)
+function apply!(eo::RandomBound, target::AbstractIndividual, ref::AbstractIndividual)
   length(target) == length(ref) == numdims(eo.searchSpace) || throw(ArgumentError("Dimensions of problem/individuals do not match"))
   ssmins = mins(eo.searchSpace)
   ssmaxs = maxs(eo.searchSpace)
@@ -31,10 +31,10 @@ function apply!(eo::RandomBound, target::Individual, ref::AbstractVector)
   return target
 end
 
-apply!(eo::RandomBound, target::Individual, pop, refIndex::Int) =
-  apply!(eo, target, viewer(pop, refIndex))
+apply!(eo::RandomBound, target::AbstractIndividual, pop, refIndex::Int) =
+    apply!(eo, target, viewer(pop, refIndex))
 
-function apply!(eo::RandomBound, target::Individual, pop, parentIndices::Vector{Int})
+function apply!(eo::RandomBound, target::AbstractIndividual, pop, parentIndices::AbstractVector{Int})
   @assert length(parentIndices) == 1
   apply!(eo, target, pop, parentIndices[1])
 end

--- a/src/genetic_operators/genetic_operator.jl
+++ b/src/genetic_operators/genetic_operator.jl
@@ -98,6 +98,7 @@ include("operators_mixture.jl")
 include("mutation/mutation_clock.jl")
 include("mutation/polynomial_mutation.jl")
 
+include("crossover/mutation_wrapper.jl")
 include("crossover/simulated_binary_crossover.jl")
 include("crossover/simplex_crossover.jl")
 include("crossover/differential_evolution_crossover.jl")

--- a/src/genetic_operators/genetic_operator.jl
+++ b/src/genetic_operators/genetic_operator.jl
@@ -50,7 +50,7 @@ numparents(o::EmbeddingOperator) = 1
 numchildren(o::EmbeddingOperator) = 1
 
 # wrapper for multi-children variant of apply!() for single-child xover operators
-function apply!{NP,T<:AbstractVector{Float64}}(xover::CrossoverOperator{NP,1}, targets::AbstractVector{T}, target_indices::AbstractVector{Int}, pop, parentIndices)
+function apply!{NP,I<:AbstractIndividual}(xover::CrossoverOperator{NP,1}, targets::AbstractVector{I}, target_indices::AbstractVector{Int}, pop, parentIndices)
     length(targets) == length(target_indices) || throw(ArgumentError("The number of target doesn't match the number of their indices"))
     for i in eachindex(target_indices)
         apply!(xover, targets[i], target_indices[i], pop, parentIndices)

--- a/src/natural_evolution_strategies.jl
+++ b/src/natural_evolution_strategies.jl
@@ -42,7 +42,7 @@ type SeparableNESOpt{F,E<:EmbeddingOperator} <: NaturalEvolutionStrategyOpt
       Normal(0, 1),
       mu_learnrate, sigma_learnrate, max_sigma,
       zeros(d, lambda),
-      Candidate{F}[Candidate{F}(Vector{Float64}(d), i) for i in 1:lambda],
+      Candidate{F}[Candidate{F}(Individual(d), i) for i in 1:lambda],
       # Most modern NES papers use log rather than linear fitness shaping.
       fitness_shaping_utilities_log(lambda),
       Vector{Float64}(lambda))
@@ -255,7 +255,7 @@ type XNESOpt{F,E<:EmbeddingOperator} <: ExponentialNaturalEvolutionStrategyOpt
     new(embed, lambda, fitness_shaping_utilities_log(lambda), Vector{Float64}(lambda),
       mu_learnrate, sigma_learnrate, B_learnrate, max_sigma,
       ini_lnB === nothing ? ini_xnes_B(search_space(embed)) : ini_lnB, ini_sigma, ini_x, zeros(d, lambda),
-      Candidate{F}[Candidate{F}(Vector{Float64}(d), i) for i in 1:lambda],
+      Candidate{F}[Candidate{F}(Individual(d), i) for i in 1:lambda],
       # temporaries
       zeros(d), zeros(d), zeros(d),
       zeros(d, d),

--- a/src/ntuple_fitness.jl
+++ b/src/ntuple_fitness.jl
@@ -1,19 +1,25 @@
 """
   Base class for tuple-based fitness schemes.
+
+  `N` is the number of the objectives
+  `F` is the type of each objective
+  `FA` is the actual type of the multi-objective fitness
+  `MIN` if objectives should be minimized or maximized
+  `AGG` the type of aggregator
 """
-abstract TupleFitnessScheme{N,F<:Number,MIN,AGG} <: FitnessScheme{NTuple{N,F}}
+abstract TupleFitnessScheme{N,F<:Number,FA,MIN,AGG} <: FitnessScheme{FA}
 
 @inline numobjectives{N}(::TupleFitnessScheme{N}) = N
 @inline fitness_eltype{N,F}(::TupleFitnessScheme{N,F}) = F
-@inline is_minimizing{N,F,MIN}(::TupleFitnessScheme{N,F,MIN}) = MIN
+@inline is_minimizing{N,F,FA,MIN}(::TupleFitnessScheme{N,F,FA,MIN}) = MIN
 
-@generated nafitness{N,F}(::TupleFitnessScheme{N,F}) = ntuple(_ -> convert(F, NaN), Val{N})
-isnafitness{N,F}(f::NTuple{N,F}, ::TupleFitnessScheme{N,F}) = any(isnan, f) # or any?
+@generated nafitness{N,F}(::TupleFitnessScheme{N,F,NTuple{N,F}}) = ntuple(_ -> convert(F, NaN), Val{N})
+isnafitness{N,F}(f::NTuple{N,F}, ::TupleFitnessScheme{N,F}) = any(isnan, f)
 
 aggregate{N,F}(f::NTuple{N,F}, fs::TupleFitnessScheme{N,F}) = fs.aggregator(f)
 
-@inline is_better{N,F}(f1::NTuple{N,F}, f2::NTuple{N,F}, fs::TupleFitnessScheme{N,F}) = hat_compare(f1, f2, fs, -1) == -1
-@inline is_worse{N,F}(f1::NTuple{N,F}, f2::NTuple{N,F}, fs::TupleFitnessScheme{N,F}) = hat_compare(f1, f2, fs, 1) == 1
+@inline is_better{N,F}(f1::NTuple{N,F}, f2::NTuple{N,F}, fs::TupleFitnessScheme{N,F,NTuple{N,F}}) = hat_compare(f1, f2, fs, -1) == -1
+@inline is_worse{N,F}(f1::NTuple{N,F}, f2::NTuple{N,F}, fs::TupleFitnessScheme{N,F,NTuple{N,F}}) = hat_compare(f1, f2, fs, 1) == 1
 
 """
   Pareto dominance for `N`-tuple (`N`≧1) fitnesses.
@@ -22,7 +28,7 @@ aggregate{N,F}(f::NTuple{N,F}, fs::TupleFitnessScheme{N,F}) = fs.aggregator(f)
   Might be used for comparisons (or not, depending on the setup).
   Always used when printing fitness vectors though.
 """
-immutable ParetoFitnessScheme{N,F<:Number,MIN,AGG} <: TupleFitnessScheme{N,F,MIN,AGG}
+immutable ParetoFitnessScheme{N,F<:Number,MIN,AGG} <: TupleFitnessScheme{N,F,NTuple{N,F},MIN,AGG}
     aggregator::AGG    # fitness aggregation function
 
     @compat (::Type{ParetoFitnessScheme{N,F}}){N,F<:Number,AGG}(;is_minimizing::Bool=true, aggregator::AGG=sum) =
@@ -233,7 +239,7 @@ end
   Might be used for comparisons (or not, depending on the setup).
   Always used when printing fitness vectors though.
 """
-immutable EpsBoxDominanceFitnessScheme{N,F<:Number,MIN,AGG} <: TupleFitnessScheme{N,F,MIN,AGG}
+immutable EpsBoxDominanceFitnessScheme{N,F<:Number,MIN,AGG} <: TupleFitnessScheme{N,F,IndexedTupleFitness{N,F},MIN,AGG}
     ϵ::Vector{F}        # per-objective ɛ-domination thresholds
     aggregator::AGG     # fitness aggregation function
 
@@ -246,9 +252,7 @@ immutable EpsBoxDominanceFitnessScheme{N,F<:Number,MIN,AGG} <: TupleFitnessSchem
         new{N,F,is_minimizing,AGG}(check_epsbox_ϵ(ϵ, N), aggregator)
 end
 
-# overloads of the default behaviour, because the actual fitness type is not NTuple{N,F}
-fitness_type{N,F}(::Type{EpsBoxDominanceFitnessScheme{N,F}}) = IndexedTupleFitness{N,F}
-isnafitness{N,F}(f::IndexedTupleFitness{N,F}, ::EpsBoxDominanceFitnessScheme{N,F}) = any(isnan, f.orig) # or any?
+isnafitness{N,F}(f::IndexedTupleFitness{N,F}, fit_scheme::EpsBoxDominanceFitnessScheme{N,F}) = isnafitness(f.orig, fit_scheme)
 
 Base.convert{N,F,MIN}(::Type{EpsBoxDominanceFitnessScheme}, fs::ParetoFitnessScheme{N,F,MIN}, ϵ::F=one(F)) =
   EpsBoxDominanceFitnessScheme{N,F}(ϵ, is_minimizing=MIN, aggregator=fs.aggregator)
@@ -266,6 +270,8 @@ Base.convert{N,F,MIN}(::Type{IndexedTupleFitness{N,F}}, fitness::NTuple{N,F},
 Base.convert{N,F,MIN}(::Type{IndexedTupleFitness}, fitness::NTuple{N,F},
                       fs::EpsBoxDominanceFitnessScheme{N,F,MIN}) =
     IndexedTupleFitness(fitness, aggregate(fitness, fs), fs.ϵ, Val{MIN})
+
+Base.convert{N,F}(::Type{NTuple{N,F}}, fitness::IndexedTupleFitness{N,F}, fs::EpsBoxDominanceFitnessScheme{N,F}) = fitness.orig
 
 hat_compare{N,F,MIN}(u::IndexedTupleFitness{N,F}, v::IndexedTupleFitness{N,F},
                  fs::EpsBoxDominanceFitnessScheme{N,F,MIN}, expected::Int=0) =

--- a/src/ntuple_fitness.jl
+++ b/src/ntuple_fitness.jl
@@ -263,6 +263,9 @@ Base.convert{N,F,MIN}(::Type{EpsBoxDominanceFitnessScheme}, fs::ParetoFitnessSch
 Base.convert{N,F,MIN}(::Type{EpsBoxDominanceFitnessScheme}, fs::EpsDominanceFitnessScheme{N,F,MIN}, ϵ::Union{F,Vector{F}}=fs.ϵ) =
   EpsBoxDominanceFitnessScheme{N,F}(ϵ, is_minimizing=MIN, aggregator=fs.aggregator)
 
+Base.convert{N,F<:Number,MIN,AGG}(::Type{ParetoFitnessScheme}, fs::EpsBoxDominanceFitnessScheme{N,F,MIN,AGG}) =
+  ParetoFitnessScheme{N,F}(is_minimizing=MIN, aggregator=fs.aggregator)
+
 Base.convert{N,F,MIN}(::Type{IndexedTupleFitness{N,F}}, fitness::NTuple{N,F},
                       fs::EpsBoxDominanceFitnessScheme{N,F,MIN}) =
     IndexedTupleFitness(fitness, aggregate(fitness, fs), fs.ϵ, Val{MIN})

--- a/src/opt_controller.jl
+++ b/src/opt_controller.jl
@@ -254,10 +254,13 @@ setup_optimizer!{O<:SteppingOptimizer}(ctrl::OptRunController{O}) =
 setup_optimizer!{O<:AskTellOptimizer}(ctrl::OptRunController{O}) =
   setup!(ctrl.optimizer, ctrl.evaluator)
 
-finalize_optimizer!{O<:SteppingOptimizer}(ctrl::OptRunController{O}) =
-  finalize!(ctrl.optimizer)
-finalize_optimizer!{O<:AskTellOptimizer}(ctrl::OptRunController{O}) =
-  finalize!(ctrl.optimizer, ctrl.evaluator)
+shutdown_optimizer!{O<:SteppingOptimizer}(ctrl::OptRunController{O}) =
+  shutdown!(ctrl.optimizer)
+
+function shutdown_optimizer!{O<:AskTellOptimizer}(ctrl::OptRunController{O})
+  shutdown!(ctrl.optimizer)
+  shutdown!(ctrl.evaluator)
+end
 
 """
   `run!(ctrl::OptRunController)`
@@ -292,7 +295,7 @@ function run!(ctrl::OptRunController)
     ctrl.stop_reason = check_stop_condition(ctrl)
   end
   ctrl.stop_time = time()
-  finalize_optimizer!(ctrl)
+  shutdown_optimizer!(ctrl)
   tr(ctrl, "\nOptimization stopped after $(ctrl.num_steps) steps and $(elapsed_time(ctrl)) seconds\n")
 end
 

--- a/src/optimization_result.jl
+++ b/src/optimization_result.jl
@@ -88,8 +88,9 @@ immutable FrontierIndividualWrapper{F,FA} <: FitIndividual{F}
     inner::FrontierIndividual{FA}
     fitness::F
 
-    Base.call{F,FA}(::Type{FrontierIndividualWrapper{F}}, indi::FrontierIndividual{FA}, fit_scheme::FitnessScheme{FA}) =
-        new{F, FA}(indi, convert(F, fitness(indi), fit_scheme))
+    @compat (::Type{FrontierIndividualWrapper{F}}){F,FA}(
+        indi::FrontierIndividual{FA}, fit_scheme::FitnessScheme{FA}) =
+            new{F, FA}(indi, convert(F, fitness(indi), fit_scheme))
 end
 
 params(indi::FrontierIndividualWrapper) = params(indi.inner)

--- a/src/optimizer.jl
+++ b/src/optimizer.jl
@@ -90,16 +90,16 @@ function setup!(o::SteppingOptimizer)
   # Do nothing, override if you need to setup prior to the optimization loop
 end
 
-function finalize!(o::SteppingOptimizer)
-  # Do nothing, override if you need to finalize something after the optimization loop
-end
-
 function setup!(o::AskTellOptimizer, evaluator::Evaluator)
   # Do nothing, override if you need to setup prior to the optimization loop
 end
 
-function finalize!(o::AskTellOptimizer, evaluator::Evaluator)
-  # Do nothing, override if you need to finalize something after the optimization loop
+function shutdown!(o::Optimizer)
+  # Do nothing, override if you need to setup prior to the optimization loop
+end
+
+function shutdown!(o::SteppingOptimizer)
+  shutdown!(evaluator(o)) # shutdown the evaluator
 end
 
 # The standard name function converts the type of the optimizer to a string

--- a/src/population.jl
+++ b/src/population.jl
@@ -135,7 +135,7 @@ function acquire_candi{F}(pop::FitPopulation{F})
   end
   res = pop!(pop.candi_pool)
   # reset reference to genetic operation
-  res.op = NO_GEN_OP
+  res.extra = NO_GEN_OP
   res.tag = 0
   return res
 end

--- a/src/population.jl
+++ b/src/population.jl
@@ -7,7 +7,7 @@ abstract Population
   The base abstract types for population that also stores the candidates
   fitness.
 
-  `F` is the type of fitness values.
+  `F` is the fitness type.
 """
 abstract PopulationWithFitness{F} <: Population
 
@@ -93,16 +93,16 @@ Base.getindex(pop::FitPopulation, indi_ixs) = pop.individuals[:, indi_ixs]
 """
 viewer(pop::FitPopulation, indi_ix) = view(pop.individuals, :, indi_ix)
 
-Base.setindex!{F}(pop::FitPopulation{F}, indi::Individual, ::Colon, indi_ix::Integer) =
+Base.setindex!(pop::FitPopulation, indi::Individual, ::Colon, indi_ix::Integer) =
     setindex!(pop, indi, indi_ix)
 
-function Base.setindex!{F}(pop::FitPopulation{F}, indi::Individual, indi_ix::Integer)
+function Base.setindex!(pop::FitPopulation, indi::Individual, indi_ix::Integer)
     pop.individuals[:, indi_ix] = indi
     pop.fitness[indi_ix] = pop.nafitness
     pop
 end
 
-function Base.setindex!{F}(pop::FitPopulation{F}, indi::ArchivedIndividual{F}, indi_ix::Integer)
+function Base.setindex!{F}(pop::FitPopulation{F}, indi::FitIndividual{F}, indi_ix::Integer)
     pop.individuals[:, indi_ix] = params(indi)
     pop.fitness[indi_ix] = fitness(indi)
     pop

--- a/src/population.jl
+++ b/src/population.jl
@@ -131,7 +131,7 @@ candidate_type{F}(pop::FitPopulation{F}) = Candidate{F}
 """
 function acquire_candi{F}(pop::FitPopulation{F})
   if isempty(pop.candi_pool)
-    return Candidate{F}(Vector{Float64}(numdims(pop)), -1, pop.nafitness)
+    return Candidate{F}(Individual(numdims(pop)), -1, pop.nafitness)
   end
   res = pop!(pop.candi_pool)
   # reset reference to genetic operation

--- a/src/search_space.jl
+++ b/src/search_space.jl
@@ -18,7 +18,17 @@ abstract FixedDimensionSearchSpace <: SearchSpace
 abstract ContinuousSearchSpace <: FixedDimensionSearchSpace
 
 """
-  The point of the `SearchSpace`.
+    The point of the `SearchSpace`.
+
+    The abstract type. It allows different actual implementations to be used,
+    e.g `Vector` or `SubArray`.
+"""
+typealias AbstractIndividual AbstractVector{Float64}
+
+"""
+    The point of the `SearchSpace`.
+
+    The concrete type that could be used for storage.
 """
 typealias Individual Vector{Float64}
 
@@ -60,7 +70,7 @@ end
 """
   Check if given individual lies in the given search space.
 """
-function Base.in(ind, css::ContinuousSearchSpace)
+function Base.in(ind::AbstractIndividual, css::ContinuousSearchSpace)
   @assert length(ind) == numdims(css)
   for i in eachindex(ind)
       if !(mins(css)[i] <= ind[i] <= maxs(css)[i])
@@ -104,7 +114,7 @@ symmetric_search_space(numdims, range = (0.0, 1.0)) = RangePerDimSearchSpace(fil
 """
   Projects a given point onto the search space coordinate-wise.
 """
-feasible(v, ss::RangePerDimSearchSpace) = Float64[ clamp( v[i], mins(ss)[i], maxs(ss)[i] ) for i in eachindex(v) ]
+feasible(v::AbstractIndividual, ss::RangePerDimSearchSpace) = Float64[ clamp( v[i], mins(ss)[i], maxs(ss)[i] ) for i in eachindex(v) ]
 
 # concatenates two range-based search spaces
 Base.vcat(ss1::RangePerDimSearchSpace, ss2::RangePerDimSearchSpace) =

--- a/test/test_evaluator.jl
+++ b/test/test_evaluator.jl
@@ -62,6 +62,19 @@ facts("Evaluator") do
     evaluator_tests(() -> BlackBoxOptim.ProblemEvaluator(p))
   end
 
+  context("rank_by_fitness!()") do
+    e = BlackBoxOptim.ProblemEvaluator(p)
+
+    candidates = [BlackBoxOptim.Candidate{Float64}(clamp!(randn(2), -1.0, 1.0)) for i in 1:10]
+    # partially evaluate fitness
+    BlackBoxOptim.update_fitness!(e, candidates[1:5])
+    @fact BlackBoxOptim.num_evals(e) --> 5
+    # complete fitness evaluation and sort by it
+    BlackBoxOptim.rank_by_fitness!(e, candidates)
+    @fact BlackBoxOptim.num_evals(e) --> 10
+    @fact sortperm(candidates, by = fitness) --> collect(1:10)
+  end
+
 if BlackBoxOptim.enable_parallel_methods
   context("ParallelEvaluator") do
     evaluator_tests(() -> BlackBoxOptim.ParallelEvaluator(p, pids=workers()))

--- a/test/test_evaluator.jl
+++ b/test/test_evaluator.jl
@@ -56,7 +56,7 @@ end
 
 facts("Evaluator") do
   # Set up a small example problem
-  f(x) = sum(x.^2)
+  f(x) = sumabs2(x)
   p = minimization_problem(f, "", (-1.0, 1.0), 2)
   context("ProblemEvaluator") do
     evaluator_tests(() -> BlackBoxOptim.ProblemEvaluator(p))

--- a/test/test_evaluator.jl
+++ b/test/test_evaluator.jl
@@ -26,7 +26,7 @@ function evaluator_tests(make_eval::Function)
 
     @fact BlackBoxOptim.best_of(a, b, e) --> (a, 0.25)
     @fact BlackBoxOptim.best_of(b, a, e) --> (a, 0.25)
-
+    BlackBoxOptim.shutdown!(e)
   end
 
   context("update_fitness!()") do
@@ -36,6 +36,7 @@ function evaluator_tests(make_eval::Function)
     BlackBoxOptim.update_fitness!(e, candidates)
     @fact BlackBoxOptim.num_evals(e) --> length(candidates)
     @fact all(c -> isfinite(c.fitness), candidates) --> true
+    BlackBoxOptim.shutdown!(e)
   end
 
   context("rank_by_fitness!()") do
@@ -49,6 +50,7 @@ function evaluator_tests(make_eval::Function)
     BlackBoxOptim.rank_by_fitness!(e, candidates)
     @fact BlackBoxOptim.num_evals(e) --> 10
     @fact sortperm(candidates, by = fitness) --> collect(1:10)
+    BlackBoxOptim.shutdown!(e)
   end
 end
 


### PR DESCRIPTION
Another round of updates, mostly cleanups; the algorithms should not be affected:
* more Julia v0.5 compatibility fixes
* cleanups of the internal `Individual` and `Fitness` API
* clean up of the public API to access frontier elements (fitness and individual). No more ugly `fitness(i).orig[1]` constructs to access the method-independent fitness.
* `shutdown!(optimizer)` (required by asynchronous parallel evaluator that is not a part of this PR)
* update stability tests

The last commit makes the detection of stability issues on v0.5 (see #51) more robust. I observed that if `MaxTime` is small (0.3), the first gc might not happen during the first optimization run(s). Since the initial gc also triggers some time-consuming compilation, the result of that run(s) would be also off. It could explain the problems observed in #51 on v0.5. The updated script excludes any iteration with deviating running time from the benchmark.