### PR TITLE
Performance optimizations and 0.5 compatibility

### DIFF
--- a/src/BlackBoxOptim.jl
+++ b/src/BlackBoxOptim.jl
@@ -1,4 +1,4 @@
-VERSION >= v"0.4.0-dev+6521" && __precompile__(true)
+__precompile__()
 
 module BlackBoxOptim
 

--- a/src/BlackBoxOptim.jl
+++ b/src/BlackBoxOptim.jl
@@ -3,8 +3,7 @@ __precompile__()
 module BlackBoxOptim
 
 using Distributions, StatsBase, Compat
-
-import Compat: String, view
+using Compat: String, view
 
 # selectively enable parallel evaluation:
 # - Julia v0.3: no RemoteChannel

--- a/src/BlackBoxOptim.jl
+++ b/src/BlackBoxOptim.jl
@@ -5,12 +5,6 @@ module BlackBoxOptim
 using Distributions, StatsBase, Compat
 using Compat: String, view
 
-# selectively enable parallel evaluation:
-# - Julia v0.3: no RemoteChannel
-# + Julia v0.4
-# - Julia v0.5: incompatible changes in parallel API
-enable_parallel_methods = VERSION >= v"0.4.0" && VERSION < v"0.5.0-"
-
 export  Optimizer, AskTellOptimizer, SteppingOptimizer, PopulationOptimizer,
         bboptimize, bbsetup, compare_optimizers,
 
@@ -111,9 +105,7 @@ include("archives/epsbox_archive.jl")
 include("genetic_operators/genetic_operator.jl")
 
 include("evaluator.jl")
-if enable_parallel_methods
 include("parallel_evaluator.jl")
-end
 
 include("population.jl")
 include("optimizer.jl")

--- a/src/differential_evolution.jl
+++ b/src/differential_evolution.jl
@@ -96,7 +96,7 @@ function tell!{F}(de::DiffEvoOpt,
     candi = rankedCandidates[i]
     # accept the modified individuals from the top ranked half
     if i <= n_acceptable_candidates
-      is_improved = candi.params != population(de)[candi.index]
+      is_improved = candi.params != viewer(population(de), candi.index)
       adjust!(de, candi, is_improved)
     else
       is_improved = false

--- a/src/differential_evolution.jl
+++ b/src/differential_evolution.jl
@@ -79,7 +79,7 @@ function evolved_pair{F}(de::DiffEvoOpt, target::Candidate{F}, trial::Candidate{
   # embed the trial parameter vector into the search space
   apply!(de.embed, trial.params, de.population, target.index)
   target.extra = trial.extra = op
-  target.tag = trial.tag = 0
+  target.tag = trial.tag = tag
   if trial.params != target.params
     reset_fitness!(trial, de.population)
   end

--- a/src/genetic_operators/crossover/mutation_wrapper.jl
+++ b/src/genetic_operators/crossover/mutation_wrapper.jl
@@ -11,7 +11,7 @@ end
 
 function apply!(wrapper::MutationWrapper, target::Individual, targetIndex::Int, pop, parentIndices)
     @assert length(parentIndices) == 1
-    apply!(wrapper.inner, copy!(target, view(pop, parentIndices[1])), targetIndex)
+    apply!(wrapper.inner, copy!(target, viewer(pop, parentIndices[1])), targetIndex)
 end
 
 Base.show(io::IO, xover::MutationWrapper) = print(io, "MutationWrapper(", xover.inner, ")")

--- a/src/genetic_operators/crossover/parent_centric_crossover.jl
+++ b/src/genetic_operators/crossover/parent_centric_crossover.jl
@@ -29,8 +29,11 @@ function apply!{NP}(xover::ParentCentricCrossover{NP}, target::Individual, targe
     broadcast!(-, parents_centered, parents_centered, center)
     # project other parents vectors orthogonal to
     # the subspace orthogonal to the selected parent
-    other_parents_centered = (eye(size(parents_centered,1)) -
-            A_mul_Bt(view(parents_centered, :, 1), view(parents_centered, :, 1))) *
+    tmp_mtx = A_mul_Bt(view(parents_centered, :, 1), view(parents_centered, :, 1))
+    @inbounds for i in 1:size(tmp_mtx, 1)
+        tmp_mtx[i,i] -= 1.0
+    end
+    other_parents_centered = tmp_mtx *
             view(parents_centered, :, 2:length(parentIndices))
     sd = mean(map(sqrt, sumabs2(other_parents_centered, 2)))
     if sd > 1E-8

--- a/src/genetic_operators/genetic_operator.jl
+++ b/src/genetic_operators/genetic_operator.jl
@@ -43,8 +43,8 @@ apply{T <: Real}(o::MutationOperator, parents::Vector{Vector{T}}) = map(p -> app
 numchildren(o::GeneticOperator) = 1
 numparents(o::MutationOperator) = 1 # But it will apply to each parent separately if given more than one...
 
-numparents{NP,NC}(o::CrossoverOperator{NP,NC}) = NP
-numchildren{NP,NC}(o::CrossoverOperator{NP,NC}) = NC
+numparents{NP,NC}(o::CrossoverOperator{NP,NC}) = NP::Int
+numchildren{NP,NC}(o::CrossoverOperator{NP,NC}) = NC::Int
 
 numparents(o::EmbeddingOperator) = 1
 numchildren(o::EmbeddingOperator) = 1

--- a/src/opt_controller.jl
+++ b/src/opt_controller.jl
@@ -9,11 +9,7 @@ function make_evaluator(problem::OptimizationProblem, archive=nothing, params::P
         archive = TopListArchive(fitness_scheme(problem), numdims(problem), archiveCapacity)
     end
     if length(workers) > 0
-        if BlackBoxOptim.enable_parallel_methods
-            return ParallelEvaluator(problem, archive, pids=workers)
-        else
-            throw(SystemError("Parallel evaluation disabled"))
-        end
+        return ParallelEvaluator(problem, archive, pids=workers)
     else
         return ProblemEvaluator(problem, archive)
     end

--- a/src/parameters.jl
+++ b/src/parameters.jl
@@ -19,16 +19,16 @@ DictChain{K,V}(dict::Associative{K,V}) = DictChain{K,V}(dict)
 DictChain{K,V}(dict1::Associative{K,V}, dict2::Associative{K,V}) = DictChain{K,V}(dict1, dict2)
 DictChain{K,V}(dict1::Associative{K,V}, dict2::Associative{K,V}, dict3::Associative{K,V}) = DictChain{K,V}(dict1, dict2, dict3)
 
-function Base.show{K,V}(io::IO, dc::DictChain{K,V})
+function Base.show(io::IO, dc::DictChain)
   print(io, typeof(dc), "[")
   for (i, dict) in enumerate(dc.dicts)
-    if i > 1
-      print(",")
-    end
+    (i > 1) && print(io, ",")
     show(io, dict)
   end
   print(io, "]")
 end
+
+Base.show(io::IO, ::MIME{Symbol("text/plain")}, dc::DictChain) = show(io, dc)
 
 function Base.getindex{K,V}(p::DictChain{K,V}, key)
   for d in p.dicts

--- a/src/parameters.jl
+++ b/src/parameters.jl
@@ -30,7 +30,7 @@ function Base.show{K,V}(io::IO, dc::DictChain{K,V})
   print(io, "]")
 end
 
-function Base.getindex{K,V}(p::DictChain{K,V}, key::K)
+function Base.getindex{K,V}(p::DictChain{K,V}, key)
   for d in p.dicts
     if haskey(d, key)
       return getindex(d, key)
@@ -39,14 +39,14 @@ function Base.getindex{K,V}(p::DictChain{K,V}, key::K)
   throw(KeyError(key))
 end
 
-function Base.setindex!{K,V}(p::DictChain{K,V}, value::V, key::K)
+function Base.setindex!{K,V}(p::DictChain{K,V}, value, key)
   if isempty(p.dicts)
     push!(p.dicts, Dict{K,V}()) # add new dictionary on top
   end
   setindex!(first(p.dicts), value, key)
 end
 
-function Base.haskey{K,V}(p::DictChain{K,V}, key::K)
+function Base.haskey{K,V}(p::DictChain{K,V}, key)
   for d in p.dicts
     if haskey(d, key)
       return true
@@ -55,7 +55,7 @@ function Base.haskey{K,V}(p::DictChain{K,V}, key::K)
   return false
 end
 
-function Base.get{K,V}(p::DictChain{K,V}, key::K, default = nothing)
+function Base.get{K,V}(p::DictChain{K,V}, key, default = nothing)
   return haskey(p, key) ? getindex(p, key) : default
 end
 
@@ -90,7 +90,7 @@ flatten{K,V}(d::DictChain{K,V}) = convert(Dict{K,V}, d)
 
 Base.convert{K,V}(::Type{Dict{K,V}}, dc::DictChain{K,V}) = merge!(Dict{K,V}(), dc)
 
-function Base.delete!{K,V}(p::DictChain{K,V}, key::K)
+function Base.delete!{K,V}(p::DictChain{K,V}, key)
   for d in p.dicts
     delete!(d, key)
   end

--- a/src/population.jl
+++ b/src/population.jl
@@ -146,7 +146,7 @@ acquire_candis{F}(pop::FitPopulation{F}, n::Integer) =
 # Get an individual from a pool and sets it to ix-th individual from population.
 function acquire_candi(pop::FitPopulation, ix::Int)
     x = acquire_candi(pop)
-    x.params[:] = pop[ix] # FIXME might be suboptimal until Julia has array refs
+    copy!(x.params, viewer(pop, ix))
     x.index = ix
     x.fitness = fitness(pop, ix)
     return x

--- a/src/problem.jl
+++ b/src/problem.jl
@@ -56,7 +56,7 @@ objfunc(p::FunctionBasedProblem) = p.objfunc
 fitness(x, p::FunctionBasedProblem) = objfunc(p)(x)
 
 Base.copy(p::FunctionBasedProblem) =
-  FunctionBasedProblem(copy(p.objfunc), copy(p.name), p.fitness_scheme, p.ss, p.opt_value)
+  FunctionBasedProblem(deepcopy(p.objfunc), deepcopy(p.name), p.fitness_scheme, p.ss, p.opt_value)
 
 opt_value(p::FunctionBasedProblem) = p.opt_value
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,3 +1,5 @@
+module BlackBoxOptimTests
+
 startclocktime = time()
 include("helper.jl")
 
@@ -107,3 +109,5 @@ end
 
 elapsedclock = time() - startclocktime
 println("Tested $(numtestfiles) files in $(round(elapsedclock, 1)) seconds.")
+
+end # module BlackBoxOptimTests

--- a/test/test_bimodal_cauchy_distribution.jl
+++ b/test/test_bimodal_cauchy_distribution.jl
@@ -1,25 +1,31 @@
 @testset "Bimodal Cauchy Distributions" begin
 
-    @testset "sample bimodal cauchy with truncation on one side" begin
-        bc = BlackBoxOptim.bimodal_cauchy(0.65, 0.1, 1.0, 0.1)
+    @testset "sample bimodal cauchy with truncation above 1" begin
+        bc = BlackBoxOptim.BimodalCauchy(0.65, 0.1, 1.0, 0.1, clampBelow0=false)
 
-        for i in 1:100
-            v = BlackBoxOptim.sample_bimodal_cauchy(bc; truncateAbove1 = true, truncateBelow0 = false)
-
-            @test v <= 1.0
-            @test v > 0.0 # Very unlikely to be 0.0 so should be ok...
+        n_gt0 = 0
+        n_le1 = 0
+        for _ in 1:10000
+            v = rand(bc)
+            (v > 0.0) && (n_gt0 += 1) # Very unlikely to be 0.0 so should be ok...
+            (v <= 1.0) && (n_le1 += 1)
         end
+        @test n_gt0 == 10000
+        @test n_le1 == 10000
     end
 
-    @testset "sample bimodal cauchy with truncation on both sides" begin
-        bc = BlackBoxOptim.bimodal_cauchy(0.1, 0.1, 0.95, 0.1)
+    @testset "sample bimodal cauchy with truncation below 0 and above 1" begin
+        bc = BlackBoxOptim.BimodalCauchy(0.1, 0.1, 0.95, 0.1)
 
-        for i in 1:100
-            v = BlackBoxOptim.sample_bimodal_cauchy(bc; truncateAbove1 = true, truncateBelow0 = true)
-
-            @test v <= 1.0
-            @test v >= 0.0
+        n_ge0 = 0
+        n_le1 = 0
+        for _ in 1:10000
+            v = rand(bc)
+            (v >= 0.0) && (n_ge0 += 1)
+            (v <= 1.0) && (n_le1 += 1)
         end
+        @test n_ge0 == 10000
+        @test n_le1 == 10000
     end
 
 end

--- a/test/test_crossover_operators.jl
+++ b/test/test_crossover_operators.jl
@@ -62,4 +62,15 @@ DE = de_rand_1_bin(fake_problem, ParamsDict(
     end
 end
 
+@testset "MutationWrapper" begin
+    ss = symmetric_search_space(2, (0.0, 10.0))
+    pop = reshape(collect(1.0:8.0), 2, 4)
+    gibbs = UniformMutation(ss)
+    gibbs_wrapper = BlackBoxOptim.MutationWrapper(gibbs)
+    @test numchildren(gibbs_wrapper) == 1
+    @test numparents(gibbs_wrapper) == 1
+    mut_res = BlackBoxOptim.apply!(gibbs_wrapper, [0.0, 0.0], 1, pop, [2])
+    @test sum(mut_res .== BlackBoxOptim.viewer(pop, 2)) == 0
+end
+
 end

--- a/test/test_crossover_operators.jl
+++ b/test/test_crossover_operators.jl
@@ -9,7 +9,7 @@ DE = de_rand_1_bin(fake_problem, ParamsDict(
 @testset "DiffEvoRandBin1" begin
     @testset "always copies from donor if length is 1" begin
         @test BlackBoxOptim.apply!(BlackBoxOptim.DiffEvoRandBin1(0.0, 0.0),
-                                                            [0.0], 4, DE.population, [1,2,3]) == [3.0]
+                                   [0.0], 4, DE.population, [1,2,3]) == [3.0]
     end
 
     @testset "always copies at least one element from donor" begin
@@ -19,7 +19,7 @@ DE = de_rand_1_bin(fake_problem, ParamsDict(
             target = pop[:,1]
             saved_target = copy(target)
             res = BlackBoxOptim.apply!(BlackBoxOptim.DiffEvoRandBin1(0.0, 0.0),
-                                                                target, 1, pop, [2,3,4])
+                                       target, 1, pop, [2,3,4])
             @test (res === target)
             @test ndims( res ) == 1
             @test length( res ) == len
@@ -34,7 +34,7 @@ DE = de_rand_1_bin(fake_problem, ParamsDict(
             target = pop[:,1]
             saved_target = copy(target)
             res = BlackBoxOptim.apply!(BlackBoxOptim.DiffEvoRandBin1(0.1, 0.5),
-                                                                target, 1, pop, [2,3,4])
+                                       target, 1, pop, [2,3,4])
             @test any(target .!= saved_target)
             @test any(target .== saved_target)
         end
@@ -55,10 +55,10 @@ DE = de_rand_1_bin(fake_problem, ParamsDict(
         pop2 = reshape(collect(1.0:8.0), 4, 2)'
         @test BlackBoxOptim.apply!( BlackBoxOptim.DiffEvoRandBin1(1.0, 0.6),
                                                                 [0.0,0.0], 4, pop2, [1,2,3]) == [3.0 + (0.6 * (1.0 - 2.0)),
-                                                                                                                                7.0 + (0.6 * (5.0 - 6.0))]
+                                                                                                 7.0 + (0.6 * (5.0 - 6.0))]
         @test BlackBoxOptim.apply!( BlackBoxOptim.DiffEvoRandBin1(1.0, 0.6),
                                                                 [0.0,0.0], 4, pop2, [1,2,4]) == [4.0 + (0.6 * (1.0 - 2.0)),
-                                                                                                                                8.0 + (0.6 * (5.0 - 6.0))]
+                                                                                                 8.0 + (0.6 * (5.0 - 6.0))]
     end
 end
 

--- a/test/test_evaluator.jl
+++ b/test/test_evaluator.jl
@@ -75,10 +75,8 @@ end
         @test sortperm(candidates, by = fitness) == collect(1:10)
     end
 
-if BlackBoxOptim.enable_parallel_methods
     @testset "ParallelEvaluator" begin
         evaluator_tests(() -> BlackBoxOptim.ParallelEvaluator(p, pids=workers()))
     end
-end
 
 end

--- a/test/test_parameters.jl
+++ b/test/test_parameters.jl
@@ -150,8 +150,8 @@ end
 
     @testset "With parameters in multiple sets" begin
         ps = ParamsDictChain(ParamsDict(:a => 1, :c => 4),
-                                                ParamsDict(:a => 2, :b => 3),
-                                                ParamsDict(:c => 5))
+                             ParamsDict(:a => 2, :b => 3),
+                             ParamsDict(:c => 5))
         @test isa(ps, Parameters)
 
         @test ps[:a] == 1
@@ -164,8 +164,8 @@ end
 
     @testset "Updating parameters after construction" begin
         ps = ParamsDictChain(ParamsDict(:a => 1, :c => 4),
-                                                ParamsDict(:a => 2, :b => 3),
-                                                ParamsDict(:c => 5))
+                             ParamsDict(:a => 2, :b => 3),
+                             ParamsDict(:c => 5))
 
         ps[:c] = 6
         ps[:b] = 7
@@ -177,9 +177,9 @@ end
 
     @testset "Constructing from another parameters object" begin
         ps1 = ParamsDictChain(ParamsDict(:a => 1, :c => 4),
-                                                    ParamsDict(:a => 2, :b => 3))
+                              ParamsDict(:a => 2, :b => 3))
         ps2 = ParamsDictChain(ParamsDict(:a => 5), ps1,
-                                                    ParamsDict(:c => 6))
+                              ParamsDict(:c => 6))
 
         @test ps1[:a] == 1
         @test ps2[:a] == 5
@@ -188,7 +188,7 @@ end
 
     @testset "Get key without default" begin
         ps = ParamsDictChain(ParamsDict(:a => 1, :c => 4),
-                                                ParamsDict(:a => 2, :b => 3))
+                             ParamsDict(:a => 2, :b => 3))
         @test get(ps, :a) == 1
         @test get(ps, :b) == 3
         @test get(ps, :d) == nothing
@@ -196,13 +196,13 @@ end
 
     @testset "Get key with default" begin
         ps = ParamsDictChain(ParamsDict(:a => 1, :c => 4),
-                                                ParamsDict(:a => 2, :b => 3))
+                             ParamsDict(:a => 2, :b => 3))
         @test get(ps, :d, 10) == 10
     end
 
     @testset "Merge with Parameters or Dict" begin
         ps = ParamsDictChain(ParamsDict(:a => 1, :c => 4),
-                                                ParamsDict(:a => 2, :b => 3))
+                             ParamsDict(:a => 2, :b => 3))
         ps2 = chain(ps, ParamsDict(:d => 5, :a => 20))
         @test ps2[:d] == 5
         @test ps2[:b] == 3

--- a/test/test_parameters.jl
+++ b/test/test_parameters.jl
@@ -106,10 +106,9 @@
         d3 = Dict{Symbol,Int}(:a => 3, :b => 5)
 
         dc = DictChain(d1, d2, d3)
-        #iob = IOBuffer()
-        #show(iob, dc) # should output to DevNull, but looks like it's broken currently
-        #@show takebuf_string(iob)
-        #@test takebuf_string(io) == "BlackBoxOptim.DictChain{Symbol,Int64}[Dict(:a=>1),Dict(:a=>2,:b=>4),Dict(:a=>3,:b=>5)]"
+        iob = IOBuffer()
+        show(iob, dc)
+        @test takebuf_string(iob) == "BlackBoxOptim.DictChain{Symbol,Int64}[Dict(:a=>1),Dict(:a=>2,:b=>4),Dict(:a=>3,:b=>5)]"
     end
 
     @testset "flatten" begin

--- a/test/test_parameters.jl
+++ b/test/test_parameters.jl
@@ -1,9 +1,10 @@
 @testset "DictChain" begin
-    @testset "Matching keys and type parameters" begin
+    @testset "Matching keys and value types for get()/set() methods" begin
         dc1 = DictChain{Int,String}()
 
-        # Actually throws MethodError: @test_throws KeyError (dc1[:NotThere] = 3)
-        # Actually throws MethodError: @test_throws KeyError (dc1[:NotThere] = "abc")
+        @test_throws KeyError dc1[:NotThere]
+        @test_throws MethodError (dc1[:NotThere] = 3)
+        @test_throws MethodError (dc1[:NotThere] = "abc")
         @test_throws MethodError (dc1[3] = 3)
 
         dc1[3] = "abc"
@@ -131,7 +132,7 @@ end
         ps = ParamsDictChain()
         @test isa(ps, Parameters)
         @test_throws KeyError ps[:NotThere]
-        @test_throws MethodError ps["Neither there"]
+        @test_throws KeyError ps["Neither there"]
 
         ps[:a] = 1
         @test ps[:a] == 1
@@ -142,7 +143,7 @@ end
         @test isa(ps, Parameters)
 
         @test ps[:a] == 1
-        @test_throws MethodError ps["a"] # incorrect key
+        @test_throws KeyError ps["a"] # incorrect key
 
         @test_throws KeyError ps[:A]
         @test_throws KeyError ps[:B]

--- a/test/test_population.jl
+++ b/test/test_population.jl
@@ -11,6 +11,30 @@
         @test isnafitness(fitness(p1, 1), fs)
         @test isnafitness(fitness(p1, 4), fs)
 
+        @testset "accessing individuals" begin
+    		@test isa(p1[1], Vector{Float64})
+            @test length(p1[1]) == numdims(p1)
+            @test isa(BlackBoxOptim.viewer(p1, 1), AbstractVector{Float64})
+            @test length(BlackBoxOptim.viewer(p1, 1)) == numdims(p1)
+
+            @test isa(p1[popsize(p1)], Vector{Float64}) # last solution vector
+            @test_throws BoundsError p1[0]
+            @test_throws BoundsError p1[popsize(p1)+1]
+            @test_throws BoundsError BlackBoxOptim.viewer(p1, 0)
+            @test_throws BoundsError BlackBoxOptim.viewer(p1, popsize(p1)+1)
+            rand_solution_idx = rand(2:(popsize(p1)-1))
+            @test isa(p1[rand_solution_idx], Array{Float64, 1}) # random solution vector
+        end
+
+        @testset "accessing individuals fitness" begin
+            # and to access their fitness values:
+            @test isa(fitness(p1, 1), Float64)
+            @test isa(fitness(p1, popsize(p1)), Float64)
+            rand_solution_idx = rand(2:(popsize(p1)-1))
+            @test_throws BoundsError fitness(p1, 0)
+            @test_throws BoundsError fitness(p1, popsize(p1)+1)
+        end
+
         @testset "candidates pool" begin
             @test BlackBoxOptim.candi_pool_size(p1) == 0
             candi1 = BlackBoxOptim.acquire_candi(p1, 1)

--- a/test/test_search_space.jl
+++ b/test/test_search_space.jl
@@ -5,7 +5,7 @@
             ss1 = symmetric_search_space(reps, (0.0, 1.0))
             ind = rand_individual(ss1)
             for j in 1:reps
-                @test (mins(ss1)[j] <= ind[j] <= maxs(ss1)[j]) 
+                @test (mins(ss1)[j] <= ind[j] <= maxs(ss1)[j])
             end
         end
     end
@@ -80,7 +80,7 @@
     end
 
     @testset "rand_individuals correctly handles column-wise generation in assymetric search spaces" begin
-        for i in 1:NumTestRepetitions÷10
+        for _ in 1:NumTestRepetitions÷10
             numdimensions = rand(1:13)
             minbounds = rand(numdimensions)
             ds = rand(1:10, numdimensions) .* rand(numdimensions)
@@ -94,7 +94,7 @@
             # Now generate 100 individuals and make sure they are all within bounds
             inds = rand_individuals(ss, 100)
             @test size(inds, 2) == 100
-            for i in 1:size(inds, 2)
+            @inbounds for i in 1:size(inds, 2)
                 for d in 1:numdimensions
                     @test (minbounds[d] <= inds[d,i] <= maxbounds[d])
                 end

--- a/test/test_toplevel_bboptimize.jl
+++ b/test/test_toplevel_bboptimize.jl
@@ -68,7 +68,6 @@
             @test (min_fitness_value == best_fitness(res))
         end
 
-if BlackBoxOptim.enable_parallel_methods
         @testset "using population optimizer and parallel evaluator" begin
             opt = bbsetup(rosenbrock; Method=:adaptive_de_rand_1_bin,
                                         SearchRange = (-5.0, 5.0), NumDimensions = 2,
@@ -76,7 +75,6 @@ if BlackBoxOptim.enable_parallel_methods
             res = bboptimize(opt)
             @test isa(BlackBoxOptim.evaluator(lastrun(opt)), BlackBoxOptim.ParallelEvaluator)
         end
-end
 
     end
 


### PR DESCRIPTION
Some performance optimizations for Borg based on the quick look at profiling and `@code_warntype`. I hope to detect more bottlenecks and update this PR.

It looks like some Julia codegen optimizations are broken on v0.5, several people reported ~x5 slowdowns (see e.g. JuliaLang/julia#18129 JuliaLang/julia#18135). BBO might suffer from this as well, but I'm not sure what is the most effective (and automated) way to detect and isolate such issues.