### PR TITLE
Rename OptimizationValue to OptimalFitness

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,8 +110,8 @@ In addition to the `Method` parameter, there are many other parameters you can c
 * `MaxFuncEvals`: How many evaluations that are allowed of the function being optimized.
 * `TraceMode`: How optimization progress should be displayed (`:silent`, `:compact`, `:verbose`). Defaults to `:compact` that outputs current number of fitness evaluations and best value each `TraceInterval` seconds.
 * `PopulationSize`: How large is the initial population for population-based optimizers? Defaults to `50`.
-* `OptimizationValue`. If you know the value of the best fitness, you can add it as an `OptimizationValue`. The algorithm stops as soon as the distance between the fitness and `OptimizationValue` is less than `FitnessTolerance`
-This list is not complete though, please refer to the examples and tests directories for additional examples.
+* `OptimalFitness`. Allows to specify the value of the best fitness for a given problem. The algorithm stops as soon as the distance between the current `best_fitness()` and `OptimalFitness` is less than `FitnessTolerance`.
+This list is not complete though, please refer to the `examples` and `tests` directories for additional examples.
 
 # State of the Library
 

--- a/src/bboptimize.jl
+++ b/src/bboptimize.jl
@@ -28,12 +28,8 @@ function setup_problem(func::Function, parameters::Parameters)
 
   # Now create an optimization problem with the given information. We currently reuse the type
   # from our pre-defined problems so some of the data for the constructor is dummy.
-  if haskey(parameters, :OptimizationValue)
-    problem = FunctionBasedProblem(func, "<unknown>", parameters[:FitnessScheme], ss, parameters[:OptimizationValue])
-  else
-    problem = FunctionBasedProblem(func, "<unknown>", parameters[:FitnessScheme], ss)
-  end
-
+  problem = FunctionBasedProblem(func, "<unknown>", parameters[:FitnessScheme], ss,
+                                 parameters[:OptimalFitness])
 
   # validate fitness: create a random solution from the search space and ensure that fitness(problem) returns fitness_type(problem).
   ind = rand_individual(search_space(problem))

--- a/src/default_parameters.jl
+++ b/src/default_parameters.jl
@@ -8,6 +8,7 @@ const DefaultParameters = ParamsDict(
   :SearchRange    => (-1.0, 1.0), # Default search range to use per dimension unless specified
   :SearchSpace    => false, # Search space can be directly specified and will then take precedence over NumDimensions and SearchRange.
   :FitnessScheme  => MinimizingFitnessScheme, # fitness scheme to be used
+  :OptimalFitness => nothing, # optimal (target) fitness, if known
 
   :Method => :adaptive_de_rand_1_bin_radiuslimited,
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -36,7 +36,6 @@ my_tests = [
 
   "test_generating_set_search.jl",
   "test_direct_search_with_probabilistic_descent.jl",
-  "test_solve.jl",
 ]
 
 for t in my_tests

--- a/test/test_solve.jl
+++ b/test/test_solve.jl
@@ -1,9 +1,0 @@
-facts("Testing solver") do
-    function rosenbrock(x)
-      return( sum( 100*( x[2:end] - x[1:end-1].^2 ).^2 + ( x[1:end-1] - 1 ).^2 ) )
-    end
-    result1 = bboptimize(rosenbrock, SearchRange = (-5.0, 5.0), NumDimensions = 5, Method = :de_rand_1_bin, FitnessTolerance = 1e-5, OptimizationValue = 0.0, MaxSteps = 1000000, TraceMode = :silent);
-    result2 = bboptimize(rosenbrock, SearchRange = (-5.0, 5.0), NumDimensions = 5, Method = :de_rand_1_bin, FitnessTolerance = 1e-5, MaxSteps = 1000000, TraceMode = :silent);
-    @fact best_fitness(result1) --> less_than(1e-5)
-    @fact result1.iterations --> less_than(result2.iterations)
-end

--- a/test/test_toplevel_bboptimize.jl
+++ b/test/test_toplevel_bboptimize.jl
@@ -144,4 +144,17 @@ end
       end
     end
   end
+
+  context("OptimalFitness option works") do
+    # FIXME use the same (fixed?) random seed to guarantee reproducibility
+    result1 = bboptimize(rosenbrock, SearchRange = (-5.0, 5.0), NumDimensions = 5,
+                         Method = :de_rand_1_bin, FitnessTolerance = 1e-5,
+                         MaxSteps = 1000000, TraceMode = :silent,
+                         OptimalFitness = 0.0)
+    result2 = bboptimize(rosenbrock, SearchRange = (-5.0, 5.0), NumDimensions = 5,
+                         Method = :de_rand_1_bin, FitnessTolerance = 1e-5,
+                         MaxSteps = 1000000, TraceMode = :silent)
+    @fact best_fitness(result1) --> less_than(1e-5)
+    @fact result1.iterations --> less_than(result2.iterations)
+  end
 end


### PR DESCRIPTION
The PR makes some minor simplifications and cleanups to #50 that introduced `OptimizationValue` option. I also suggest to rename it to `OptimalFitness`, so it uses the same vocabulary as the rest of BBO API (or even to `TargetFitness`, since the specified value might not be optimal, but the method will stop as soon as the best solution reaches it).

**cc** @matthieugomez 