### PR TITLE
Drop 0.4, fix 0.6 Julia support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,8 @@ os:
   - linux
   - osx
 julia:
-  - 0.4
   - 0.5
+  - 0.6
   - nightly
 matrix:
   allow_failures:

--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@ BlackBoxOptim.jl
 
 [![Coverage Status](https://coveralls.io/repos/robertfeldt/BlackBoxOptim.jl/badge.png?branch=master)](https://coveralls.io/r/robertfeldt/BlackBoxOptim.jl?branch=master)
 
-[![BlackBoxOptim](http://pkg.julialang.org/badges/BlackBoxOptim_0.4.svg)](http://pkg.julialang.org/?pkg=BlackBoxOptim)
-
 [![BlackBoxOptim](http://pkg.julialang.org/badges/BlackBoxOptim_0.5.svg)](http://pkg.julialang.org/?pkg=BlackBoxOptim)
+
+[![BlackBoxOptim](http://pkg.julialang.org/badges/BlackBoxOptim_0.6.svg)](http://pkg.julialang.org/?pkg=BlackBoxOptim)
 
 # Installation
 ```julia

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,5 +1,4 @@
-julia 0.4
-BaseTestNext
+julia 0.5
 StatsBase
 Distributions
 Compat 0.7.9

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,5 +1,5 @@
 julia 0.5
 StatsBase
 Distributions
-Compat 0.7.9
+Compat 0.18
 CPUTime

--- a/spikes/adaptive_encoding.jl
+++ b/spikes/adaptive_encoding.jl
@@ -1,4 +1,4 @@
-abstract CoordinateTransform
+@compat abstract type CoordinateTransform end
 
 # Based on the pseudo-code on page 156 in Loschchilov's PhD Thesis from 2013.
 type AdaptiveEncoding <: CoordinateTransform

--- a/spikes/auc_bandit_adaptive_selection.jl
+++ b/spikes/auc_bandit_adaptive_selection.jl
@@ -8,7 +8,7 @@
 # operators, values etc. It does not have any info about what the things it selects
 # between are, below we call them items. The set of items the selector selects
 # from is typically static but might not be.
-abstract AdaptiveSelector
+@compat abstract type AdaptiveSelector end
 
 # The default AdaptiveSelector is a random selector.
 type RandomSelector <: AdaptiveSelector

--- a/spikes/cec14_exp1_tune_one_run_cmsa_es/cec_cmsa_es.jl
+++ b/spikes/cec14_exp1_tune_one_run_cmsa_es/cec_cmsa_es.jl
@@ -165,7 +165,7 @@ end
 
 # We create different types of Covariance matrix samplers based on different
 # decompositions.
-abstract CovarianceMatrixSampler
+@compat abstract type CovarianceMatrixSampler end
 
 function update_covariance_matrix!(cms::CovarianceMatrixSampler, delta, a)
   C = a * cms.C + (1 - a) * delta

--- a/spikes/covar_matrix_self_adaptation_es.jl
+++ b/spikes/covar_matrix_self_adaptation_es.jl
@@ -300,7 +300,7 @@ end
 
 # We create different types of Covariance matrix samplers based on different
 # decompositions.
-abstract CovarianceMatrixSampler
+@compat abstract type CovarianceMatrixSampler end
 
 function update_covariance_matrix!(cms::CovarianceMatrixSampler, delta, a)
   C = a * cms.C + (1 - a) * delta

--- a/spikes/evolutionary_programming.jl
+++ b/spikes/evolutionary_programming.jl
@@ -11,7 +11,7 @@ PopulationBasedEvolutionaryProgrammingDefaultParameters = {
 # datum while the generic population-based EP is kept in a single type. This
 # way we can easily change the strategy without having to rewrite the common parts
 # throughout.
-abstract EvolutionaryProgrammingStrategy
+@compat abstract type EvolutionaryProgrammingStrategy end
 
 type PopulationBasedEvolutionaryProgramming <: PopulationOptimizer
   parameters::Parameters

--- a/spikes/generating_set_search.jl
+++ b/spikes/generating_set_search.jl
@@ -1,6 +1,6 @@
 # A direction generator generates the search directions to use at each step of
 # a GSS search.
-abstract DirectionGenerator
+@compat abstract type DirectionGenerator end
 
 type ConstantDirectionGen <: DirectionGenerator
   directions::Array{Float64, 2}

--- a/spikes/mesh_adaptive_direct_search.jl
+++ b/spikes/mesh_adaptive_direct_search.jl
@@ -1,4 +1,4 @@
-abstract MeshAdaptiveDirectSearch
+@compat abstract type MeshAdaptiveDirectSearch end
 
 type LTMADS <: MeshAdaptiveDirectSearch
   n::Int

--- a/spikes/nlopt_highdim.jl
+++ b/spikes/nlopt_highdim.jl
@@ -3,7 +3,7 @@ using DataFrames
 
 include(joinpath("..", "src", "problems", "single_objective_base_functions.jl"))
 
-abstract Evaluator
+@compat abstract type Evaluator end
 
 type NonGradientEvaluator <: Evaluator
   func::Function

--- a/spikes/subset_tournament_cmsa_es/subset_tournament_cmsa_es.jl
+++ b/spikes/subset_tournament_cmsa_es/subset_tournament_cmsa_es.jl
@@ -286,7 +286,7 @@ end
 
 # We create different types of Covariance matrix samplers based on different
 # decompositions.
-abstract CovarianceMatrixSampler
+@compat abstract type CovarianceMatrixSampler end
 
 function update_covariance_matrix!(cms::CovarianceMatrixSampler, delta, a)
   C = a * cms.C + (1 - a) * delta

--- a/src/adaptive_differential_evolution.jl
+++ b/src/adaptive_differential_evolution.jl
@@ -34,14 +34,14 @@ end
 AdaptiveDiffEvoParameters(options::Parameters) = AdaptiveDiffEvoParameters(options[:fdistr], options[:crdistr])
 
 function crossover_parameters(params::AdaptiveDiffEvoParameters, pop::Population, target_index)
-  # initialize the f & cr array
-  if isempty(params.fs)
-    params.fs = [rand(params.fdistr) for _ in 1:popsize(pop)]
-  end
-  if isempty(params.crs)
-    params.crs = [rand(params.crdistr) for _ in 1:popsize(pop)]
-  end
-  return (params.crs[target_index], params.fs[target_index])
+    # initialize the f & cr array
+    if isempty(params.fs)
+        params.fs = rand!(params.fdistr, Vector{Float64}(popsize(pop)))
+    end
+    if isempty(params.crs)
+        params.crs = rand!(params.crdistr, Vector{Float64}(popsize(pop)))
+    end
+    return (params.crs[target_index], params.fs[target_index])
 end
 
 function adjust!(params::AdaptiveDiffEvoParameters, index, is_improved::Bool)

--- a/src/adaptive_differential_evolution.jl
+++ b/src/adaptive_differential_evolution.jl
@@ -46,9 +46,9 @@ end
 
 function adjust!(params::AdaptiveDiffEvoParameters, index, is_improved::Bool)
     if !is_improved
-      # The trial vector for this target was not better so we change the f and cr constants.
-      params.fs[index] = rand(params.fdistr)
-      params.crs[index] = rand(params.crdistr)
+        # The trial vector for this target was not better so we change the f and cr constants.
+        @inbounds params.fs[index] = rand(params.fdistr)
+        @inbounds params.crs[index] = rand(params.crdistr)
     end
 end
 

--- a/src/adaptive_differential_evolution.jl
+++ b/src/adaptive_differential_evolution.jl
@@ -70,8 +70,8 @@ adjust!{F}(xover::AdaptiveDiffEvoRandBin, op_index::Int, candi_index::Int,
                  new_fitness::F, old_fitness::F, is_improved::Bool) =
     adjust!(xover.params, candi_index, is_improved)
 
-typealias AdaptiveDiffEvoRandBin1 AdaptiveDiffEvoRandBin{3}
-typealias AdaptiveDiffEvoRandBin2 AdaptiveDiffEvoRandBin{5}
+@compat const AdaptiveDiffEvoRandBin1 = AdaptiveDiffEvoRandBin{3}
+@compat const AdaptiveDiffEvoRandBin2 = AdaptiveDiffEvoRandBin{5}
 
 function adaptive_diffevo(problem::OptimizationProblem,
                  options::Parameters, name::String,

--- a/src/archive.jl
+++ b/src/archive.jl
@@ -2,7 +2,7 @@
   `Archive` saves information about promising solutions during an optimization
   run.
 """
-abstract Archive{F,FS<:FitnessScheme}
+@compat abstract type Archive{F,FS<:FitnessScheme} end
 
 numdims(a::Archive) = a.numdims
 fitness_type{F}(a::Archive{F}) = F
@@ -18,7 +18,7 @@ archived_fitness(fit::Any, a::Archive) = convert(fitness_type(a), fit, fitness_s
 """
     Base class for individuals stored in `Archive`.
 """
-abstract ArchivedIndividual{F} <: FitIndividual{F}
+@compat abstract type ArchivedIndividual{F} <: FitIndividual{F} end
 
 tag(indi::ArchivedIndividual) = indi.tag
 

--- a/src/archive.jl
+++ b/src/archive.jl
@@ -30,11 +30,11 @@ immutable TopListIndividual{F} <: ArchivedIndividual{F}
     fitness::F
     tag::Int
 
-    @compat (::Type{TopListIndividual}){F}(params::AbstractIndividual, fitness::F, tag::Int) =
+    (::Type{TopListIndividual}){F}(params::AbstractIndividual, fitness::F, tag::Int) =
         new{F}(params, fitness, tag)
 end
 
-@compat Base.:(==){F}(x::TopListIndividual{F}, y::TopListIndividual{F}) =
+Base.:(==){F}(x::TopListIndividual{F}, y::TopListIndividual{F}) =
   (x.fitness == y.fitness) && (x.params == y.params)
 
 " Fitness as stored in `TopListArchive`. "
@@ -71,7 +71,7 @@ type TopListArchive{F<:Number,FS<:FitnessScheme} <: Archive{F,FS}
   # class is: `(magnitude_class, time, num_fevals, fitness, width_of_confidence_interval)`
   fitness_history::Vector{TopListFitness{F}}
 
-  @compat function (::Type{TopListArchive}){FS<:FitnessScheme}(fit_scheme::FS, numdims::Integer, capacity::Integer = 10)
+  function (::Type{TopListArchive}){FS<:FitnessScheme}(fit_scheme::FS, numdims::Integer, capacity::Integer = 10)
     F = fitness_type(FS)
     new{F,FS}(fit_scheme, time(), numdims, 0, capacity, TopListIndividual{F}[], TopListFitness{F}[])
   end

--- a/src/archives/epsbox_archive.jl
+++ b/src/archives/epsbox_archive.jl
@@ -13,7 +13,7 @@ immutable FrontierIndividual{F} <: ArchivedIndividual{F}
                    params, tag, num_fevals, n_restarts, timestamp=time()) =
         new(fitness, params, tag, num_fevals, n_restarts, timestamp)
 
-    @compat (::Type{FrontierIndividual}){F}(fitness::F,
+    (::Type{FrontierIndividual}){F}(fitness::F,
                    params, tag, num_fevals, n_restarts, timestamp=time()) =
         new{F}(fitness, params, tag, num_fevals, n_restarts, timestamp)
 end
@@ -25,7 +25,7 @@ tag(indi::FrontierIndividual) = indi.tag
 """
 typealias EpsBoxFrontierIndividual{N,F<:Number} FrontierIndividual{IndexedTupleFitness{N,F}}
 
-@compat (::Type{EpsBoxFrontierIndividual}){N,F}(fitness::IndexedTupleFitness{N,F},
+(::Type{EpsBoxFrontierIndividual}){N,F}(fitness::IndexedTupleFitness{N,F},
                params, tag, num_fevals, n_restarts, timestamp=time()) =
     FrontierIndividual(fitness, params, tag, num_fevals, n_restarts, timestamp)
 
@@ -53,13 +53,13 @@ type EpsBoxArchive{N,F,FS<:EpsBoxDominanceFitnessScheme} <: Archive{IndexedTuple
   frontier::Vector{EpsBoxFrontierIndividual{N,F}}  # candidates along the fitness Pareto frontier
   frontier_isoccupied::BitVector # true if given frontier element is occupied
 
-  @compat function (::Type{EpsBoxArchive}){N,F}(fit_scheme::EpsBoxDominanceFitnessScheme{N,F}; max_size::Integer = 1_000_000)
+  function (::Type{EpsBoxArchive}){N,F}(fit_scheme::EpsBoxDominanceFitnessScheme{N,F}; max_size::Integer = 1_000_000)
     new{N,F,typeof(fit_scheme)}(fit_scheme, time(), 0, 0, 0, 0, 0, 0, max_size,
                                 sizehint!(Vector{EpsBoxFrontierIndividual{N,F}}(), 64),
                                 sizehint!(BitVector(), 64))
   end
 
-  @compat (::Type{EpsBoxArchive}){N,F}(fit_scheme::EpsBoxDominanceFitnessScheme{N,F}, params::Parameters) =
+  (::Type{EpsBoxArchive}){N,F}(fit_scheme::EpsBoxDominanceFitnessScheme{N,F}, params::Parameters) =
     EpsBoxArchive(fit_scheme, max_size=params[:MaxArchiveSize])
 end
 
@@ -77,7 +77,7 @@ numdims(a::EpsBoxArchive) = !isempty(a.frontier) ? length(a.frontier[1].params) 
 """
 immutable EpsBoxArchiveFrontierIterator{A<:EpsBoxArchive}
     archive::A
-    @compat (::Type{EpsBoxArchiveFrontierIterator}){A<:EpsBoxArchive}(a::A) = new{A}(a)
+    (::Type{EpsBoxArchiveFrontierIterator}){A<:EpsBoxArchive}(a::A) = new{A}(a)
 end
 
 @inline Base.length(it::EpsBoxArchiveFrontierIterator) = length(it.archive)

--- a/src/archives/epsbox_archive.jl
+++ b/src/archives/epsbox_archive.jl
@@ -23,7 +23,7 @@ tag(indi::FrontierIndividual) = indi.tag
 """
     Individual stored in `EpsBoxArchive`.
 """
-typealias EpsBoxFrontierIndividual{N,F<:Number} FrontierIndividual{IndexedTupleFitness{N,F}}
+@compat const EpsBoxFrontierIndividual{N,F<:Number} = FrontierIndividual{IndexedTupleFitness{N,F}}
 
 (::Type{EpsBoxFrontierIndividual}){N,F}(fitness::IndexedTupleFitness{N,F},
                params, tag, num_fevals, n_restarts, timestamp=time()) =

--- a/src/bimodal_cauchy_distribution.jl
+++ b/src/bimodal_cauchy_distribution.jl
@@ -33,3 +33,10 @@ function Base.rand(distr::BimodalCauchy)
         end
     end
 end
+
+function Base.rand!(distr::BimodalCauchy, A::AbstractArray)
+    for i in eachindex(A)
+        @inbounds A[i] = rand(distr)
+    end
+    return A
+end

--- a/src/bimodal_cauchy_distribution.jl
+++ b/src/bimodal_cauchy_distribution.jl
@@ -23,7 +23,7 @@ end
 
 function Base.rand(distr::BimodalCauchy)
     while true
-        value = rand(rand() < distr.mix_prob ? distr.a : distr.b)
+        value = rand() < distr.mix_prob ? rand(distr.a) : rand(distr.b)
         if value >= 1.0
             distr.clampAbove1 && return 1.0
         elseif value <= 0.0

--- a/src/borg_moea.jl
+++ b/src/borg_moea.jl
@@ -36,7 +36,7 @@ type BorgMOEA{FS<:FitnessScheme,V<:Evaluator,P<:Population,M<:GeneticOperator,E<
   modify::M         # operator to mutate frontier element during restarts
   embed::E          # embedding operator
 
-  @compat function (::Type{BorgMOEA}){O<:OptimizationProblem, P<:Population,
+  function (::Type{BorgMOEA}){O<:OptimizationProblem, P<:Population,
                      M<:GeneticOperator, E<:EmbeddingOperator}(
         problem::O,
         pop::P, recombinate::Vector{CrossoverOperator},

--- a/src/differential_evolution.jl
+++ b/src/differential_evolution.jl
@@ -17,7 +17,7 @@ type DiffEvoOpt{P<:Population,S<:IndividualsSelector,M<:GeneticOperator,E<:Embed
   modify::M        # genetic operator
   embed::E         # embedding operator
 
-  @compat function (::Type{DiffEvoOpt}){P<:Population, S<:IndividualsSelector,
+  function (::Type{DiffEvoOpt}){P<:Population, S<:IndividualsSelector,
                      M<:GeneticOperator, E<:EmbeddingOperator}(
         name::String, pop::P,
         select::S = S(), modify::M = M(), embed::E = E())

--- a/src/direct_search_with_probabilistic_descent.jl
+++ b/src/direct_search_with_probabilistic_descent.jl
@@ -12,7 +12,7 @@
 """
 function sample_unit_hypersphere(n, num = 1)
   X = randn(n, num)
-  sqrootsums = 1 ./ sqrt(sum( X.^2, 1 ))
+  sqrootsums = 1 ./ sqrt.(sum(abs2, X, 1))
   broadcast(*, sqrootsums, X)
 end
 

--- a/src/dx_nes.jl
+++ b/src/dx_nes.jl
@@ -54,7 +54,7 @@ type DXNESOpt{F,E<:EmbeddingOperator} <: ExponentialNaturalEvolutionStrategyOpt
       moving_threshold, evol_discount, evol_Zscale, 0.9 + 0.15 * log(d),
       zeros(d), ini_lnB === nothing ? ini_xnes_B(search_space(embed)) : ini_lnB, ini_sigma, ini_x,
       zeros(d, lambda),
-      Candidate{F}[Candidate{F}(Array(Float64, d), i) for i in 1:lambda],
+      Candidate{F}[Candidate{F}(Vector{Float64}(d), i) for i in 1:lambda],
       # temporaries
       zeros(d), zeros(d), zeros(d),
       zeros(d, d),

--- a/src/evaluator.jl
+++ b/src/evaluator.jl
@@ -28,12 +28,12 @@ type ProblemEvaluator{FP, FA, A<:Archive, P<:OptimizationProblem} <: Evaluator{P
   num_evals::Int
   last_fitness::FP
 
-  @compat (::Type{ProblemEvaluator}){P<:OptimizationProblem, A<:Archive}(
+  (::Type{ProblemEvaluator}){P<:OptimizationProblem, A<:Archive}(
       problem::P, archive::A) =
     new{fitness_type(fitness_scheme(problem)),fitness_type(archive),A,P}(problem, archive,
         0, nafitness(fitness_scheme(problem)))
 
-  @compat (::Type{ProblemEvaluator}){P<:OptimizationProblem}(
+  (::Type{ProblemEvaluator}){P<:OptimizationProblem}(
       problem::P; archiveCapacity::Int = 10) =
     ProblemEvaluator(problem, TopListArchive(fitness_scheme(problem), numdims(problem), archiveCapacity))
 

--- a/src/evaluator.jl
+++ b/src/evaluator.jl
@@ -2,7 +2,7 @@
   The abstract base for types that manage the objective function evaluation.
   `P` is the optimization problem it is used for.
 """
-abstract Evaluator{P <: OptimizationProblem}
+@compat abstract type Evaluator{P <: OptimizationProblem} end
 
 fitness_scheme(e::Evaluator) = fitness_scheme(problem(e))
 fitness_type(e::Evaluator) = fitness_type(fitness_scheme(e))

--- a/src/fit_individual.jl
+++ b/src/fit_individual.jl
@@ -4,7 +4,7 @@
 
   `F` is the original problem's fitness type
 """
-abstract FitIndividual{F}
+@compat abstract type FitIndividual{F} end
 
 fitness_type{F}(indi::FitIndividual{F}) = F
 

--- a/src/fit_individual.jl
+++ b/src/fit_individual.jl
@@ -41,7 +41,7 @@ type Candidate{F} <: FitIndividual{F}
              tag::Int = 0) =
         new(params, index, fitness, extra, tag)
 
-    @compat (::Type{Candidate}){F}(
+    (::Type{Candidate}){F}(
             params::Individual, index::Int = -1,
             fitness::F = NaN,
             extra::Any = Void,

--- a/src/fitness.jl
+++ b/src/fitness.jl
@@ -9,7 +9,7 @@
   `FitnessScheme` could also be used as a function that defines the fitness
   ordering, i.e. `fs(x, y) == true` iff fitness `x` is better than `y`.
 """
-abstract FitnessScheme{F}
+@compat abstract type FitnessScheme{F} end
 
 """
   `fitness_type(fs::FitnessScheme)`
@@ -37,7 +37,7 @@ Base.convert{F}(::Type{F}, fit::F, fit_scheme::FitnessScheme{F}) = fit
   The default scale used is the aggregate of the fitness components.
 """
 # FIXME
-abstract RatioFitnessScheme{F} <: FitnessScheme{F}
+@compat abstract type RatioFitnessScheme{F} <: FitnessScheme{F} end
 
 """
   `Float64`-valued scalar fitness scheme.

--- a/src/fitness.jl
+++ b/src/fitness.jl
@@ -29,7 +29,7 @@ Base.convert{F}(::Type{F}, fit::F, fit_scheme::FitnessScheme{F}) = fit
 
 # ordering induced by the fitness scheme
 # FIXME enable once v0.5 issue #14919 is fixed
-# @compat (fs::FitnessScheme{F}){F}(x::F, y::F) = is_better(x, y, fs)
+# (fs::FitnessScheme{F}){F}(x::F, y::F) = is_better(x, y, fs)
 
 """
   In `RatioFitnessScheme` the fitness values can be ranked on a ratio scale so
@@ -95,7 +95,7 @@ same_fitness(f1, f2, scheme::FitnessScheme) = hat_compare(f1, f2, scheme) == 0
 immutable HatCompare{FS<:FitnessScheme}
     fs::FS
 
-    @compat (::Type{HatCompare}){FS<:FitnessScheme}(fs::FS) = new{FS}(fs)
+    (::Type{HatCompare}){FS<:FitnessScheme}(fs::FS) = new{FS}(fs)
 end
 
-@compat (hc::HatCompare){F}(x::F, y::F) = hat_compare(x, y, hc.fs)
+(hc::HatCompare){F}(x::F, y::F) = hat_compare(x, y, hc.fs)

--- a/src/fitness/fitness_types.jl
+++ b/src/fitness/fitness_types.jl
@@ -1,8 +1,8 @@
-abstract NewFitness
+@compat abstract type NewFitness end
 
-abstract SingleObjectiveFitness <: NewFitness
+@compat abstract type SingleObjectiveFitness <: NewFitness end
 
-abstract MultiObjectiveFitness <: NewFitness
+@compat abstract type MultiObjectiveFitness <: NewFitness end
 
 # Some evaluators go through several stages of fitness evaluation:
 #   1. a candidate is simulated -> *simulation(s)*

--- a/src/generating_set_search.jl
+++ b/src/generating_set_search.jl
@@ -5,13 +5,13 @@
 #
 
 """ A supertype for all generating set searcher-like algorithms. """
-abstract DirectSearcher <: SteppingOptimizer
+@compat abstract type DirectSearcher <: SteppingOptimizer end
 
 """
   `DirectionGenerator` generates the search directions to use at each step of
   a GSS search.
 """
-abstract DirectionGenerator
+@compat abstract type DirectionGenerator end
 
 immutable ConstantDirectionGen <: DirectionGenerator
   directions::Matrix{Float64}

--- a/src/genetic_operators/crossover/differential_evolution_crossover.jl
+++ b/src/genetic_operators/crossover/differential_evolution_crossover.jl
@@ -1,4 +1,4 @@
-abstract DiffEvoCrossoverOperator{NP,NC} <: CrossoverOperator{NP,NC}
+@compat abstract type DiffEvoCrossoverOperator{NP,NC} <: CrossoverOperator{NP,NC} end
 
 # FIXME is it possible somehow to do arithmetic operations with N?
 immutable DiffEvoRandBin{N} <: DiffEvoCrossoverOperator{N,1}

--- a/src/genetic_operators/crossover/differential_evolution_crossover.jl
+++ b/src/genetic_operators/crossover/differential_evolution_crossover.jl
@@ -16,8 +16,8 @@ const DEX_DefaultOptions = ParamsDict(
 
 crossover_parameters(xover::DiffEvoRandBin, pop, target_index) = xover.cr, xover.f
 
-typealias DiffEvoRandBin1 DiffEvoRandBin{3}
-typealias DiffEvoRandBin2 DiffEvoRandBin{5}
+@compat const DiffEvoRandBin1 = DiffEvoRandBin{3}
+@compat const DiffEvoRandBin2 = DiffEvoRandBin{5}
 
 function apply!(xover::DiffEvoCrossoverOperator{3,1}, target, target_index::Int, pop, parentIndices)
   @assert length(parentIndices) == 3

--- a/src/genetic_operators/crossover/mutation_wrapper.jl
+++ b/src/genetic_operators/crossover/mutation_wrapper.jl
@@ -5,7 +5,7 @@
 immutable MutationWrapper{OP<:MutationOperator} <: CrossoverOperator{1,1}
     inner::OP
 
-    @compat (::Type{MutationWrapper}){OP<:MutationOperator}(mutation::OP) =
+    (::Type{MutationWrapper}){OP<:MutationOperator}(mutation::OP) =
         new{OP}(mutation)
 end
 

--- a/src/genetic_operators/crossover/parent_centric_crossover.jl
+++ b/src/genetic_operators/crossover/parent_centric_crossover.jl
@@ -35,7 +35,7 @@ function apply!{NP}(xover::ParentCentricCrossover{NP}, target::Individual, targe
     end
     other_parents_centered = tmp_mtx *
             view(parents_centered, :, 2:length(parentIndices))
-    sd = mean(map(sqrt, sumabs2(other_parents_centered, 2)))
+    sd = mean(map(sqrt, sum(abs2, other_parents_centered, 2)))
     if sd > 1E-8
         svdf = svdfact(other_parents_centered)
         svals_norm = norm(svdf.S)

--- a/src/genetic_operators/crossover/unimodal_normal_distribution_crossover.jl
+++ b/src/genetic_operators/crossover/unimodal_normal_distribution_crossover.jl
@@ -28,7 +28,7 @@ function apply!{NP}(xover::UnimodalNormalDistributionCrossover{NP}, target::Indi
     parents = pop[:, parentIndices]
     center = mean(parents, 2)
     broadcast!(-, parents, parents, center)
-    sd = mean(map(sqrt, sumabs2(parents, 2)))
+    sd = mean(map(sqrt, sum(abs2, parents, 2)))
     svdf = svdfact(parents)
     svals = svdf.S / norm(svdf.S)
     @inbounds for (i,s) in enumerate(svals)

--- a/src/genetic_operators/embedding/random_bound.jl
+++ b/src/genetic_operators/embedding/random_bound.jl
@@ -6,7 +6,7 @@
 immutable RandomBound{S<:SearchSpace} <: EmbeddingOperator
     searchSpace::S
 
-    @compat (::Type{RandomBound}){S<:SearchSpace}(searchSpace::S) = new{S}(searchSpace)
+    (::Type{RandomBound}){S<:SearchSpace}(searchSpace::S) = new{S}(searchSpace)
 end
 
 # outer ctors

--- a/src/genetic_operators/genetic_operator.jl
+++ b/src/genetic_operators/genetic_operator.jl
@@ -1,35 +1,35 @@
 """
   Abstract genetic operator that transforms individuals in the population.
 """
-abstract GeneticOperator
+@compat abstract type GeneticOperator end
 
 """
   Modifies (mutates) one individual.
 
   The concrete implementations must provide `apply!()` method.
 """
-abstract MutationOperator <: GeneticOperator
+@compat abstract type MutationOperator <: GeneticOperator end
 
 """
   Modifies `NC` "children" by transferring some information from `NP` "parents".
 
   The concrete implementations must provide `apply!()` method.
 """
-abstract CrossoverOperator{NP,NC} <: GeneticOperator
+@compat abstract type CrossoverOperator{NP,NC} <: GeneticOperator end
 
 """
   Embeds(projects) the individual into the search space.
 
   The concrete implementations must provide `apply!()` method.
 """
-abstract EmbeddingOperator <: GeneticOperator
+@compat abstract type EmbeddingOperator <: GeneticOperator end
 
 """
   Selects the individuals from the population.
 
   The concrete implementations must provide `select()` method.
 """
-abstract IndividualsSelector
+@compat abstract type IndividualsSelector end
 
 """
   `select(selector<:IndividualsSelector, population, numSamples::Int)`
@@ -91,7 +91,7 @@ function trace_state(io::IO, op::GeneticOperator, mode::Symbol) end
   A mixture of genetic operators,
   use `next()` to choose the next operator from the mixture.
 """
-abstract GeneticOperatorsMixture <: GeneticOperator
+@compat abstract type GeneticOperatorsMixture <: GeneticOperator end
 
 include("operators_mixture.jl")
 

--- a/src/genetic_operators/mutation/mutation_clock.jl
+++ b/src/genetic_operators/mutation/mutation_clock.jl
@@ -4,7 +4,7 @@ num_vars_to_next_mutation_point(probMutation) = ceil( Int, (-log(rand())) / prob
     Provides `apply()` operator that mutates one specified dimension of a parameter
     vector.
 """
-abstract GibbsMutationOperator <: MutationOperator
+@compat abstract type GibbsMutationOperator <: MutationOperator end
 
 # apply operator to each dimension
 function apply!{T<:Real}(m::GibbsMutationOperator, params::AbstractVector{T}, target_index::Int)

--- a/src/genetic_operators/mutation/mutation_clock.jl
+++ b/src/genetic_operators/mutation/mutation_clock.jl
@@ -20,7 +20,7 @@ end
 immutable UniformMutation{SS<:SearchSpace} <: GibbsMutationOperator
     ss::SS
 
-    @compat (::Type{UniformMutation}){SS<:SearchSpace}(ss::SS) = new{SS}(ss)
+    (::Type{UniformMutation}){SS<:SearchSpace}(ss::SS) = new{SS}(ss)
 end
 
 search_space(m::UniformMutation) = m.ss
@@ -42,7 +42,7 @@ type MutationClock{S<:GibbsMutationOperator} <: MutationOperator
     rate::Float64           # Probability to mutate a dimension
     nextVarToMutate::Int    # dimension index - 1
 
-    @compat (::Type{MutationClock}){S<:GibbsMutationOperator}(inner::S, rate::Float64 = 0.05) =
+    (::Type{MutationClock}){S<:GibbsMutationOperator}(inner::S, rate::Float64 = 0.05) =
         new{S}(inner, rate, 1 + num_vars_to_next_mutation_point(rate))
 end
 

--- a/src/genetic_operators/mutation/polynomial_mutation.jl
+++ b/src/genetic_operators/mutation/polynomial_mutation.jl
@@ -6,8 +6,8 @@ immutable PolynomialMutation{SS<:SearchSpace} <: GibbsMutationOperator
     ss::SS
     η::Float64
 
-    @compat (::Type{PolynomialMutation}){SS<:SearchSpace}(ss::SS, η = 50.0) = new{SS}(ss, η)
-    @compat (::Type{PolynomialMutation}){SS<:SearchSpace}(ss::SS, options::Parameters) = new{SS}(ss, options[:PM_η])
+    (::Type{PolynomialMutation}){SS<:SearchSpace}(ss::SS, η = 50.0) = new{SS}(ss, η)
+    (::Type{PolynomialMutation}){SS<:SearchSpace}(ss::SS, options::Parameters) = new{SS}(ss, options[:PM_η])
 end
 
 """

--- a/src/genetic_operators/operators_mixture.jl
+++ b/src/genetic_operators/operators_mixture.jl
@@ -4,7 +4,7 @@
 """
 type FixedGeneticOperatorsMixture <: GeneticOperatorsMixture
     operators::Vector{GeneticOperator} # available operations
-    weights::WeightVec{Float64}        # fixed weights
+    weights::Weights{Float64, Float64, Vector{Float64}}  # fixed weights
 
     function FixedGeneticOperatorsMixture{GO<:GeneticOperator}(
         operators::AbstractVector{GO},

--- a/src/genetic_operators/selector/radius_limited.jl
+++ b/src/genetic_operators/selector/radius_limited.jl
@@ -25,11 +25,5 @@ function select(sel::RadiusLimitedSelector, population, numSamples::Int)
     deme_start = rand(1:psize)
     ixs = rand_indexes(deme_start:(deme_start+radius-1), numSamples)
     # Ensure they are not out of bounds by wrapping over at the end.
-    map(ixs) do ix
-        if ix > psize
-            mod(ix-1, psize) + 1 # We have to increase by 1 since Julia arrays start indices at 1
-        else
-            ix
-        end
-    end
+    map!(ix -> mod1(ix, psize), ixs, ixs)
 end

--- a/src/genetic_operators/selector/radius_limited.jl
+++ b/src/genetic_operators/selector/radius_limited.jl
@@ -18,18 +18,18 @@ immutable RadiusLimitedSelector <: IndividualsSelector
 end
 
 function select(sel::RadiusLimitedSelector, population, numSamples::Int)
-  # The radius must be at least as big as the number of samples + 2 so that
-  # there is something to sample from.
-  radius = max(sel.radius, numSamples+2)
-  psize = popsize(population)
-  deme_start = rand(1:psize)
-  indices = sample(deme_start:(deme_start+radius-1), numSamples; replace = false)
-  # Ensure they are not out of bounds by wrapping over at the end.
-  map(indices) do index
-    if index > psize
-      mod(index-1, psize) + 1 # We have to increase by 1 since Julia arrays start indices at 1
-    else
-      index
+    # The radius must be at least as big as the number of samples + 2 so that
+    # there is something to sample from.
+    radius = max(sel.radius, numSamples+2)
+    psize = popsize(population)
+    deme_start = rand(1:psize)
+    ixs = rand_indexes(deme_start:(deme_start+radius-1), numSamples)
+    # Ensure they are not out of bounds by wrapping over at the end.
+    map(ixs) do ix
+        if ix > psize
+            mod(ix-1, psize) + 1 # We have to increase by 1 since Julia arrays start indices at 1
+        else
+            ix
+        end
     end
-  end
 end

--- a/src/genetic_operators/selector/simple.jl
+++ b/src/genetic_operators/selector/simple.jl
@@ -6,6 +6,5 @@
 immutable SimpleSelector <: IndividualsSelector
 end
 
-function select(::SimpleSelector, population, numSamples::Int)
-  sample(1:popsize(population), numSamples; replace = false)
-end
+select(::SimpleSelector, population, numSamples::Int) =
+    rand_indexes(1:popsize(population), numSamples)

--- a/src/genetic_operators/selector/tournament.jl
+++ b/src/genetic_operators/selector/tournament.jl
@@ -14,7 +14,7 @@ end
 # selection using `n_tours` tournaments
 function select(sel::TournamentSelector, population, n_tours::Int)
     n_candidates = min(popsize(population), sel.size*n_tours)
-    all_candidates = sample(1:popsize(population), n_candidates; replace=false)
+    all_candidates = rand_indexes(1:popsize(population), n_candidates)
 
     res = Vector{Int}(n_tours)
     tour_candidates = Vector{Int}(sel.size)

--- a/src/genetic_operators/selector/tournament.jl
+++ b/src/genetic_operators/selector/tournament.jl
@@ -5,7 +5,7 @@ type TournamentSelector{H} <: IndividualsSelector
     hat_comp::H     # fitness comparison tri-valued operator
     size::Int       # tournament size
 
-    @compat function (::Type{TournamentSelector}){FS}(fs::FS, size::Int=2)
+    function (::Type{TournamentSelector}){FS}(fs::FS, size::Int=2)
         h = HatCompare(fs)
         new{typeof(h)}(h, size)
     end

--- a/src/natural_evolution_strategies.jl
+++ b/src/natural_evolution_strategies.jl
@@ -1,4 +1,4 @@
-abstract NaturalEvolutionStrategyOpt <: PopulationOptimizer
+@compat abstract type NaturalEvolutionStrategyOpt <: PopulationOptimizer end
 
 """
   Separable Natural Evolution Strategy (sNES) optimizer.
@@ -141,7 +141,7 @@ end
   ```
 where `B` is an exponential of some symmetric matrix `lnB`, `tr(lnB)==0.0`
 """
-abstract ExponentialNaturalEvolutionStrategyOpt <: NaturalEvolutionStrategyOpt
+@compat abstract type ExponentialNaturalEvolutionStrategyOpt <: NaturalEvolutionStrategyOpt end
 
 function update_candidates!(exnes::ExponentialNaturalEvolutionStrategyOpt, Z::Matrix)
   B = expm(exnes.ln_B)

--- a/src/natural_evolution_strategies.jl
+++ b/src/natural_evolution_strategies.jl
@@ -101,8 +101,10 @@ function tell!{F}(snes::SeparableNESOpt{F}, rankedCandidates::Vector{Candidate{F
   # Update the mean and sigma vectors based on the gradient
   old_mu = copy(snes.mu)
   snes.mu += snes.mu_learnrate * (snes.sigma .* gradient_mu)
-  snes.sigma .*= exp(snes.sigma_learnrate / 2 * gradient_sigma)
-  snes.sigma = clamp(snes.sigma, 0.0, snes.max_sigma)
+  @inbounds for i in eachindex(snes.sigma)
+      snes.sigma[i] = clamp(snes.sigma[i] * exp(0.5 * snes.sigma_learnrate * gradient_sigma[i]),
+                            0.0, snes.max_sigma)
+  end
   apply!(snes.embed, snes.mu, old_mu)
 
   # There is no notion of how many was better in NES so return 0

--- a/src/ntuple_fitness.jl
+++ b/src/ntuple_fitness.jl
@@ -7,7 +7,7 @@
   `MIN` if objectives should be minimized or maximized
   `AGG` the type of aggregator
 """
-abstract TupleFitnessScheme{N,F<:Number,FA,MIN,AGG} <: FitnessScheme{FA}
+@compat abstract type TupleFitnessScheme{N,F<:Number,FA,MIN,AGG} <: FitnessScheme{FA} end
 
 @inline numobjectives{N}(::TupleFitnessScheme{N}) = N
 @inline fitness_eltype{N,F}(::TupleFitnessScheme{N,F}) = F

--- a/src/ntuple_fitness.jl
+++ b/src/ntuple_fitness.jl
@@ -31,10 +31,10 @@ aggregate{N,F}(f::NTuple{N,F}, fs::TupleFitnessScheme{N,F}) = fs.aggregator(f)
 immutable ParetoFitnessScheme{N,F<:Number,MIN,AGG} <: TupleFitnessScheme{N,F,NTuple{N,F},MIN,AGG}
     aggregator::AGG    # fitness aggregation function
 
-    @compat (::Type{ParetoFitnessScheme{N,F}}){N,F<:Number,AGG}(;is_minimizing::Bool=true, aggregator::AGG=sum) =
+    (::Type{ParetoFitnessScheme{N,F}}){N,F<:Number,AGG}(;is_minimizing::Bool=true, aggregator::AGG=sum) =
         new{N,F,is_minimizing,AGG}(aggregator)
 
-    @compat (::Type{ParetoFitnessScheme{N}}){N,F<:Number,AGG}(; fitness_type::Type{F} = Float64,
+    (::Type{ParetoFitnessScheme{N}}){N,F<:Number,AGG}(; fitness_type::Type{F} = Float64,
                                 is_minimizing::Bool=true, aggregator::AGG=sum) =
         new{N,fitness_type,is_minimizing,AGG}(aggregator)
 end
@@ -79,13 +79,13 @@ immutable EpsDominanceFitnessScheme{N,F<:Number,MIN,AGG} <: FitnessScheme{NTuple
     ϵ::F              # ɛ-domination threshold
     aggregator::AGG    # fitness aggregation function
 
-    @compat function (::Type{EpsDominanceFitnessScheme{N,F}}){N,F<:Number,AGG}(
+    function (::Type{EpsDominanceFitnessScheme{N,F}}){N,F<:Number,AGG}(
                                 ϵ::F; is_minimizing::Bool=true, aggregator::AGG=sum)
         ϵ>0.0 || throw(ArgumentError("ϵ must be positive"))
         new{N,F,is_minimizing,AGG}(ϵ, aggregator)
     end
 
-    @compat (::Type{EpsDominanceFitnessScheme{N}}){N,F<:Number,AGG}(ϵ::F; fitness_type::Type{F} = Float64,
+    (::Type{EpsDominanceFitnessScheme{N}}){N,F<:Number,AGG}(ϵ::F; fitness_type::Type{F} = Float64,
                                is_minimizing::Bool=true, aggregator::AGG=sum) =
         EpsDominanceFitnessScheme{N,fitness_type}(ϵ; is_minimizing=is_minimizing, aggegator=aggregator)
 end
@@ -163,11 +163,11 @@ immutable IndexedTupleFitness{N,F}
     index::NTuple{N,Int}    # ϵ-index vector
     dist::F                 # distance between ϵ-index vector and the original fitness
 
-    @compat function (::Type{IndexedTupleFitness}){N,F,MIN}(u::NTuple{N,F}, agg::F, ϵ::Vector{F}, is_minimizing::Type{Val{MIN}})
+    function (::Type{IndexedTupleFitness}){N,F,MIN}(u::NTuple{N,F}, agg::F, ϵ::Vector{F}, is_minimizing::Type{Val{MIN}})
         ix, dist = ϵ_index(u, ϵ, is_minimizing)
         return new{N,F}(u, agg, ix, dist)
     end
-    @compat (::Type{IndexedTupleFitness}){N,F,MIN}(u::NTuple{N,F}, agg::F, ϵ::F, is_minimizing::Type{Val{MIN}}) =
+    (::Type{IndexedTupleFitness}){N,F,MIN}(u::NTuple{N,F}, agg::F, ϵ::F, is_minimizing::Type{Val{MIN}}) =
         IndexedTupleFitness(u, agg, fill(ϵ, N), is_minimizing)
 end
 
@@ -243,11 +243,11 @@ immutable EpsBoxDominanceFitnessScheme{N,F<:Number,MIN,AGG} <: TupleFitnessSchem
     ϵ::Vector{F}        # per-objective ɛ-domination thresholds
     aggregator::AGG     # fitness aggregation function
 
-    @compat (::Type{EpsBoxDominanceFitnessScheme{N,F}}){N,F<:Number,AGG}(ϵ::Union{F,Vector{F}};
+    (::Type{EpsBoxDominanceFitnessScheme{N,F}}){N,F<:Number,AGG}(ϵ::Union{F,Vector{F}};
                                is_minimizing::Bool=true, aggregator::AGG=sum) =
         new{N,F,is_minimizing,AGG}(check_epsbox_ϵ(ϵ, N), aggregator)
 
-    @compat (::Type{EpsBoxDominanceFitnessScheme{N}}){N,F<:Number,AGG}(ϵ::Union{F,Vector{F}};
+    (::Type{EpsBoxDominanceFitnessScheme{N}}){N,F<:Number,AGG}(ϵ::Union{F,Vector{F}};
                                is_minimizing::Bool=true, aggregator::AGG=sum) =
         new{N,F,is_minimizing,AGG}(check_epsbox_ϵ(ϵ, N), aggregator)
 end
@@ -294,5 +294,5 @@ hat_compare{N,F}(u::NTuple{N,F}, v::NTuple{N,F},
                 convert(IndexedTupleFitness, v, fs), fs, expected)
 
 # special overload that strips index equality flag
-@compat (hc::HatCompare{FS}){FS<:EpsBoxDominanceFitnessScheme,N,F}(
+(hc::HatCompare{FS}){FS<:EpsBoxDominanceFitnessScheme,N,F}(
         u::IndexedTupleFitness{N,F}, v::IndexedTupleFitness{N,F}) = hat_compare(u, v, hc.fs)[1]

--- a/src/optimization_result.jl
+++ b/src/optimization_result.jl
@@ -2,13 +2,13 @@
     Base class for archive-specific component
     of the `OptimizationResults`.
 """
-abstract ArchiveOutput
+@compat abstract type ArchiveOutput end
 
 """
     Base class for method-specific component
     of the `OptimizationResults`.
 """
-abstract MethodOutput
+@compat abstract type MethodOutput end
 
 immutable DummyMethodOutput <: MethodOutput end
 

--- a/src/optimization_result.jl
+++ b/src/optimization_result.jl
@@ -13,7 +13,7 @@ abstract MethodOutput
 immutable DummyMethodOutput <: MethodOutput end
 
 # no method-specific output by default
-@compat (::Type{MethodOutput})(method::Optimizer) = DummyMethodOutput()
+(::Type{MethodOutput})(method::Optimizer) = DummyMethodOutput()
 
 """
   The results of running optimization method.
@@ -75,11 +75,11 @@ immutable TopListArchiveOutput{F,C} <: ArchiveOutput
   best_fitness::F
   best_candidate::C
 
-  @compat (::Type{TopListArchiveOutput}){F}(archive::TopListArchive{F}) =
+  (::Type{TopListArchiveOutput}){F}(archive::TopListArchive{F}) =
     new{F,Individual}(best_fitness(archive), best_candidate(archive))
 end
 
-@compat (::Type{ArchiveOutput})(archive::TopListArchive) = TopListArchiveOutput(archive)
+(::Type{ArchiveOutput})(archive::TopListArchive) = TopListArchiveOutput(archive)
 
 """
     Wrapper for `FrontierIndividual` that allows easy access to the problem fitness.
@@ -88,7 +88,7 @@ immutable FrontierIndividualWrapper{F,FA} <: FitIndividual{F}
     inner::FrontierIndividual{FA}
     fitness::F
 
-    @compat (::Type{FrontierIndividualWrapper{F}}){F,FA}(
+    (::Type{FrontierIndividualWrapper{F}}){F,FA}(
         indi::FrontierIndividual{FA}, fit_scheme::FitnessScheme{FA}) =
             new{F, FA}(indi, convert(F, fitness(indi), fit_scheme))
 end
@@ -105,7 +105,7 @@ immutable EpsBoxArchiveOutput{N,F,FS<:EpsBoxDominanceFitnessScheme} <: ArchiveOu
   frontier::Vector{FrontierIndividualWrapper{NTuple{N,F},IndexedTupleFitness{N,F}}} # inferred Pareto frontier
   fit_scheme::FS
 
-  @compat function (::Type{EpsBoxArchiveOutput}){N,F}(archive::EpsBoxArchive{N,F})
+  function (::Type{EpsBoxArchiveOutput}){N,F}(archive::EpsBoxArchive{N,F})
     fit_scheme = fitness_scheme(archive)
     new{N,F,typeof(fit_scheme)}(convert(NTuple{N,F}, best_fitness(archive), fit_scheme), best_candidate(archive),
                                 FrontierIndividualWrapper{NTuple{N,F}, IndexedTupleFitness{N,F}}[FrontierIndividualWrapper{NTuple{N,F}}(archive.frontier[i], fit_scheme) for i in find(archive.frontier_isoccupied)],
@@ -113,7 +113,7 @@ immutable EpsBoxArchiveOutput{N,F,FS<:EpsBoxDominanceFitnessScheme} <: ArchiveOu
   end
 end
 
-@compat (::Type{ArchiveOutput})(archive::EpsBoxArchive) = EpsBoxArchiveOutput(archive)
+(::Type{ArchiveOutput})(archive::EpsBoxArchive) = EpsBoxArchiveOutput(archive)
 
 pareto_frontier(or::OptimizationResults) = or.archive_output.frontier
 
@@ -124,10 +124,10 @@ pareto_frontier(or::OptimizationResults) = or.archive_output.frontier
 immutable PopulationOptimizerOutput{P} <: MethodOutput
   population::P
 
-  @compat (::Type{PopulationOptimizerOutput})(method::PopulationOptimizer) =
+  (::Type{PopulationOptimizerOutput})(method::PopulationOptimizer) =
     new{typeof(population(method))}(population(method))
 end
 
-@compat (::Type{MethodOutput})(optimizer::PopulationOptimizer) = PopulationOptimizerOutput(optimizer)
+(::Type{MethodOutput})(optimizer::PopulationOptimizer) = PopulationOptimizerOutput(optimizer)
 
 population(or::OptimizationResults) = or.method_output.population

--- a/src/optimizer.jl
+++ b/src/optimizer.jl
@@ -1,13 +1,13 @@
 """
   Base abstract class for black-box optimization algorithms.
 """
-abstract Optimizer
+@compat abstract type Optimizer end
 
 """
     Optimizers derived from `SteppingOptimizer` implement classical iterative optimization scheme
     `step!()` → `step!()` → …
 """
-abstract SteppingOptimizer <: Optimizer
+@compat abstract type SteppingOptimizer <: Optimizer end
 evaluator(so::SteppingOptimizer) = so.evaluator
 
 """
@@ -22,7 +22,7 @@ function step! end # FIXME avoid defining 0-arg function
   `ask()` → ..eval fitness.. → `tell!()`
   sequence at each step.
 """
-abstract AskTellOptimizer <: Optimizer
+@compat abstract type AskTellOptimizer <: Optimizer end
 
 """
   `ask(ato::AskTellOptimizer)`
@@ -81,7 +81,7 @@ function tell! end # FIXME avoid defining 0-arg function
 """
   Base class for population-based optimization methods.
 """
-abstract PopulationOptimizer <: AskTellOptimizer
+@compat abstract type PopulationOptimizer <: AskTellOptimizer end
 
 population(popopt::PopulationOptimizer) = popopt.population
 popsize(popopt::PopulationOptimizer) = popsize(population(popopt))

--- a/src/parallel_evaluator.jl
+++ b/src/parallel_evaluator.jl
@@ -4,7 +4,7 @@
 immutable ParallelEvaluatorWorker{P<:OptimizationProblem}
   problem::P
 
-  @compat (::Type{ParallelEvaluatorWorker}){P}(problem::P) = new{P}(problem)
+  (::Type{ParallelEvaluatorWorker}){P}(problem::P) = new{P}(problem)
 end
 
 fitness(params::Individual, worker::ParallelEvaluatorWorker) =
@@ -30,7 +30,7 @@ type ParallelEvaluationState{F, FS}
                                     # fitness calculation
   next_index::Int                   # index of the next candidate to calculate fitness
 
-  @compat function (::Type{ParallelEvaluationState}){FS<:FitnessScheme}(fitness_scheme::FS, nworkers::Int)
+  function (::Type{ParallelEvaluationState}){FS<:FitnessScheme}(fitness_scheme::FS, nworkers::Int)
     F = fitness_type(fitness_scheme)
     new{F,FS}(fitness_scheme, Vector{Candidate{F}}(),
               fill(false, nworkers), Vector{Int}(), Condition(), 0)

--- a/src/parallel_evaluator.jl
+++ b/src/parallel_evaluator.jl
@@ -10,8 +10,8 @@ end
 fitness(params::Individual, worker::ParallelEvaluatorWorker) =
   fitness(params, worker.problem)
 
-typealias ChannelRef{T} @compat RemoteChannel{Channel{T}}
-typealias ParallelEvaluatorWorkerRef{P} ChannelRef{ParallelEvaluatorWorker{P}}
+@compat const ChannelRef{T} = @compat RemoteChannel{Channel{T}}
+@compat const ParallelEvaluatorWorkerRef{P} = ChannelRef{ParallelEvaluatorWorker{P}}
 
 fitness{P}(params::Individual, worker_ref::ParallelEvaluatorWorkerRef{P}) =
   fitness(params, fetch(fetch(worker_ref))::ParallelEvaluatorWorker{P})

--- a/src/parameters.jl
+++ b/src/parameters.jl
@@ -8,7 +8,7 @@ type DictChain{K,V} <: Associative{K,V}
   DictChain(dicts::Vector{Associative{K,V}}) = new(dicts)
 
   # empty dicts vector
-  DictChain() = new(Array(Associative{K,V}, 0))
+  DictChain() = new(Vector{Associative{K,V}}())
 
   DictChain(dicts::Associative{K,V}...) = new(Associative{K,V}[dict for dict in dicts])
 end

--- a/src/parameters.jl
+++ b/src/parameters.jl
@@ -100,13 +100,13 @@ end
 """
   The parameters storage type for `BlackBoxOptim`.
 """
-typealias Parameters Associative{Symbol,Any}
+@compat const Parameters = Associative{Symbol,Any}
 
 """
   The default parameters storage in `BlackBoxOptim`.
 """
-typealias ParamsDict Dict{Symbol,Any}
-typealias ParamsDictChain DictChain{Symbol,Any}
+@compat const ParamsDict = Dict{Symbol,Any}
+@compat const ParamsDictChain = DictChain{Symbol,Any}
 
 """
   The default placeholder value for parameters argument.

--- a/src/population.jl
+++ b/src/population.jl
@@ -26,6 +26,24 @@ numdims{F}(pop::Vector{Candidate{F}}) = isempty(pop) ? 0 : length(pop[1].params)
 
 viewer(pop::PopulationMatrix, indi_ix) = view(pop, :, indi_ix)
 
+# select random indexes
+# FIXME use sample() when Julia keyarg inference problem (https://github.com/JuliaLang/julia/issues/9551) would be solved
+# at the moment it's just an extract from SampleBase.sample!() for ordered=false, replace=false
+function rand_indexes(a::AbstractArray{Int}, k::Int)
+    n = length(a)
+    x = Vector{Int}(k)
+    if k == 1
+        @inbounds x[1] = sample(a)
+    elseif k == 2
+        @inbounds (x[1], x[2]) = StatsBase.samplepair(a)
+    elseif n < k * 24
+        StatsBase.fisher_yates_sample!(a, x)
+    else
+        StatsBase.self_avoid_sample!(a, x)
+    end
+    return x
+end
+
 """
   The default implementation of `PopulationWithFitness{F}`.
 """

--- a/src/population.jl
+++ b/src/population.jl
@@ -14,7 +14,7 @@ abstract PopulationWithFitness{F} <: Population
 """
   The simplest `Population` implementation -- a matrix of floats, each column is an individual.
 """
-typealias PopulationMatrix Matrix{Float64}
+@compat const PopulationMatrix = Matrix{Float64}
 
 popsize(pop::PopulationMatrix) = size(pop, 2)
 numdims(pop::PopulationMatrix) = size(pop, 1)

--- a/src/population.jl
+++ b/src/population.jl
@@ -2,14 +2,14 @@
   The base abstract type for the collection of candidate solutions
   in the population-based optimization methods.
 """
-abstract Population
+@compat abstract type Population end
 """
   The base abstract types for population that also stores the candidates
   fitness.
 
   `F` is the fitness type.
 """
-abstract PopulationWithFitness{F} <: Population
+@compat abstract type PopulationWithFitness{F} <: Population end
 
 """
   The simplest `Population` implementation -- a matrix of floats, each column is an individual.

--- a/src/problem.jl
+++ b/src/problem.jl
@@ -2,7 +2,7 @@
   The base abstract type for all optimization problems.
   `FS` is a type of a problem's `FitnessScheme`.
 """
-abstract OptimizationProblem{FS<:FitnessScheme}
+@compat abstract type OptimizationProblem{FS<:FitnessScheme} end
 
 # common definitions for `OptimizationProblem`
 # (enforce field names of subtypes)

--- a/src/problem.jl
+++ b/src/problem.jl
@@ -34,7 +34,7 @@ type FunctionBasedProblem{FS<:FitnessScheme,SS<:SearchSpace,FO} <: OptimizationP
   ss::SS                # search space
   opt_value::FO         # known optimal value or nothing
 
-  @compat function (::Type{FunctionBasedProblem}){FS<:FitnessScheme,SS<:SearchSpace,FO}(objfunc::Function, name::String, fitness_scheme::FS, ss::SS, opt_value::FO = nothing)
+  function (::Type{FunctionBasedProblem}){FS<:FitnessScheme,SS<:SearchSpace,FO}(objfunc::Function, name::String, fitness_scheme::FS, ss::SS, opt_value::FO = nothing)
     if FO <: Number
       fitness_type(fitness_scheme) == FO || throw(ArgumentError("Fitness type ($(fitness_type(fitness_scheme))) and opt_value type ($(FO)) do not match"))
       if isnafitness(opt_value, fitness_scheme) # if NA fitness is given, the problem is unbouned

--- a/src/problems/bbob.jl
+++ b/src/problems/bbob.jl
@@ -4,7 +4,7 @@
 module COCO
 
 # BBOB test functions are optimization problems
-abstract BBOBFunction <: OptimizationProblem
+@compat abstract type BBOBFunction <: OptimizationProblem end
 
 # Number of dimensions.
 ndims(f::BBOBFunction) = f.ndims
@@ -67,7 +67,7 @@ end
 # we can use Julia's type system to model the noise functions in a better
 # way than how it is done in Python. Thus a noise function need not be a
 # BBOBFunction.
-abstract BBOBNoiseFunction
+@compat abstract type BBOBNoiseFunction end
 
 # Different types depending on the noise function used.
 type BBOBNfreeFunction <: BBOBNoiseFunction
@@ -92,7 +92,7 @@ type BBOBCauchyFunction <: BBOBNoiseFunction
 end
 noise(f::BBOBCauchyFunction, ftrue) = fCauchy(ftrue, f.cauchyalpha, f.cauchyp)
 
-abstract FSphere{NoiseFunc} <: BBOBFunction
+@compat abstract type FSphere{NoiseFunc} <: BBOBFunction end
 compute_core(f::FSphere, x) = sum(x.^2)
 
 # Sphere without noise

--- a/src/problems/bbob/separable_functions.jl
+++ b/src/problems/bbob/separable_functions.jl
@@ -1,6 +1,4 @@
 # Computational cores of BBOB separable functions f1-f5
 
 # f1 = Sphere function
-function sphere_function{T <: Number}(x::Vector{T})
-    sum(x.^2, 1)
-end
+sphere_function{T <: Number}(x::Vector{T}) = sum(abs2, x, 1)

--- a/src/problems/multi_objective.jl
+++ b/src/problems/multi_objective.jl
@@ -5,7 +5,7 @@ immutable Hypersurface{N,SS<:SearchSpace}
     manifold::Function
     parameter_space::SS
 
-    @compat function (::Type{Hypersurface}){SS<:SearchSpace}(manifold::Function, parameter_space::SS)
+    function (::Type{Hypersurface}){SS<:SearchSpace}(manifold::Function, parameter_space::SS)
         N = numdims(parameter_space)+1
         int_pt = manifold(0.5*(mins(parameter_space)+maxs(parameter_space)), Val{1})
         length(int_pt) == N || throw(DimensionMismatch())

--- a/src/problems/multi_objective.jl
+++ b/src/problems/multi_objective.jl
@@ -130,7 +130,7 @@ end
    Parameterized by t[1]=f[1] and t[2]=f[2].
 """
 function CEC09_UP8_PF{NP}(t::Vector{Float64}, ::Type{Val{NP}})
-    d=sumabs2(t)
+    d=sum(abs2, t)
     (t[1], t[2], d <= 1.0 ? (1.0 - d)^(1/3) : NaN)
 end
 
@@ -147,7 +147,7 @@ const CEC09_Unconstrained_Set = Dict{Int,FunctionBasedProblemFamily}(
                                     symmetric_search_space(2, (0.0, 1.0)))
 )
 
-schaffer1(x) = (sumabs2(x), sumabs2(x .- 2.0))
+schaffer1(x) = (sum(abs2, x), sum(xx -> abs2(xx - 2.0), x))
 schaffer1_PF{NP}(t, ::Type{Val{NP}}) = (NP*t[1]^2, NP*(2-t[1])^2)
 
 const Schaffer1Family = FunctionBasedProblemFamily(schaffer1, "Schaffer1", ParetoFitnessScheme{2}(is_minimizing=true),

--- a/src/problems/problem_family.jl
+++ b/src/problems/problem_family.jl
@@ -6,7 +6,7 @@
     number of the search space dimensions) that allows
     to instantiate `OptimizationProblem` for the concrete parameters.
 """
-abstract ProblemFamily{FS<:FitnessScheme}
+@compat abstract type ProblemFamily{FS<:FitnessScheme} end
 
 """
   Family of `FunctionBasedProblem` optimization problems

--- a/src/problems/problem_family.jl
+++ b/src/problems/problem_family.jl
@@ -20,7 +20,7 @@ type FunctionBasedProblemFamily{F,FS<:FitnessScheme,FO} <: ProblemFamily{FS}
   range_per_dim::ParamBounds            # Default range per dimension
   opt_value::FO                         # optional optimal value, or nothing
 
-  @compat function (::Type{FunctionBasedProblemFamily}){FS<:FitnessScheme,FO}(objfunc::Function, name::String,
+  function (::Type{FunctionBasedProblemFamily}){FS<:FitnessScheme,FO}(objfunc::Function, name::String,
                                         fitness_scheme::FS, range::ParamBounds, opt_value::FO = nothing,
                                         reserved_ss::RangePerDimSearchSpace = ZERO_SEARCH_SPACE)
     if FO <: Number

--- a/src/problems/single_objective.jl
+++ b/src/problems/single_objective.jl
@@ -51,7 +51,7 @@ const JadeFunctionSet = Dict{Int,FunctionBasedProblemFamily}(
 
   The concrete derived types must implement a `sub_problem()` method.
 """
-abstract TransformedProblem{FS<:FitnessScheme} <: OptimizationProblem{FS}
+@compat abstract type TransformedProblem{FS<:FitnessScheme} <: OptimizationProblem{FS} end
 
 search_space(tp::TransformedProblem) = search_space(sub_problem(tp))
 is_fixed_dimensional(tp::TransformedProblem) = is_fixed_dimensional(sub_problem(tp))

--- a/src/problems/single_objective_base_functions.jl
+++ b/src/problems/single_objective_base_functions.jl
@@ -85,15 +85,17 @@ cigtab(x) = x[1]^2 + 1e8 * x[end]^2 + 1e4 * sum(abs2, view(x, 2:length(x)-1))
   Generic function to define `ShekelN` problems.
 """
 function shekel(x, a, c)
-  sum = 0.0
-  for i in 1:length(c)
-    den = 0.0
-    for j in 1:size(a, 2)
-      den += (x[j] - a[i,j])^2
+    @assert length(x) == size(a, 2)
+    @assert length(c) == size(a, 1)
+    sum = 0.0
+    @inbounds for i in eachindex(c)
+        den = 0.0
+        for j in 1:size(a, 2)
+            den += abs2(x[j] - a[i,j])
+        end
+        sum = sum - 1 / (den + c[i])
     end
-    sum = sum - 1 / (den + c[i])
-  end
-  return sum
+    return sum
 end
 
 # constants for `Shekel10`
@@ -133,15 +135,18 @@ shekel5(x) = shekel(x, Shekel5_A, Shekel5_C)
   Generic function for `Hartman N` problem family.
 """
 function hartman(x, alpha, A, P)
-  sum = 0.0
-  for i in 1:length(alpha)
-    isum = 0.0
-    for j in 1:size(A, 2)
-      isum += A[i,j] * (x[j] - P[i,j])^2
+    @assert size(A) == size(P)
+    @assert length(x) == size(P, 2)
+    @assert length(alpha) == size(P, 1)
+    res = 0.0
+    @inbounds for i in 1:length(alpha)
+        isum = 0.0
+        for j in 1:size(A, 2)
+            isum += A[i,j] * (x[j] - P[i,j])^2
+        end
+        res -= alpha[i] * exp(-isum)
     end
-    sum -= alpha[i] * exp(-isum)
-  end
-  sum
+    res
 end
 
 # constants for `Hartman6`

--- a/src/problems/single_objective_base_functions.jl
+++ b/src/problems/single_objective_base_functions.jl
@@ -2,9 +2,7 @@
 #####################################################################
 # Base functions.
 #####################################################################
-function sphere(x)
-  sumabs2(x)
-end
+sphere(x) = sum(abs2, x)
 
 """
   Schwefel's ellipsoid.
@@ -28,16 +26,16 @@ end
 
 function rastrigin(x)
   D = length(x)
-  10 * D + sum( x.^2 ) - 10 * sum( cos( 2 * π * x ) )
+  10 * D + sum(abs2, x) - 10 * sum(xx -> cos(2π * xx), x)
 end
 
 function ackley(x)
   D = length(x)
   try
-    20 - 20.*exp(-0.2.*sqrt(sum(x.^2)/D)) - exp(sum(cos(2 * π * x))/D) + e
-  catch e
+    20 - 20.*exp(-0.2.*sqrt(sum(abs2, x)/D)) - exp(sum(xx -> cos(2π * xx), x)/D) + e
+  catch ex
     # Sometimes we have gotten a DomainError from the cos function so we protect this call
-    println(e)
+    println(ex)
     println("For input x = ", x)
     # Return a very large fitness value to indicate that this is NOT the solution we want.
     # TODO: Fix better way to handle this!
@@ -53,46 +51,35 @@ function schwefel1_2(x)
     partsum += x[i]
     partsums[i] = partsum
   end
-  sum(partsums.^2)
+  sum(abs2, partsums)
 end
 
 function rosenbrock(x)
   n = length(x)
-  return( sum( 100*( x[2:n] - x[1:(n-1)].^2 ).^2 + ( x[1:(n-1)] - 1 ).^2 ) )
+  return( sum(100*(view(x, 2:n) - view(x, 1:(n-1)).^2).^2 + (view(x, 1:(n-1)) - 1).^2) )
 end
 
-function step(x)
-  sum(ceil(x + 0.5))
-end
+step(x) = sum(xx -> ceil(xx + 0.5), x)
 
 function griewank(x)
   n = length(x)
-  1 + (1/4000)*sum(x.^2) - prod(cos(x ./ sqrt(1:n)))
+  1 + (1/4000)*sum(abs2, x) - prod(cos(x ./ sqrt(1:n)))
 end
 
-function schwefel2_22(x)
-  ax = abs(x)
-  sum(ax) + prod(ax)
-end
+schwefel2_22(x) = sum(abs, x) + prod(abs, x)
 
-function schwefel2_21(x)
-  maximum(abs(x))
-end
+schwefel2_21(x) = maximum(abs, x)
 
 # I'm unsure about this one since it does not return the expected minima at
 # [1.0, 1.0].
 function schwefel2_26(x)
   D = length(x)
-  418.98288727243369 * D - sum(x .* sin(sqrt(abs(x))))
+  418.98288727243369 * D - sum(xx -> xx * sin(sqrt(abs(xx))), x)
 end
 
-function cigar(x)
-  x[1]^2 + 1e6 * sum(x[2:end].^2)
-end
+cigar(x) = x[1]^2 + 1e6 * sum(abs2, view(x, 2:length(x)))
 
-function cigtab(x)
-  x[1]^2 + 1e8 * x[end]^2 + 1e4 * sum(x[2:(end-1)].^2)
-end
+cigtab(x) = x[1]^2 + 1e8 * x[end]^2 + 1e4 * sum(abs2, view(x, 2:length(x)-1))
 
 """
   Generic function to define `ShekelN` problems.
@@ -191,13 +178,9 @@ function quartic(x)
   sum( (1:D) .* x.^4 )
 end
 
-function noisy_quartic(x)
-  quartic(x) + rand()
-end
+noisy_quartic(x) = quartic(x) + rand()
 
-function s2_step(x)
-  sum( ceil(x + 0.5).^2 )
-end
+s2_step(x) = sum(xx -> abs2(ceil(xx + 0.5)), x)
 
 #####################################################################
 # Misc other interesting optimization functions and families.
@@ -240,14 +223,13 @@ end
 """
 function deceptive_cuccu2011(l, w)
   (x) -> begin
-    absx = abs(x)
-    sumabsx = sum(absx)
+    sumabsx = sum(abs, x)
     if sumabsx <= 1
-      return sum(x.^2)
+      return sum(abs2, x)
     elseif sumabsx >= l+1
-      return sum((absx - l).^2)
+      return sum(xx -> abs2(abs(xx) - l), x)
     else
-      return (1 - 0.5 * sum(sin( (π * w * (absx - 1)) / l ).^2))
+      return (1 - 0.5 * sum(xx -> abs2(sin( (π * w * (abs(xx) - 1)) / l )), x))
     end
   end
 end
@@ -262,6 +244,4 @@ deceptive_cuccu2011_30_2 = deceptive_cuccu2011(30, 2)
   available from http://www.if.ufrgs.br/~stariolo/publications/TsSt96_PhysA233_395_1996.pdf
  the original paper used this as a 4-dimensional problem but here it is generalized.
 """
-function energy_tsallis1996(x::Array)
-  return sumabs2(x.^2 - 8.0) + 5.0*sum(x) + 57.3276
-end
+energy_tsallis1996(x::AbstractArray) = sum(xx -> abs2(xx^2 - 8.0), x) + 5.0*sum(x) + 57.3276

--- a/src/search_space.jl
+++ b/src/search_space.jl
@@ -23,19 +23,19 @@ abstract ContinuousSearchSpace <: FixedDimensionSearchSpace
     The abstract type. It allows different actual implementations to be used,
     e.g `Vector` or `SubArray`.
 """
-typealias AbstractIndividual AbstractVector{Float64}
+@compat const AbstractIndividual = AbstractVector{Float64}
 
 """
     The point of the `SearchSpace`.
 
     The concrete type that could be used for storage.
 """
-typealias Individual Vector{Float64}
+@compat const Individual = Vector{Float64}
 
 """
   The valid range of values for a specific dimension in a `SearchSpace`.
 """
-typealias ParamBounds Tuple{Float64,Float64}
+@compat const ParamBounds = Tuple{Float64,Float64}
 
 """
   Get the range of valid values for a specific dimension.

--- a/src/search_space.jl
+++ b/src/search_space.jl
@@ -4,18 +4,18 @@
   The base abstract class has very few restrictions
   and can allow varying number of dimensions etc.
 """
-abstract SearchSpace
+@compat abstract type SearchSpace end
 
 """
   `SearchSpace` with a fixed finite number of dimensions.
   Applicable to the vast majority of problems.
 """
-abstract FixedDimensionSearchSpace <: SearchSpace
+@compat abstract type FixedDimensionSearchSpace <: SearchSpace end
 
 """
   Fixed-dimensional space, each dimension has a continuous range of valid values.
 """
-abstract ContinuousSearchSpace <: FixedDimensionSearchSpace
+@compat abstract type ContinuousSearchSpace <: FixedDimensionSearchSpace end
 
 """
     The point of the `SearchSpace`.

--- a/src/simultaneous_perturbation_stochastic_approximation.jl
+++ b/src/simultaneous_perturbation_stochastic_approximation.jl
@@ -32,7 +32,7 @@ SimultaneousPerturbationSA2(problem::OptimizationProblem, parameters::Parameters
 
 name(spsa::SimultaneousPerturbationSA2) = "SPSA2 (Simultaneous Perturbation Stochastic Approximation, 1st order, 2 samples)"
 
-sample_bernoulli_vector(n::Int) = 2.0 * round(rand(n)) - 1.0
+sample_bernoulli_vector(n::Int) = [2.0*round(rand()) - 1.0 for _ in 1:n]
 
 function ask(spsa::SimultaneousPerturbationSA2)
   delta = sample_bernoulli_vector(spsa.n)

--- a/src/simultaneous_perturbation_stochastic_approximation.jl
+++ b/src/simultaneous_perturbation_stochastic_approximation.jl
@@ -1,7 +1,7 @@
 """
   `AskTellOptimizer` that utilizes randomization to generate the candidates.
 """
-abstract StochasticApproximationOptimizer <: AskTellOptimizer
+@compat abstract type StochasticApproximationOptimizer <: AskTellOptimizer end
 
 const SPSADefaultParameters = ParamsDict(
   :Alpha => 0.602,  # The optimal value is 1.0 but values down to 0.602 often can give faster convergence

--- a/test/helper.jl
+++ b/test/helper.jl
@@ -3,3 +3,6 @@ using BaseTestNext
 using Compat
 
 const NumTestRepetitions = 100
+
+random_candidate(n, lo, hi) =
+    BlackBoxOptim.Candidate{Float64}([clamp(randn(), lo, hi) for _ in 1:n])

--- a/test/helper.jl
+++ b/test/helper.jl
@@ -1,6 +1,5 @@
 using BlackBoxOptim
-using BaseTestNext
-using Compat
+using Base.Test
 
 const NumTestRepetitions = 100
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -48,11 +48,6 @@ my_tests = [
 
 if Main.TimeTestExecution
 
-# readstring not available pre 0.5:
-if VERSION < v"0.5.0"
-  readstring(stream) = readall(stream)
-end
-
 function get_git_remote_and_branch()
   lines = split(readstring(`git remote -v show`), "\n")
   remote = match(r"[a-z0-9]+\s+([^\s]+)", lines[1]).captures[1]

--- a/test/test_crossover_operators.jl
+++ b/test/test_crossover_operators.jl
@@ -3,7 +3,7 @@
 ss = symmetric_search_space(1, (0.0, 10.0))
 fake_problem = FunctionBasedProblem(x -> 0.0, "test_problem", MinimizingFitnessScheme, ss)
 DE = de_rand_1_bin(fake_problem, ParamsDict(
-    :Population => collect(1.0:10.0)',
+    :Population => reshape(collect(1.0:10.0), (1, 10)),
     :f => 0.4, :cr => 0.5, :NumParents => 3))
 
 @testset "DiffEvoRandBin1" begin

--- a/test/test_differential_evolution.jl
+++ b/test/test_differential_evolution.jl
@@ -3,7 +3,7 @@
 ss = symmetric_search_space(1, (0.0, 10.0))
 fake_problem = FunctionBasedProblem(x -> 0.0, "test_problem", MinimizingFitnessScheme, ss)
 DE = de_rand_1_bin(fake_problem, ParamsDict(
-    :Population => collect(1.0:10.0)',
+    :Population => reshape(collect(1.0:10.0), (1, 10)),
     :f => 0.4, :cr => 0.5, :NumParents => 3))
 
 @testset "ask()/tell!()" begin

--- a/test/test_epsbox_archive.jl
+++ b/test/test_epsbox_archive.jl
@@ -128,7 +128,7 @@
     end
 
     @testset "shaffer1() Pareto frontier" begin
-            schaffer1(x) = (sumabs2(x), sumabs2(x .- 2.0))
+            schaffer1(x) = (sum(abs2, x), sum(xx -> abs2(xx - 2.0), x))
             scheme = EpsBoxDominanceFitnessScheme{2}(0.1, is_minimizing=true)
             a = EpsBoxArchive(scheme)
 

--- a/test/test_evaluator.jl
+++ b/test/test_evaluator.jl
@@ -56,7 +56,7 @@ end
 
 @testset "Evaluator" begin
     # Set up a small example problem
-    f(x) = sumabs2(x)
+    f(x) = sum(abs2, x)
     p = minimization_problem(f, "", (-1.0, 1.0), 2)
     @testset "ProblemEvaluator" begin
         evaluator_tests(() -> BlackBoxOptim.ProblemEvaluator(p))

--- a/test/test_evaluator.jl
+++ b/test/test_evaluator.jl
@@ -32,7 +32,7 @@ function evaluator_tests(make_eval::Function)
     @testset "update_fitness!()" begin
         e = make_eval()
 
-        candidates = BlackBoxOptim.Candidate{Float64}[BlackBoxOptim.Candidate{Float64}(clamp(randn(2), -1.0, 1.0)) for i in 1:10]
+        candidates = [random_candidate(2, -1.0, 1.0) for i in 1:10]
         BlackBoxOptim.update_fitness!(e, candidates)
         @test BlackBoxOptim.num_evals(e) == length(candidates)
         @test all(c -> isfinite(c.fitness), candidates)
@@ -42,7 +42,7 @@ function evaluator_tests(make_eval::Function)
     @testset "rank_by_fitness!()" begin
         e = make_eval()
 
-        candidates = BlackBoxOptim.Candidate{Float64}[BlackBoxOptim.Candidate{Float64}(clamp(randn(2), -1.0, 1.0)) for i in 1:10]
+        candidates = [random_candidate(2, -1.0, 1.0) for i in 1:10]
         # partially evaluate fitness
         BlackBoxOptim.update_fitness!(e, candidates[1:5])
         @test BlackBoxOptim.num_evals(e) == 5
@@ -65,7 +65,7 @@ end
     @testset "rank_by_fitness!()" begin
         e = BlackBoxOptim.ProblemEvaluator(p)
 
-        candidates = [BlackBoxOptim.Candidate{Float64}(clamp!(randn(2), -1.0, 1.0)) for i in 1:10]
+        candidates = [random_candidate(2, -1.0, 1.0) for i in 1:10]
         # partially evaluate fitness
         BlackBoxOptim.update_fitness!(e, candidates[1:5])
         @test BlackBoxOptim.num_evals(e) == 5

--- a/test/test_parameters.jl
+++ b/test/test_parameters.jl
@@ -108,7 +108,7 @@
         dc = DictChain(d1, d2, d3)
         iob = IOBuffer()
         show(iob, dc)
-        @test takebuf_string(iob) == "BlackBoxOptim.DictChain{Symbol,$Int}[Dict(:a=>1),Dict(:a=>2,:b=>4),Dict(:a=>3,:b=>5)]"
+        @test String(take!(iob)) == "BlackBoxOptim.DictChain{Symbol,$Int}[Dict(:a=>1),Dict(:a=>2,:b=>4),Dict(:a=>3,:b=>5)]"
     end
 
     @testset "flatten" begin

--- a/test/test_search_space.jl
+++ b/test/test_search_space.jl
@@ -89,7 +89,7 @@
             ss = RangePerDimSearchSpace(parambounds)
             @test mins(ss) == minbounds
             @test maxs(ss) == maxbounds
-            @test round(deltas(ss), 6) == round(ds, 6)
+            @test round.(deltas(ss), 6) == round.(ds, 6)
 
             # Now generate 100 individuals and make sure they are all within bounds
             inds = rand_individuals(ss, 100)

--- a/test/test_selectors.jl
+++ b/test/test_selectors.jl
@@ -2,7 +2,7 @@
 
 ss = symmetric_search_space(1, (0.0, 10.0))
 fake_problem = FunctionBasedProblem(x -> 0.0, "test_problem", MinimizingFitnessScheme, ss)
-fake_pop = collect(1.0:10.0)'
+fake_pop = reshape(collect(1.0:10.0), (1, 10))
 
 @testset "SimpleSelector" begin
     @test popsize(fake_pop) == 10
@@ -39,7 +39,8 @@ end
 
 @testset "Tournament" begin
         sel = BlackBoxOptim.TournamentSelector(MinimizingFitnessScheme, 3)
-        fake_pop = FitPopulation(collect(1.0:10.0)', NaN, collect(1.0:10.0))
+        fake_pop = FitPopulation(reshape(collect(1.0:10.0), (1, 10)),
+                                 NaN, collect(1.0:10.0))
 
         @testset "tournament()" begin
                 for i in 1:NumTestRepetitions

--- a/test/test_smoketest_bboptimize.jl
+++ b/test/test_smoketest_bboptimize.jl
@@ -17,7 +17,7 @@
 end
 
 @testset "bboptimize() multi-objective methods smoketest" begin
-    schaffer1(x) = (sumabs2(x), sumabs2(x .- 2.0))
+    schaffer1(x) = (sum(abs2, x), sum(xx -> abs2(xx - 2.0), x))
 
     for m in keys(BlackBoxOptim.MultiObjectiveMethods)
         @testset "$(m)" begin

--- a/test/test_tracing.jl
+++ b/test/test_tracing.jl
@@ -1,6 +1,6 @@
 @testset "Testing methods diagnostic tracing" begin
-        rosenbrock(x) = 100.0*sumabs2(x[2:end] - x[1:end-1].^2) + sumabs2(x[1:end-1]-1.0)
-        schaffer1(x) = (sumabs2(x), sumabs2(x .- 2.0))
+        rosenbrock(x) = 100.0*sum(i -> abs2(x[i+1] - x[i]^2), 1:length(x)-1) + sum(i -> abs2(x[i] - 1.0), 1:length(x)-1)
+        schaffer1(x) = (sum(abs2, x), sum(xx -> abs2(xx - 2.0), x))
 
         @testset "trace_state()" begin
                 for mode in [:silent, :compact, :verbose]


### PR DESCRIPTION
Fixes a number of Julia.Base v0.6 API deprecations.
Especially `X'` that returns `RowVector` and results in tests failures in v0.6.