### PR TITLE
drop Julia 0.5 and formatting cleanups

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ os:
   - linux
   - osx
 julia:
-  - 0.5
   - 0.6
   - nightly
 matrix:

--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@ BlackBoxOptim.jl
 
 [![Build Status](https://travis-ci.org/robertfeldt/BlackBoxOptim.jl.svg?branch=master)](https://travis-ci.org/robertfeldt/BlackBoxOptim.jl)
 [![Coverage Status](https://coveralls.io/repos/robertfeldt/BlackBoxOptim.jl/badge.png?branch=master)](https://coveralls.io/r/robertfeldt/BlackBoxOptim.jl?branch=master)
-[![BlackBoxOptim](http://pkg.julialang.org/badges/BlackBoxOptim_0.4.svg)](http://pkg.julialang.org/?pkg=BlackBoxOptim)
-[![BlackBoxOptim](http://pkg.julialang.org/badges/BlackBoxOptim_0.5.svg)](http://pkg.julialang.org/?pkg=BlackBoxOptim)
+[![BlackBoxOptim](http://pkg.julialang.org/badges/BlackBoxOptim_0.6.svg)](http://pkg.julialang.org/?pkg=BlackBoxOptim)
+[![BlackBoxOptim](http://pkg.julialang.org/badges/BlackBoxOptim_0.7.svg)](http://pkg.julialang.org/?pkg=BlackBoxOptim)
 
 `BlackBoxOptim` is a global optimization package for Julia (http://julialang.org/). It supports both multi- and single-objective optimization problems and is focused on (meta-)heuristic/stochastic algorithms (DE, NES etc) that do NOT require the function being optimized to be differentiable. This is in contrast to more traditional, deterministic algorithms that are often based on gradients/differentiability. It also supports parallel evaluation to speed up optimization for functions that are slow to evaluate.
 

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,5 +1,5 @@
-julia 0.5
+julia 0.6
 StatsBase
 Distributions
-Compat 0.18
+Compat
 CPUTime

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,7 +8,7 @@ environment:
 branches:
   only:
     - master
-    - /release-.*/
+    - /release-0.6/
 
 notifications:
   - provider: Email

--- a/spikes/adaptive_encoding.jl
+++ b/spikes/adaptive_encoding.jl
@@ -1,4 +1,4 @@
-@compat abstract type CoordinateTransform end
+abstract type CoordinateTransform end
 
 # Based on the pseudo-code on page 156 in Loschchilov's PhD Thesis from 2013.
 type AdaptiveEncoding <: CoordinateTransform

--- a/spikes/auc_bandit_adaptive_selection.jl
+++ b/spikes/auc_bandit_adaptive_selection.jl
@@ -8,7 +8,7 @@
 # operators, values etc. It does not have any info about what the things it selects
 # between are, below we call them items. The set of items the selector selects
 # from is typically static but might not be.
-@compat abstract type AdaptiveSelector end
+abstract type AdaptiveSelector end
 
 # The default AdaptiveSelector is a random selector.
 type RandomSelector <: AdaptiveSelector

--- a/spikes/cec14_exp1_tune_one_run_cmsa_es/cec_cmsa_es.jl
+++ b/spikes/cec14_exp1_tune_one_run_cmsa_es/cec_cmsa_es.jl
@@ -165,7 +165,7 @@ end
 
 # We create different types of Covariance matrix samplers based on different
 # decompositions.
-@compat abstract type CovarianceMatrixSampler end
+abstract type CovarianceMatrixSampler end
 
 function update_covariance_matrix!(cms::CovarianceMatrixSampler, delta, a)
   C = a * cms.C + (1 - a) * delta

--- a/spikes/covar_matrix_self_adaptation_es.jl
+++ b/spikes/covar_matrix_self_adaptation_es.jl
@@ -300,7 +300,7 @@ end
 
 # We create different types of Covariance matrix samplers based on different
 # decompositions.
-@compat abstract type CovarianceMatrixSampler end
+abstract type CovarianceMatrixSampler end
 
 function update_covariance_matrix!(cms::CovarianceMatrixSampler, delta, a)
   C = a * cms.C + (1 - a) * delta

--- a/spikes/evolutionary_programming.jl
+++ b/spikes/evolutionary_programming.jl
@@ -11,7 +11,7 @@ PopulationBasedEvolutionaryProgrammingDefaultParameters = {
 # datum while the generic population-based EP is kept in a single type. This
 # way we can easily change the strategy without having to rewrite the common parts
 # throughout.
-@compat abstract type EvolutionaryProgrammingStrategy end
+abstract type EvolutionaryProgrammingStrategy end
 
 type PopulationBasedEvolutionaryProgramming <: PopulationOptimizer
   parameters::Parameters

--- a/spikes/generating_set_search.jl
+++ b/spikes/generating_set_search.jl
@@ -1,6 +1,6 @@
 # A direction generator generates the search directions to use at each step of
 # a GSS search.
-@compat abstract type DirectionGenerator end
+abstract type DirectionGenerator end
 
 type ConstantDirectionGen <: DirectionGenerator
   directions::Array{Float64, 2}

--- a/spikes/mesh_adaptive_direct_search.jl
+++ b/spikes/mesh_adaptive_direct_search.jl
@@ -1,4 +1,4 @@
-@compat abstract type MeshAdaptiveDirectSearch end
+abstract type MeshAdaptiveDirectSearch end
 
 type LTMADS <: MeshAdaptiveDirectSearch
   n::Int

--- a/spikes/nlopt_highdim.jl
+++ b/spikes/nlopt_highdim.jl
@@ -3,7 +3,7 @@ using DataFrames
 
 include(joinpath("..", "src", "problems", "single_objective_base_functions.jl"))
 
-@compat abstract type Evaluator end
+abstract type Evaluator end
 
 type NonGradientEvaluator <: Evaluator
   func::Function

--- a/spikes/subset_tournament_cmsa_es/subset_tournament_cmsa_es.jl
+++ b/spikes/subset_tournament_cmsa_es/subset_tournament_cmsa_es.jl
@@ -286,7 +286,7 @@ end
 
 # We create different types of Covariance matrix samplers based on different
 # decompositions.
-@compat abstract type CovarianceMatrixSampler end
+abstract type CovarianceMatrixSampler end
 
 function update_covariance_matrix!(cms::CovarianceMatrixSampler, delta, a)
   C = a * cms.C + (1 - a) * delta

--- a/src/BlackBoxOptim.jl
+++ b/src/BlackBoxOptim.jl
@@ -84,9 +84,9 @@ export  Optimizer, AskTellOptimizer, SteppingOptimizer, PopulationOptimizer,
         name
 
 module Utils
-  include("utilities/latin_hypercube_sampling.jl")
-  include("utilities/assign_ranks.jl")
-  include("utilities/halton_sequence.jl")
+    include("utilities/latin_hypercube_sampling.jl")
+    include("utilities/assign_ranks.jl")
+    include("utilities/halton_sequence.jl")
 end
 
 include("search_space.jl")

--- a/src/adaptive_differential_evolution.jl
+++ b/src/adaptive_differential_evolution.jl
@@ -8,10 +8,10 @@ const ADE_DefaultOptions = chain(DE_DefaultOptions, ParamsDict(
 ))
 
 """
-  Specific data and functions for adaptation
-  An Adaptive DE typically changes parameters of the search dynamically. This is
-  typically done in the `tell!()` function when we know if the trial vector
-  was better than the target vector.
+Specific data and functions for adaptation
+An Adaptive DE typically changes parameters of the search dynamically. This is
+typically done in the `tell!()` function when we know if the trial vector
+was better than the target vector.
 """
 type AdaptiveDiffEvoParameters
   # Distributions we will use to generate new F and CR values.
@@ -53,7 +53,7 @@ function adjust!(params::AdaptiveDiffEvoParameters, index, is_improved::Bool)
 end
 
 """
-  An Adaptive DE crossover operator changes `cr` and `f` parameters of the search dynamically.
+An Adaptive DE crossover operator changes `cr` and `f` parameters of the search dynamically.
 """
 type AdaptiveDiffEvoRandBin{N} <: DiffEvoCrossoverOperator{N,1}
   params::AdaptiveDiffEvoParameters

--- a/src/adaptive_differential_evolution.jl
+++ b/src/adaptive_differential_evolution.jl
@@ -1,10 +1,10 @@
 include("bimodal_cauchy_distribution.jl")
 
 const ADE_DefaultOptions = chain(DE_DefaultOptions, ParamsDict(
-  # Distributions we will use to generate new F and CR values.
-  :fdistr => BimodalCauchy(0.65, 0.1, 1.0, 0.1, clampBelow0 = false),
-  :crdistr => BimodalCauchy(0.1, 0.1, 0.95, 0.1, clampBelow0 = false),
-  :SearchSpace => symmetric_search_space(1)
+    # Distributions we will use to generate new F and CR values.
+    :fdistr => BimodalCauchy(0.65, 0.1, 1.0, 0.1, clampBelow0 = false),
+    :crdistr => BimodalCauchy(0.1, 0.1, 0.95, 0.1, clampBelow0 = false),
+    :SearchSpace => symmetric_search_space(1)
 ))
 
 """
@@ -14,24 +14,25 @@ typically done in the `tell!()` function when we know if the trial vector
 was better than the target vector.
 """
 type AdaptiveDiffEvoParameters
-  # Distributions we will use to generate new F and CR values.
-  # In the literature Cauchy distributions have been used for sampling the
-  # `f` and `cr` constants
-  # FIXME allow any distribution?
-  fdistr::BimodalCauchy
-  crdistr::BimodalCauchy
+    # Distributions we will use to generate new F and CR values.
+    # In the literature Cauchy distributions have been used for sampling the
+    # `f` and `cr` constants
+    # FIXME allow any distribution?
+    fdistr::BimodalCauchy
+    crdistr::BimodalCauchy
 
-  fs::Vector{Float64}   # One f value per individual in population
-  crs::Vector{Float64}  # One cr value per individual in population
+    fs::Vector{Float64}   # One f value per individual in population
+    crs::Vector{Float64}  # One cr value per individual in population
 
-  function AdaptiveDiffEvoParameters(fdistr::BimodalCauchy, crdistr::BimodalCauchy)
-    @assert !fdistr.clampBelow0 && !crdistr.clampBelow0 # population probs should not be degenerated
-    new(fdistr, crdistr,
+    function AdaptiveDiffEvoParameters(fdistr::BimodalCauchy, crdistr::BimodalCauchy)
+        @assert !fdistr.clampBelow0 && !crdistr.clampBelow0 # population probs should not be degenerated
+        new(fdistr, crdistr,
         Vector{Float64}(), Vector{Float64}()) # start with empty arrays because the population size unknown
-  end
+    end
 end
 
-AdaptiveDiffEvoParameters(options::Parameters) = AdaptiveDiffEvoParameters(options[:fdistr], options[:crdistr])
+AdaptiveDiffEvoParameters(options::Parameters) =
+    AdaptiveDiffEvoParameters(options[:fdistr], options[:crdistr])
 
 function crossover_parameters(params::AdaptiveDiffEvoParameters, pop::Population, target_index)
     # initialize the f & cr array
@@ -56,11 +57,12 @@ end
 An Adaptive DE crossover operator changes `cr` and `f` parameters of the search dynamically.
 """
 type AdaptiveDiffEvoRandBin{N} <: DiffEvoCrossoverOperator{N,1}
-  params::AdaptiveDiffEvoParameters
+    params::AdaptiveDiffEvoParameters
 
-  AdaptiveDiffEvoRandBin(params::AdaptiveDiffEvoParameters) = new(params)
+    AdaptiveDiffEvoRandBin(params::AdaptiveDiffEvoParameters) = new(params)
 
-  AdaptiveDiffEvoRandBin(options::Parameters) = new(AdaptiveDiffEvoParameters(options))
+    AdaptiveDiffEvoRandBin(options::Parameters) =
+        new(AdaptiveDiffEvoParameters(options))
 end
 
 crossover_parameters(xover::AdaptiveDiffEvoRandBin, pop::Population, target_index) =
@@ -74,21 +76,23 @@ const AdaptiveDiffEvoRandBin1 = AdaptiveDiffEvoRandBin{3}
 const AdaptiveDiffEvoRandBin2 = AdaptiveDiffEvoRandBin{5}
 
 function adaptive_diffevo(problem::OptimizationProblem,
-                 options::Parameters, name::String,
-                 select::IndividualsSelector = SimpleSelector(),
-                 crossover::DiffEvoCrossoverOperator =
-                    AdaptiveDiffEvoRandBin1(chain(ADE_DefaultOptions, options)))
+                options::Parameters, name::String,
+                select::IndividualsSelector = SimpleSelector(),
+                crossover::DiffEvoCrossoverOperator =
+                AdaptiveDiffEvoRandBin1(chain(ADE_DefaultOptions, options)))
   opts = chain(ADE_DefaultOptions, options)
   pop = population(problem, opts)
   DiffEvoOpt(name, pop, select, crossover,
              RandomBound(search_space(problem)))
 end
 
-adaptive_de_rand_1_bin(problem::OptimizationProblem, options::Parameters = EMPTY_PARAMS,
-              name = "AdaptiveDE/rand/1/bin") =
+adaptive_de_rand_1_bin(problem::OptimizationProblem,
+                       options::Parameters = EMPTY_PARAMS,
+                       name = "AdaptiveDE/rand/1/bin") =
     adaptive_diffevo(problem, options, name)
 
-adaptive_de_rand_1_bin_radiuslimited(problem::OptimizationProblem, options::Parameters = EMPTY_PARAMS,
+adaptive_de_rand_1_bin_radiuslimited(problem::OptimizationProblem,
+                                     options::Parameters = EMPTY_PARAMS,
                                      name = "AdaptiveDE/rand/1/bin/radiuslimited") =
     adaptive_diffevo(problem, options, name,
                      RadiusLimitedSelector(chain(ADE_DefaultOptions, options)[:SamplerRadius]))

--- a/src/adaptive_differential_evolution.jl
+++ b/src/adaptive_differential_evolution.jl
@@ -68,8 +68,8 @@ end
 crossover_parameters(xover::AdaptiveDiffEvoRandBin, pop::Population, target_index) =
     crossover_parameters(xover.params, pop, target_index)
 
-adjust!{F}(xover::AdaptiveDiffEvoRandBin, op_index::Int, candi_index::Int,
-                 new_fitness::F, old_fitness::F, is_improved::Bool) =
+adjust!(xover::AdaptiveDiffEvoRandBin, op_index::Int, candi_index::Int,
+        new_fitness::F, old_fitness::F, is_improved::Bool) where F =
     adjust!(xover.params, candi_index, is_improved)
 
 const AdaptiveDiffEvoRandBin1 = AdaptiveDiffEvoRandBin{3}

--- a/src/adaptive_differential_evolution.jl
+++ b/src/adaptive_differential_evolution.jl
@@ -13,7 +13,7 @@ An Adaptive DE typically changes parameters of the search dynamically. This is
 typically done in the `tell!()` function when we know if the trial vector
 was better than the target vector.
 """
-type AdaptiveDiffEvoParameters
+mutable struct AdaptiveDiffEvoParameters
     # Distributions we will use to generate new F and CR values.
     # In the literature Cauchy distributions have been used for sampling the
     # `f` and `cr` constants
@@ -56,7 +56,7 @@ end
 """
 An Adaptive DE crossover operator changes `cr` and `f` parameters of the search dynamically.
 """
-type AdaptiveDiffEvoRandBin{N} <: DiffEvoCrossoverOperator{N,1}
+mutable struct AdaptiveDiffEvoRandBin{N} <: DiffEvoCrossoverOperator{N,1}
     params::AdaptiveDiffEvoParameters
 
     AdaptiveDiffEvoRandBin(params::AdaptiveDiffEvoParameters) = new(params)

--- a/src/adaptive_differential_evolution.jl
+++ b/src/adaptive_differential_evolution.jl
@@ -59,10 +59,10 @@ An Adaptive DE crossover operator changes `cr` and `f` parameters of the search 
 mutable struct AdaptiveDiffEvoRandBin{N} <: DiffEvoCrossoverOperator{N,1}
     params::AdaptiveDiffEvoParameters
 
-    AdaptiveDiffEvoRandBin(params::AdaptiveDiffEvoParameters) = new(params)
+    AdaptiveDiffEvoRandBin{N}(params::AdaptiveDiffEvoParameters) where N = new{N}(params)
 
-    AdaptiveDiffEvoRandBin(options::Parameters) =
-        new(AdaptiveDiffEvoParameters(options))
+    AdaptiveDiffEvoRandBin{N}(options::Parameters) where N =
+        new{N}(AdaptiveDiffEvoParameters(options))
 end
 
 crossover_parameters(xover::AdaptiveDiffEvoRandBin, pop::Population, target_index) =

--- a/src/adaptive_differential_evolution.jl
+++ b/src/adaptive_differential_evolution.jl
@@ -70,8 +70,8 @@ adjust!{F}(xover::AdaptiveDiffEvoRandBin, op_index::Int, candi_index::Int,
                  new_fitness::F, old_fitness::F, is_improved::Bool) =
     adjust!(xover.params, candi_index, is_improved)
 
-@compat const AdaptiveDiffEvoRandBin1 = AdaptiveDiffEvoRandBin{3}
-@compat const AdaptiveDiffEvoRandBin2 = AdaptiveDiffEvoRandBin{5}
+const AdaptiveDiffEvoRandBin1 = AdaptiveDiffEvoRandBin{3}
+const AdaptiveDiffEvoRandBin2 = AdaptiveDiffEvoRandBin{5}
 
 function adaptive_diffevo(problem::OptimizationProblem,
                  options::Parameters, name::String,

--- a/src/archive.jl
+++ b/src/archive.jl
@@ -57,25 +57,25 @@ The two last best fitness values could be used to estimate a confidence interval
 potential there is.
 """
 type TopListArchive{F<:Number,FS<:FitnessScheme} <: Archive{F,FS}
-  fit_scheme::FS        # Fitness scheme used
-  start_time::Float64   # Time when archive created, we use this to approximate the starting time for the opt...
-  numdims::Int          # Number of dimensions in the optimization problem. Needed for confidence interval estimation.
+    fit_scheme::FS        # Fitness scheme used
+    start_time::Float64   # Time when archive created, we use this to approximate the starting time for the opt...
+    numdims::Int          # Number of dimensions in the optimization problem. Needed for confidence interval estimation.
 
-  num_fitnesses::Int    # Number of calls to add_candidate
+    num_fitnesses::Int    # Number of calls to add_candidate
 
-  capacity::Int         # Max size of top lists
-  candidates::Vector{TopListIndividual{F}}  # Top candidates and their fitness values
+    capacity::Int         # Max size of top lists
+    candidates::Vector{TopListIndividual{F}}  # Top candidates and their fitness values
 
-  # Stores a fitness history that we can later print to a csv file.
-  # For each magnitude class (as defined by `magnitude_class()` function below) we
-  # we save the first entry of that class. The tuple saved for each magnitude
-  # class is: `(magnitude_class, time, num_fevals, fitness, width_of_confidence_interval)`
-  fitness_history::Vector{TopListFitness{F}}
+    # Stores a fitness history that we can later print to a csv file.
+    # For each magnitude class (as defined by `magnitude_class()` function below) we
+    # we save the first entry of that class. The tuple saved for each magnitude
+    # class is: `(magnitude_class, time, num_fevals, fitness, width_of_confidence_interval)`
+    fitness_history::Vector{TopListFitness{F}}
 
-  function (::Type{TopListArchive}){FS<:FitnessScheme}(fit_scheme::FS, numdims::Integer, capacity::Integer = 10)
-    F = fitness_type(FS)
-    new{F,FS}(fit_scheme, time(), numdims, 0, capacity, TopListIndividual{F}[], TopListFitness{F}[])
-  end
+    function (::Type{TopListArchive}){FS<:FitnessScheme}(fit_scheme::FS, numdims::Integer, capacity::Integer = 10)
+        F = fitness_type(FS)
+        new{F,FS}(fit_scheme, time(), numdims, 0, capacity, TopListIndividual{F}[], TopListFitness{F}[])
+    end
 end
 
 fitness_scheme(a::TopListArchive) = a.fit_scheme
@@ -93,21 +93,21 @@ last_top_fitness(a::TopListArchive) = !isempty(a.candidates) ? fitness(a.candida
 The difference between the current best fitness and the former best fitness.
 """
 function delta_fitness(a::TopListArchive)
-  if length(a.fitness_history) < 2
-    Inf
-  else
-    # FIXME aggregate fitness?
-    abs(a.fitness_history[end].fitness - a.fitness_history[end-1].fitness)
-  end
+    if length(a.fitness_history) < 2
+        Inf
+    else
+        # FIXME aggregate fitness?
+        abs(a.fitness_history[end].fitness - a.fitness_history[end-1].fitness)
+    end
 end
 
 function check_stop_condition(a::TopListArchive, p::OptimizationProblem, ctrl)
     if delta_fitness(a) < ctrl.min_delta_fitness_tol
-      return "Delta fitness ($(delta_fitness(a))) below tolerance ($(ctrl.min_delta_fitness_tol))"
+        return "Delta fitness ($(delta_fitness(a))) below tolerance ($(ctrl.min_delta_fitness_tol))"
     end
 
     if fitness_is_within_ftol(p, best_fitness(a), ctrl.fitness_tol)
-      return "Fitness ($(best_fitness(ctrl))) within tolerance ($(ctrl.fitness_tol)) of optimum"
+        return "Fitness ($(best_fitness(ctrl))) within tolerance ($(ctrl.fitness_tol)) of optimum"
     end
 
     return "" # no conditions met
@@ -118,27 +118,28 @@ end
 
 Add a candidate with a fitness to the archive (if it is good enough).
 """
-function add_candidate!{F,FS<:FitnessScheme}(a::TopListArchive{F,FS}, fitness::F, candidate::AbstractIndividual, tag::Int=0, num_fevals::Int=-1)
-  a.num_fitnesses += 1
-  if (num_fevals == -1) num_fevals = a.num_fitnesses end
+function add_candidate!{F,FS<:FitnessScheme}(a::TopListArchive{F,FS}, fitness::F, candidate::AbstractIndividual,
+                                             tag::Int=0, num_fevals::Int=-1)
+    a.num_fitnesses += 1
+    if (num_fevals == -1) num_fevals = a.num_fitnesses end
 
-  if isempty(a.fitness_history) || is_better(fitness, best_fitness(a), fitness_scheme(a))
-    # Save fitness history so we can reconstruct the most important events later.
-    push!(a.fitness_history, TopListFitness{F}(fitness, fitness_improvement_ratio(a, fitness), num_fevals, time()))
-  end
-
-  if length(a) < capacity(a) ||
-     !isempty(a.candidates) && is_better(fitness, last_top_fitness(a), fitness_scheme(a))
-    new_cand = TopListIndividual(copy(candidate), fitness, tag)
-    fs = fitness_scheme(a)
-    ix = searchsortedfirst(a.candidates, new_cand,
-                           # FIXME use lt=fitness_scheme(a) when v0.5 #14919 would be fixed
-                           by=BlackBoxOptim.fitness, lt=(x, y) -> is_better(x, y, fs))
-    if ix > length(a) || a.candidates[ix] != new_cand
-      insert!(a.candidates, ix, new_cand)
+    if isempty(a.fitness_history) || is_better(fitness, best_fitness(a), fitness_scheme(a))
+        # Save fitness history so we can reconstruct the most important events later.
+        push!(a.fitness_history, TopListFitness{F}(fitness, fitness_improvement_ratio(a, fitness), num_fevals, time()))
     end
-    if length(a) > capacity(a) pop!(a.candidates) end # don't grow over the capacity
-  end
+
+    if length(a) < capacity(a) ||
+       !isempty(a.candidates) && is_better(fitness, last_top_fitness(a), fitness_scheme(a))
+        new_cand = TopListIndividual(copy(candidate), fitness, tag)
+        fs = fitness_scheme(a)
+        ix = searchsortedfirst(a.candidates, new_cand,
+                               # FIXME use lt=fitness_scheme(a) when v0.5 #14919 would be fixed
+                               by=BlackBoxOptim.fitness, lt=(x, y) -> is_better(x, y, fs))
+        if ix > length(a) || a.candidates[ix] != new_cand
+            insert!(a.candidates, ix, new_cand)
+        end
+        (length(a) > capacity(a)) && pop!(a.candidates) # don't grow over the capacity
+    end
 end
 
 """
@@ -146,70 +147,63 @@ Get a tuple of the sign and the magnitude of the value rounded to the first digi
 Used for archiving candidates separately for each magnitude class.
 """
 function magnitude_class(f)
-  f = float(f)
-  if f == 0.0
-    (-1.0, 1e100)
-  else
-    (sign(f), floor(10.0*log10(abs(f)))/10.0)
-  end
+    f = float(f)
+    if f == 0.0
+        (-1.0, 1e100)
+    else
+        (sign(f), floor(10.0*log10(abs(f)))/10.0)
+    end
 end
 
 function fitness_improvement_ratio(a::Archive, newFitness)
-  try
-    bestfitness = best_fitness(a)
-    return abs( (bestfitness - newFitness) / bestfitness )
-  catch
-    return 0.0
-  end
+    try
+        bestfitness = best_fitness(a)
+        return abs( (bestfitness - newFitness) / bestfitness )
+    catch
+        return 0.0
+    end
 end
 
 """
 Get the distance from a fitness value to the optimum/best known fitness value.
 """
-function distance_to_optimum(fitness, bestfitness)
-  abs(fitness - bestfitness)
-end
+distance_to_optimum(fitness, bestfitness) = abs(fitness - bestfitness)
 
 function fitness_history_csv_header(a::Archive)
-  "Date,Time,ElapsedTime,Magnitude,NumFuncEvals,FitnessImprovementRatio,Fitness"
+    "Date,Time,ElapsedTime,Magnitude,NumFuncEvals,FitnessImprovementRatio,Fitness"
 end
 
 function save_fitness_history_to_csv_file(a::Archive, filename = "fitness_history.csv";
-  header_prefix = "", line_prefix = "",
-  include_header = true, bestfitness = nothing)
+    header_prefix = "", line_prefix = "",
+    include_header = true, bestfitness = nothing)
 
-  fh = open(filename, "a+")
+    fh = open(filename, "a+")
 
-  if include_header
+    if include_header
+        header = [header_prefix, fitness_history_csv_header(a)]
 
-    header = [header_prefix, fitness_history_csv_header(a)]
+        if bestfitness != nothing
+        push!(header, "DistanceToBestFitness")
+        end
 
-    if bestfitness != nothing
-      push!(header, "DistanceToBestFitness")
+        println(fh, join(header, ","))
     end
 
-    println(fh, join(header, ","))
+    for af in a.fitness_history
+        mc = magnitude_class(af.fitness)
 
-  end
+        line = [line_prefix, strftime("%Y-%m-%d,%T", af.timestamp),
+            af.timestamp-a.start_time,
+            mc[1]*mc[2], af.num_fevals, af.fitness_improvement_ratio, af.fitness]
 
-  for af in a.fitness_history
+        if bestfitness != nothing
+            push!(line, distance_to_optimum(af.fitness, bestfitness))
+        end
 
-    mc = magnitude_class(af.fitness)
-
-    line = [line_prefix, strftime("%Y-%m-%d,%T", af.timestamp),
-        af.timestamp-a.start_time,
-        mc[1]*mc[2], af.num_fevals, af.fitness_improvement_ratio, af.fitness]
-
-    if bestfitness != nothing
-      push!(line, distance_to_optimum(af.fitness, bestfitness))
+        println(fh, join(line, ","))
     end
 
-    println(fh, join(line, ","))
-
-  end
-
-  close(fh)
-
+    close(fh)
 end
 
 """
@@ -219,25 +213,22 @@ Merge the collection of multiple fitness histories and calculate the `min`, `max
 values for fitness and FIR (fitness improvement ratio) at each point where the fitness is changing.
 """
 function merge_fitness_histories(histories)
-  numhist = length(histories)
-  counts = ones(numhist)
-  fitnesses = zeros(numhist)
-  firs = zeros(numhist)
-  current_feval = 1
+    numhist = length(histories)
+    counts = ones(numhist)
+    fitnesses = zeros(numhist)
+    firs = zeros(numhist)
+    current_feval = 1
 
-  # Find max history length
-  maxlen = mapreduce( length, max, histories )
+    # Find max history length
+    maxlen = mapreduce( length, max, histories )
 
-  while maximum(counts) < maxlen
-
-    # Find min feval for current events, this is the next current feval
-    for i in 1:numhist
-      t, nf, f, fir = histories[i][counts[i]]
-      # FIXME ???
+    while maximum(counts) < maxlen
+        # Find min feval for current events, this is the next current feval
+        for i in 1:numhist
+            t, nf, f, fir = histories[i][counts[i]]
+            # FIXME ???
+        end
     end
-
-  end
-
 end
 
 # Merge the fitness histories and save the average values of the fitness,
@@ -269,14 +260,14 @@ l1 = best_fitness(a)
 ```
 """
 function width_of_confidence_interval(a::Archive, p = 0.01)
-  if length(a) < 2
-    return Inf
-  else
-    l1 = fitness(a.candidates[1])
-    l2 = fitness(a.candidates[2])
-    # We use abs below so it works also for maximization.
-    abs(l2 - l1) / ( (1-p)^(-2/a.numdims) - 1)
-  end
+    if length(a) < 2
+        return Inf
+    else
+        l1 = fitness(a.candidates[1])
+        l2 = fitness(a.candidates[2])
+        # We use abs below so it works also for maximization.
+        abs(l2 - l1) / ( (1-p)^(-2/a.numdims) - 1)
+    end
 end
 
 """
@@ -288,6 +279,5 @@ The percentage improvement that can be expected from the current fitness value a
 In theory, an optimization run should be terminated when this value is very
 small, i.e. there is little improvement potential left in the run.
 """
-function fitness_improvement_potential(a::Archive, p = 0.01)
-  width_of_confidence_interval(a, p) / abs(best_fitness(a))
-end
+fitness_improvement_potential(a::Archive, p = 0.01) =
+    width_of_confidence_interval(a, p) / abs(best_fitness(a))

--- a/src/archive.jl
+++ b/src/archive.jl
@@ -29,7 +29,7 @@ struct TopListIndividual{F} <: ArchivedIndividual{F}
     fitness::F
     tag::Int
 
-    (::Type{TopListIndividual}){F}(params::AbstractIndividual, fitness::F, tag::Int) =
+    TopListIndividual(params::AbstractIndividual, fitness::F, tag::Int) where F =
         new{F}(params, fitness, tag)
 end
 
@@ -72,9 +72,11 @@ mutable struct TopListArchive{F<:Number,FS<:FitnessScheme} <: Archive{F,FS}
     # class is: `(magnitude_class, time, num_fevals, fitness, width_of_confidence_interval)`
     fitness_history::Vector{TopListFitness{F}}
 
-    function (::Type{TopListArchive}){FS<:FitnessScheme}(fit_scheme::FS, numdims::Integer, capacity::Integer = 10)
+    function TopListArchive(fit_scheme::FS, numdims::Integer,
+                            capacity::Integer = 10) where FS<:FitnessScheme
         F = fitness_type(FS)
-        new{F,FS}(fit_scheme, time(), numdims, 0, capacity, TopListIndividual{F}[], TopListFitness{F}[])
+        new{F,FS}(fit_scheme, time(), numdims, 0, capacity,
+                  TopListIndividual{F}[], TopListFitness{F}[])
     end
 end
 

--- a/src/archive.jl
+++ b/src/archive.jl
@@ -1,6 +1,5 @@
 """
-  `Archive` saves information about promising solutions during an optimization
-  run.
+`Archive` saves information about promising solutions during an optimization run.
 """
 abstract type Archive{F,FS<:FitnessScheme} end
 
@@ -11,19 +10,19 @@ fitness_scheme(a::Archive) = a.fit_scheme
 """
     archived_fitness(fit, a::Archive)
 
-    Converts given fitness `fit` to the format used by the archive `a`.
+Converts given fitness `fit` to the format used by the archive `a`.
 """
 archived_fitness(fit::Any, a::Archive) = convert(fitness_type(a), fit, fitness_scheme(a))
 
 """
-    Base class for individuals stored in `Archive`.
+Base class for individuals stored in `Archive`.
 """
 abstract type ArchivedIndividual{F} <: FitIndividual{F} end
 
 tag(indi::ArchivedIndividual) = indi.tag
 
 """
-    Individual stored in `TopListArchive`.
+Individual stored in `TopListArchive`.
 """
 immutable TopListIndividual{F} <: ArchivedIndividual{F}
     params::Individual
@@ -37,7 +36,9 @@ end
 Base.:(==){F}(x::TopListIndividual{F}, y::TopListIndividual{F}) =
   (x.fitness == y.fitness) && (x.params == y.params)
 
-" Fitness as stored in `TopListArchive`. "
+"""
+Fitness as stored in `TopListArchive`.
+"""
 immutable TopListFitness{F<:Number}
     fitness::F            # current fitness
     fitness_improvement_ratio::Float64
@@ -48,12 +49,12 @@ end
 fitness(f::TopListFitness) = f.fitness
 
 """
-  Archive that maintains a top list of the best performing (best fitness)
-  candidates seen so far.
+Archive that maintains a top list of the best performing (best fitness)
+candidates seen so far.
 
 
-  The two last best fitness values could be used to estimate a confidence interval for how much improvement
-  potential there is.
+The two last best fitness values could be used to estimate a confidence interval for how much improvement
+potential there is.
 """
 type TopListArchive{F<:Number,FS<:FitnessScheme} <: Archive{F,FS}
   fit_scheme::FS        # Fitness scheme used
@@ -87,9 +88,9 @@ best_fitness(a::TopListArchive) = !isempty(a.candidates) ? fitness(a.candidates[
 last_top_fitness(a::TopListArchive) = !isempty(a.candidates) ? fitness(a.candidates[end]) : nafitness(fitness_scheme(a))
 
 """
-  `delta_fitness(a::TopListArchive)`
+    delta_fitness(a::TopListArchive)
 
-  The difference between the current best fitness and the former best fitness.
+The difference between the current best fitness and the former best fitness.
 """
 function delta_fitness(a::TopListArchive)
   if length(a.fitness_history) < 2
@@ -113,9 +114,9 @@ function check_stop_condition(a::TopListArchive, p::OptimizationProblem, ctrl)
 end
 
 """
-  `add_candidate!(a::TopListArchive, fitness::F, candidate[, tag=0][, num_fevals=-1])`
+    add_candidate!(a::TopListArchive, fitness::F, candidate[, tag=0][, num_fevals=-1])
 
-  Add a candidate with a fitness to the archive (if it is good enough).
+Add a candidate with a fitness to the archive (if it is good enough).
 """
 function add_candidate!{F,FS<:FitnessScheme}(a::TopListArchive{F,FS}, fitness::F, candidate::AbstractIndividual, tag::Int=0, num_fevals::Int=-1)
   a.num_fitnesses += 1
@@ -141,8 +142,8 @@ function add_candidate!{F,FS<:FitnessScheme}(a::TopListArchive{F,FS}, fitness::F
 end
 
 """
-  Get a tuple of the sign and the magnitude of the value rounded to the first digit.
-  Used for archiving candidates separately for each magnitude class.
+Get a tuple of the sign and the magnitude of the value rounded to the first digit.
+Used for archiving candidates separately for each magnitude class.
 """
 function magnitude_class(f)
   f = float(f)
@@ -163,7 +164,7 @@ function fitness_improvement_ratio(a::Archive, newFitness)
 end
 
 """
-  Get the distance from a fitness value to the optimum/best known fitness value.
+Get the distance from a fitness value to the optimum/best known fitness value.
 """
 function distance_to_optimum(fitness, bestfitness)
   abs(fitness - bestfitness)
@@ -212,10 +213,10 @@ function save_fitness_history_to_csv_file(a::Archive, filename = "fitness_histor
 end
 
 """
-  `merge_fitness_histories(histories)`
+    merge_fitness_histories(histories)
 
-  Merge the collection of multiple fitness histories and calculate the `min`, `max`, `avg` and `median`
-  values for fitness and FIR (fitness improvement ratio) at each point where the fitness is changing.
+Merge the collection of multiple fitness histories and calculate the `min`, `max`, `avg` and `median`
+values for fitness and FIR (fitness improvement ratio) at each point where the fitness is changing.
 """
 function merge_fitness_histories(histories)
   numhist = length(histories)
@@ -248,24 +249,24 @@ end
 #end
 
 """
-  Calculate the width of the confidence interval at a certain `p`-value.
-  This is based on the paper:
+Calculate the width of the confidence interval at a certain `p`-value.
+This is based on the paper:
     Carvalho (2011), "Confidence intervals for the minimum of a
     function using extreme value statistics"
 
-  This means that the current estimate of the confidence interval for the minimum
-  of the optimized function lies within the interval
+This means that the current estimate of the confidence interval for the minimum
+of the optimized function lies within the interval
 
-  ```
-     ] l1 - w, l1 [
-  ```
+```
+] l1 - w, l1 [
+```
 
-  with probability ``(1-p)`` as the number of sampled function points goes to infinity,
-  where
-  ```
-    w = width_of_confidence_interval(a, p)
-    l1 = best_fitness(a)
-  ```
+with probability ``(1-p)`` as the number of sampled function points goes to infinity,
+where
+```
+w = width_of_confidence_interval(a, p)
+l1 = best_fitness(a)
+```
 """
 function width_of_confidence_interval(a::Archive, p = 0.01)
   if length(a) < 2
@@ -279,13 +280,13 @@ function width_of_confidence_interval(a::Archive, p = 0.01)
 end
 
 """
-  `fitness_improvement_potential(a::Archive[, p = 0.01])`
+    fitness_improvement_potential(a::Archive[, p = 0.01])
 
-  Calculate the solution improvement potential.
+Calculate the solution improvement potential.
 
-  The percentage improvement that can be expected from the current fitness value at a given `p`-value.
-  In theory, an optimization run should be terminated when this value is very
-  small, i.e. there is little improvement potential left in the run.
+The percentage improvement that can be expected from the current fitness value at a given `p`-value.
+In theory, an optimization run should be terminated when this value is very
+small, i.e. there is little improvement potential left in the run.
 """
 function fitness_improvement_potential(a::Archive, p = 0.01)
   width_of_confidence_interval(a, p) / abs(best_fitness(a))

--- a/src/archive.jl
+++ b/src/archive.jl
@@ -2,7 +2,7 @@
   `Archive` saves information about promising solutions during an optimization
   run.
 """
-@compat abstract type Archive{F,FS<:FitnessScheme} end
+abstract type Archive{F,FS<:FitnessScheme} end
 
 numdims(a::Archive) = a.numdims
 fitness_type{F}(a::Archive{F}) = F
@@ -18,7 +18,7 @@ archived_fitness(fit::Any, a::Archive) = convert(fitness_type(a), fit, fitness_s
 """
     Base class for individuals stored in `Archive`.
 """
-@compat abstract type ArchivedIndividual{F} <: FitIndividual{F} end
+abstract type ArchivedIndividual{F} <: FitIndividual{F} end
 
 tag(indi::ArchivedIndividual) = indi.tag
 

--- a/src/archive.jl
+++ b/src/archive.jl
@@ -24,7 +24,7 @@ tag(indi::ArchivedIndividual) = indi.tag
 """
 Individual stored in `TopListArchive`.
 """
-immutable TopListIndividual{F} <: ArchivedIndividual{F}
+struct TopListIndividual{F} <: ArchivedIndividual{F}
     params::Individual
     fitness::F
     tag::Int
@@ -39,7 +39,7 @@ Base.:(==){F}(x::TopListIndividual{F}, y::TopListIndividual{F}) =
 """
 Fitness as stored in `TopListArchive`.
 """
-immutable TopListFitness{F<:Number}
+struct TopListFitness{F<:Number}
     fitness::F            # current fitness
     fitness_improvement_ratio::Float64
     num_fevals::Int     # number of fitness evaluations so far
@@ -56,7 +56,7 @@ candidates seen so far.
 The two last best fitness values could be used to estimate a confidence interval for how much improvement
 potential there is.
 """
-type TopListArchive{F<:Number,FS<:FitnessScheme} <: Archive{F,FS}
+mutable struct TopListArchive{F<:Number,FS<:FitnessScheme} <: Archive{F,FS}
     fit_scheme::FS        # Fitness scheme used
     start_time::Float64   # Time when archive created, we use this to approximate the starting time for the opt...
     numdims::Int          # Number of dimensions in the optimization problem. Needed for confidence interval estimation.

--- a/src/archive.jl
+++ b/src/archive.jl
@@ -4,7 +4,7 @@
 abstract type Archive{F,FS<:FitnessScheme} end
 
 numdims(a::Archive) = a.numdims
-fitness_type{F}(a::Archive{F}) = F
+fitness_type(a::Archive{F}) where F = F
 fitness_scheme(a::Archive) = a.fit_scheme
 
 """
@@ -33,7 +33,7 @@ struct TopListIndividual{F} <: ArchivedIndividual{F}
         new{F}(params, fitness, tag)
 end
 
-Base.:(==){F}(x::TopListIndividual{F}, y::TopListIndividual{F}) =
+Base.:(==)(x::TopListIndividual{F}, y::TopListIndividual{F}) where F =
   (x.fitness == y.fitness) && (x.params == y.params)
 
 """
@@ -120,8 +120,8 @@ end
 
 Add a candidate with a fitness to the archive (if it is good enough).
 """
-function add_candidate!{F,FS<:FitnessScheme}(a::TopListArchive{F,FS}, fitness::F, candidate::AbstractIndividual,
-                                             tag::Int=0, num_fevals::Int=-1)
+function add_candidate!(a::TopListArchive{F}, fitness::F, candidate::AbstractIndividual,
+                        tag::Int=0, num_fevals::Int=-1) where F
     a.num_fitnesses += 1
     if (num_fevals == -1) num_fevals = a.num_fitnesses end
 

--- a/src/archives/epsbox_archive.jl
+++ b/src/archives/epsbox_archive.jl
@@ -1,7 +1,7 @@
 """
 Individual representing the solution from the Pareto set.
 """
-immutable FrontierIndividual{F} <: ArchivedIndividual{F}
+struct FrontierIndividual{F} <: ArchivedIndividual{F}
     fitness::F
     params::Individual
     tag::Int                            # tag of the individual (e.g. gen.op. ID)
@@ -36,7 +36,7 @@ dominated by any other solutions in the archive.
 It also counts the number of candidate solutions that have been added
 and how many ϵ-box progresses have been made.
 """
-type EpsBoxArchive{N,F,FS<:EpsBoxDominanceFitnessScheme} <: Archive{IndexedTupleFitness{N,F},FS}
+mutable struct EpsBoxArchive{N,F,FS<:EpsBoxDominanceFitnessScheme} <: Archive{IndexedTupleFitness{N,F},FS}
     fit_scheme::FS        # Fitness scheme used
     start_time::Float64   # Time when archive created, we use this to approximate the starting time for the opt...
 
@@ -75,7 +75,7 @@ numdims(a::EpsBoxArchive) = !isempty(a.frontier) ? length(a.frontier[1].params) 
 """
 Iterates occupied elements of the `archive.frontier`.
 """
-immutable EpsBoxArchiveFrontierIterator{A<:EpsBoxArchive}
+struct EpsBoxArchiveFrontierIterator{A<:EpsBoxArchive}
     archive::A
     (::Type{EpsBoxArchiveFrontierIterator}){A<:EpsBoxArchive}(a::A) = new{A}(a)
 end

--- a/src/archives/epsbox_archive.jl
+++ b/src/archives/epsbox_archive.jl
@@ -168,8 +168,8 @@ function tagcounts(a::EpsBoxArchive, θ::Number = 1.0)
     return res
 end
 
-function add_candidate!{N,F}(a::EpsBoxArchive{N,F}, cand_fitness::IndexedTupleFitness{N,F},
-                             candidate, tag::Int=0, num_fevals::Int=-1)
+function add_candidate!(a::EpsBoxArchive{N,F}, cand_fitness::IndexedTupleFitness{N,F},
+                        candidate, tag::Int=0, num_fevals::Int=-1) where {N,F}
     a.num_candidates += 1
     if num_fevals == -1
         num_fevals = a.num_candidates
@@ -256,8 +256,8 @@ end
 
 # actually this methods should never be called because the fitness
 # is already indexes within the method
-add_candidate!{N,F}(a::EpsBoxArchive{N,F}, cand_fitness::NTuple{N,F},
-                    candidate::AbstractIndividual, tag::Int=0, num_fevals::Int=-1) =
+add_candidate!(a::EpsBoxArchive{N,F}, cand_fitness::NTuple{N,F},
+               candidate::AbstractIndividual, tag::Int=0, num_fevals::Int=-1) where {N,F} =
     add_candidate!(a, archived_fitness(cand_fitness, a), candidate, tag, num_fevals)
 
 # called by check_stop_condition(e::Evaluator, ctrl)

--- a/src/archives/epsbox_archive.jl
+++ b/src/archives/epsbox_archive.jl
@@ -1,5 +1,5 @@
 """
-    Individual representing the solution from the Pareto set.
+Individual representing the solution from the Pareto set.
 """
 immutable FrontierIndividual{F} <: ArchivedIndividual{F}
     fitness::F
@@ -21,7 +21,7 @@ end
 tag(indi::FrontierIndividual) = indi.tag
 
 """
-    Individual stored in `EpsBoxArchive`.
+Individual stored in `EpsBoxArchive`.
 """
 const EpsBoxFrontierIndividual{N,F<:Number} = FrontierIndividual{IndexedTupleFitness{N,F}}
 
@@ -30,11 +30,11 @@ const EpsBoxFrontierIndividual{N,F<:Number} = FrontierIndividual{IndexedTupleFit
     FrontierIndividual(fitness, params, tag, num_fevals, n_restarts, timestamp)
 
 """
-    ϵ-box archive saves only the solutions that are not ϵ-box
-    dominated by any other solutions in the archive.
+ϵ-box archive saves only the solutions that are not ϵ-box
+dominated by any other solutions in the archive.
 
-    It also counts the number of candidate solutions that have been added
-    and how many ϵ-box progresses have been made.
+It also counts the number of candidate solutions that have been added
+and how many ϵ-box progresses have been made.
 """
 type EpsBoxArchive{N,F,FS<:EpsBoxDominanceFitnessScheme} <: Archive{IndexedTupleFitness{N,F},FS}
   fit_scheme::FS        # Fitness scheme used
@@ -73,7 +73,7 @@ capacity(a::EpsBoxArchive) = a.max_size
 numdims(a::EpsBoxArchive) = !isempty(a.frontier) ? length(a.frontier[1].params) : 0
 
 """
-    Iterates occupied elements of the `archive.frontier`.
+Iterates occupied elements of the `archive.frontier`.
 """
 immutable EpsBoxArchiveFrontierIterator{A<:EpsBoxArchive}
     archive::A
@@ -86,7 +86,7 @@ end
 @inline Base.next(it::EpsBoxArchiveFrontierIterator, ix::Integer) = (it.archive.frontier[ix], findnext(it.archive.frontier_isoccupied, ix+1))
 
 """
-    Get the iterator to the individuals on the Pareto frontier.
+Get the iterator to the individuals on the Pareto frontier.
 """
 pareto_frontier(a::EpsBoxArchive) = EpsBoxArchiveFrontierIterator(a)
 
@@ -102,8 +102,8 @@ function occupied_frontier_indices(a::EpsBoxArchive)
 end
 
 """
-    Get random occupied Pareto frontier index.
-    Returns 0 if frontier is empty.
+Get random occupied Pareto frontier index.
+Returns 0 if frontier is empty.
 """
 function rand_frontier_index(a::EpsBoxArchive)
     if a.len == 0
@@ -122,11 +122,11 @@ function rand_frontier_index(a::EpsBoxArchive)
 end
 
 """
-    `noprogress_streak(a::EpsBoxArchive, [since_restart])`
+    noprogress_streak(a::EpsBoxArchive, [since_restart])
 
-    Get the number of `add_candidate!()` calls since the last ϵ-progress.
-    If `since_restart` is specified, the number is relative to the last
-    restart.
+Get the number of `add_candidate!()` calls since the last ϵ-progress.
+If `since_restart` is specified, the number is relative to the last
+restart.
 """
 noprogress_streak(a::EpsBoxArchive; since_restart::Bool=false) =
     since_restart ?
@@ -145,12 +145,12 @@ function notify!(a::EpsBoxArchive, event::Symbol)
 end
 
 """
-    `tagcounts(a::EpsBoxArchive)`
+    tagcounts(a::EpsBoxArchive)
 
-    Count the tags of individuals on the ϵ-box frontier.
-    Each restart the individual remains in the frontier discounts it by `θ`.
+Count the tags of individuals on the ϵ-box frontier.
+Each restart the individual remains in the frontier discounts it by `θ`.
 
-    Returns the `tag`→`count` dictionary.
+Returns the `tag`→`count` dictionary.
 """
 function tagcounts(a::EpsBoxArchive, θ::Number = 1.0)
     (0.0 < θ <= 1.0) || throw(ArgumentError("θ ($θ) should be in (0.0, 1.0] range"))

--- a/src/archives/epsbox_archive.jl
+++ b/src/archives/epsbox_archive.jl
@@ -23,7 +23,7 @@ tag(indi::FrontierIndividual) = indi.tag
 """
     Individual stored in `EpsBoxArchive`.
 """
-@compat const EpsBoxFrontierIndividual{N,F<:Number} = FrontierIndividual{IndexedTupleFitness{N,F}}
+const EpsBoxFrontierIndividual{N,F<:Number} = FrontierIndividual{IndexedTupleFitness{N,F}}
 
 (::Type{EpsBoxFrontierIndividual}){N,F}(fitness::IndexedTupleFitness{N,F},
                params, tag, num_fevals, n_restarts, timestamp=time()) =

--- a/src/archives/epsbox_archive.jl
+++ b/src/archives/epsbox_archive.jl
@@ -37,34 +37,34 @@ It also counts the number of candidate solutions that have been added
 and how many ϵ-box progresses have been made.
 """
 type EpsBoxArchive{N,F,FS<:EpsBoxDominanceFitnessScheme} <: Archive{IndexedTupleFitness{N,F},FS}
-  fit_scheme::FS        # Fitness scheme used
-  start_time::Float64   # Time when archive created, we use this to approximate the starting time for the opt...
+    fit_scheme::FS        # Fitness scheme used
+    start_time::Float64   # Time when archive created, we use this to approximate the starting time for the opt...
 
-  num_candidates::Int               # Number of calls to add_candidate!()
-  best_candidate_ix::Int            # the index of the candidate with the best aggregated fitness
-  last_progress::Int                # when (wrt num_candidates) last ϵ-progress has occured
-  last_restart::Int                 # when (wrt num_dlast) last restart has occured
-  n_restarts::Int                   # the counter of the method restarts
+    num_candidates::Int               # Number of calls to add_candidate!()
+    best_candidate_ix::Int            # the index of the candidate with the best aggregated fitness
+    last_progress::Int                # when (wrt num_candidates) last ϵ-progress has occured
+    last_restart::Int                 # when (wrt num_dlast) last restart has occured
+    n_restarts::Int                   # the counter of the method restarts
 
-  len::Int              # current frontier size
-  max_size::Int         # maximal frontier size
-  # TODO allow different frontier containers?
-  # see e.g. Altwaijry & Menai "Data Structures in Multi-Objective Evolutionary Algorithms", 2012
-  frontier::Vector{EpsBoxFrontierIndividual{N,F}}  # candidates along the fitness Pareto frontier
-  frontier_isoccupied::BitVector # true if given frontier element is occupied
+    len::Int              # current frontier size
+    max_size::Int         # maximal frontier size
+    # TODO allow different frontier containers?
+    # see e.g. Altwaijry & Menai "Data Structures in Multi-Objective Evolutionary Algorithms", 2012
+    frontier::Vector{EpsBoxFrontierIndividual{N,F}}  # candidates along the fitness Pareto frontier
+    frontier_isoccupied::BitVector # true if given frontier element is occupied
 
-  function (::Type{EpsBoxArchive}){N,F}(fit_scheme::EpsBoxDominanceFitnessScheme{N,F}; max_size::Integer = 1_000_000)
-    new{N,F,typeof(fit_scheme)}(fit_scheme, time(), 0, 0, 0, 0, 0, 0, max_size,
-                                sizehint!(Vector{EpsBoxFrontierIndividual{N,F}}(), 64),
-                                sizehint!(BitVector(), 64))
-  end
+    function (::Type{EpsBoxArchive}){N,F}(fit_scheme::EpsBoxDominanceFitnessScheme{N,F}; max_size::Integer = 1_000_000)
+        new{N,F,typeof(fit_scheme)}(fit_scheme, time(), 0, 0, 0, 0, 0, 0, max_size,
+                                    sizehint!(Vector{EpsBoxFrontierIndividual{N,F}}(), 64),
+                                    sizehint!(BitVector(), 64))
+    end
 
-  (::Type{EpsBoxArchive}){N,F}(fit_scheme::EpsBoxDominanceFitnessScheme{N,F}, params::Parameters) =
-    EpsBoxArchive(fit_scheme, max_size=params[:MaxArchiveSize])
+    (::Type{EpsBoxArchive}){N,F}(fit_scheme::EpsBoxDominanceFitnessScheme{N,F}, params::Parameters) =
+        EpsBoxArchive(fit_scheme, max_size=params[:MaxArchiveSize])
 end
 
 const EpsBoxArchive_DefaultParameters = ParamsDict(
-  :MaxArchiveSize => 10_000,
+    :MaxArchiveSize => 10_000,
 )
 
 Base.length(a::EpsBoxArchive) = a.len
@@ -135,6 +135,7 @@ noprogress_streak(a::EpsBoxArchive; since_restart::Bool=false) =
 
 best_candidate(a::EpsBoxArchive) = a.frontier[a.best_candidate_ix].params
 best_fitness(a::EpsBoxArchive) = a.best_candidate_ix > 0 ? fitness(a.frontier[a.best_candidate_ix]) : nafitness(fitness_scheme(a))
+
 function notify!(a::EpsBoxArchive, event::Symbol)
     if event == :restart
         a.n_restarts += 1
@@ -261,6 +262,7 @@ add_candidate!{N,F}(a::EpsBoxArchive{N,F}, cand_fitness::NTuple{N,F},
 
 # called by check_stop_condition(e::Evaluator, ctrl)
 function check_stop_condition(a::EpsBoxArchive, p::OptimizationProblem, ctrl)
-    ctrl.max_steps_without_progress > 0 && noprogress_streak(a, since_restart=false) > ctrl.max_steps_without_progress ?
+    ctrl.max_steps_without_progress > 0 &&
+    noprogress_streak(a, since_restart=false) > ctrl.max_steps_without_progress ?
         "No epsilon-progress for more than $(ctrl.max_steps_without_progress) iterations" : ""
 end

--- a/src/archives/epsbox_archive.jl
+++ b/src/archives/epsbox_archive.jl
@@ -9,12 +9,12 @@ struct FrontierIndividual{F} <: ArchivedIndividual{F}
     n_restarts::Int                     # the number of method restarts so far
     timestamp::Float64                  # when archived
 
-    FrontierIndividual(fitness::F,
-                   params, tag, num_fevals, n_restarts, timestamp=time()) =
-        new(fitness, params, tag, num_fevals, n_restarts, timestamp)
+    FrontierIndividual{F}(fitness::F,
+                   params, tag, num_fevals, n_restarts, timestamp=time()) where F =
+        new{F}(fitness, params, tag, num_fevals, n_restarts, timestamp)
 
-    (::Type{FrontierIndividual}){F}(fitness::F,
-                   params, tag, num_fevals, n_restarts, timestamp=time()) =
+    FrontierIndividual(fitness::F,
+                   params, tag, num_fevals, n_restarts, timestamp=time()) where F =
         new{F}(fitness, params, tag, num_fevals, n_restarts, timestamp)
 end
 
@@ -25,8 +25,8 @@ Individual stored in `EpsBoxArchive`.
 """
 const EpsBoxFrontierIndividual{N,F<:Number} = FrontierIndividual{IndexedTupleFitness{N,F}}
 
-(::Type{EpsBoxFrontierIndividual}){N,F}(fitness::IndexedTupleFitness{N,F},
-               params, tag, num_fevals, n_restarts, timestamp=time()) =
+EpsBoxFrontierIndividual(fitness::IndexedTupleFitness{N,F},
+               params, tag, num_fevals, n_restarts, timestamp=time()) where {N,F} =
     FrontierIndividual(fitness, params, tag, num_fevals, n_restarts, timestamp)
 
 """
@@ -53,15 +53,15 @@ mutable struct EpsBoxArchive{N,F,FS<:EpsBoxDominanceFitnessScheme} <: Archive{In
     frontier::Vector{EpsBoxFrontierIndividual{N,F}}  # candidates along the fitness Pareto frontier
     frontier_isoccupied::BitVector # true if given frontier element is occupied
 
-    function (::Type{EpsBoxArchive}){N,F}(fit_scheme::EpsBoxDominanceFitnessScheme{N,F}; max_size::Integer = 1_000_000)
+    EpsBoxArchive(fit_scheme::EpsBoxDominanceFitnessScheme{N,F};
+                  max_size::Integer = 1_000_000) where {N,F} =
         new{N,F,typeof(fit_scheme)}(fit_scheme, time(), 0, 0, 0, 0, 0, 0, max_size,
                                     sizehint!(Vector{EpsBoxFrontierIndividual{N,F}}(), 64),
                                     sizehint!(BitVector(), 64))
-    end
-
-    (::Type{EpsBoxArchive}){N,F}(fit_scheme::EpsBoxDominanceFitnessScheme{N,F}, params::Parameters) =
-        EpsBoxArchive(fit_scheme, max_size=params[:MaxArchiveSize])
 end
+
+EpsBoxArchive(fit_scheme::EpsBoxDominanceFitnessScheme{N,F}, params::Parameters) where {N,F} =
+    EpsBoxArchive(fit_scheme, max_size=params[:MaxArchiveSize])
 
 const EpsBoxArchive_DefaultParameters = ParamsDict(
     :MaxArchiveSize => 10_000,
@@ -77,7 +77,7 @@ Iterates occupied elements of the `archive.frontier`.
 """
 struct EpsBoxArchiveFrontierIterator{A<:EpsBoxArchive}
     archive::A
-    (::Type{EpsBoxArchiveFrontierIterator}){A<:EpsBoxArchive}(a::A) = new{A}(a)
+    EpsBoxArchiveFrontierIterator(a::A) where {A<:EpsBoxArchive} = new{A}(a)
 end
 
 @inline Base.length(it::EpsBoxArchiveFrontierIterator) = length(it.archive)

--- a/src/bboptimize.jl
+++ b/src/bboptimize.jl
@@ -10,37 +10,37 @@ There are several `setup_problem()` method that accept different type of
     * `FunctionBasedProblemFamily` (`:NumDimensions` has to be specified in `parameters`)
 """
 function setup_problem(problem::OptimizationProblem, parameters::Parameters)
-  return problem, parameters
+    return problem, parameters
 end
 
 function setup_problem(family::FunctionBasedProblemFamily, parameters::Parameters)
-  # If an anydim problem was given the dimension param must have been specified.
-  if parameters[:NumDimensions] == :NotSpecified
-    throw(ArgumentError("You MUST specify NumDimensions= when a problem family is given"))
-  end
-  problem = instantiate(family, parameters[:NumDimensions])
+    # If an anydim problem was given the dimension param must have been specified.
+    if parameters[:NumDimensions] == :NotSpecified
+        throw(ArgumentError("You MUST specify NumDimensions= when a problem family is given"))
+    end
+    problem = instantiate(family, parameters[:NumDimensions])
 
-  return problem, parameters
+    return problem, parameters
 end
 
 function setup_problem(func::Function, parameters::Parameters)
-  ss = check_and_create_search_space(parameters)
+    ss = check_and_create_search_space(parameters)
 
-  # Now create an optimization problem with the given information. We currently reuse the type
-  # from our pre-defined problems so some of the data for the constructor is dummy.
-  problem = FunctionBasedProblem(func, "<unknown>", parameters[:FitnessScheme], ss,
-                                 parameters[:TargetFitness])
+    # Now create an optimization problem with the given information. We currently reuse the type
+    # from our pre-defined problems so some of the data for the constructor is dummy.
+    problem = FunctionBasedProblem(func, "<unknown>", parameters[:FitnessScheme], ss,
+                                   parameters[:TargetFitness])
 
-  # validate fitness: create a random solution from the search space and ensure that fitness(problem) returns fitness_type(problem).
-  ind = rand_individual(search_space(problem))
-  res = fitness(ind, problem)
-  if !isa(res, fitness_type(problem))
-    throw(ArgumentError("The supplied fitness function does NOT return the expected fitness type "*
-                        "when called with a potential solution "*
-                        "(when called with $(ind) it returned $(res)) so we cannot optimize it!"))
-  end
+    # validate fitness: create a random solution from the search space and ensure that fitness(problem) returns fitness_type(problem).
+    ind = rand_individual(search_space(problem))
+    res = fitness(ind, problem)
+    if !isa(res, fitness_type(problem))
+      throw(ArgumentError("The supplied fitness function does NOT return the expected fitness type "*
+                          "when called with a potential solution "*
+                          "(when called with $(ind) it returned $(res)) so we cannot optimize it!"))
+    end
 
-  return problem, parameters
+    return problem, parameters
 end
 
 """
@@ -59,15 +59,15 @@ Returns `OptimizationResults` instance.
 See also `bbsetup()`.
 """
 function bboptimize(optctrl::OptController; kwargs...)
-  if length(kwargs) > 0
-    update_parameters!(optctrl, convert(ParamsDict, kwargs))
-  end
-  run!(optctrl)
+    if length(kwargs) > 0
+        update_parameters!(optctrl, convert(ParamsDict, kwargs))
+    end
+    run!(optctrl)
 end
 
 function bboptimize(functionOrProblem, parameters::Parameters = EMPTY_PARAMS; kwargs...)
-  optctrl = bbsetup(functionOrProblem, parameters; kwargs...)
-  run!(optctrl)
+    optctrl = bbsetup(functionOrProblem, parameters; kwargs...)
+    run!(optctrl)
 end
 
 """
@@ -82,18 +82,18 @@ Returns the initialized `OptController` instance. To actually run the method
 call `bboptimize()` or `run!()`.
 """
 function bbsetup(functionOrProblem, parameters::Parameters = EMPTY_PARAMS; kwargs...)
-  parameters = chain(convert(ParamsDict, parameters), convert(ParamsDict, kwargs))
-  problem, params = setup_problem(functionOrProblem, chain(DefaultParameters, parameters))
-  check_valid!(params)
+    parameters = chain(convert(ParamsDict, parameters), convert(ParamsDict, kwargs))
+    problem, params = setup_problem(functionOrProblem, chain(DefaultParameters, parameters))
+    check_valid!(params)
 
-  optimizer_func = chain(SingleObjectiveMethods, MultiObjectiveMethods)[params[:Method]]
-  optimizer = optimizer_func(problem, params)
+    optimizer_func = chain(SingleObjectiveMethods, MultiObjectiveMethods)[params[:Method]]
+    optimizer = optimizer_func(problem, params)
 
-  # Now set up a controller for this problem. This will handle
-  # application of optimizer, checking for termination conditions
-  # as well as collecting the statistics about the number of function evals,
-  # keep an archive and top list of candidates.
-  ctrl = OptController(optimizer, problem, params)
+    # Now set up a controller for this problem. This will handle
+    # application of optimizer, checking for termination conditions
+    # as well as collecting the statistics about the number of function evals,
+    # keep an archive and top list of candidates.
+    ctrl = OptController(optimizer, problem, params)
 
-  return ctrl
+    return ctrl
 end

--- a/src/bboptimize.jl
+++ b/src/bboptimize.jl
@@ -60,7 +60,7 @@ See also `bbsetup()`.
 """
 function bboptimize(optctrl::OptController; kwargs...)
     if length(kwargs) > 0
-        update_parameters!(optctrl, convert(ParamsDict, kwargs))
+        update_parameters!(optctrl, kwargs2dict(kwargs))
     end
     run!(optctrl)
 end
@@ -82,7 +82,7 @@ Returns the initialized `OptController` instance. To actually run the method
 call `bboptimize()` or `run!()`.
 """
 function bbsetup(functionOrProblem, parameters::Parameters = EMPTY_PARAMS; kwargs...)
-    parameters = chain(convert(ParamsDict, parameters), convert(ParamsDict, kwargs))
+    parameters = chain(convert(ParamsDict, parameters), kwargs2dict(kwargs))
     problem, params = setup_problem(functionOrProblem, chain(DefaultParameters, parameters))
     check_valid!(params)
 

--- a/src/bboptimize.jl
+++ b/src/bboptimize.jl
@@ -1,10 +1,10 @@
 """
-  `setup_problem(problem, parameters::Parameters)`
+    setup_problem(problem, parameters::Parameters)
 
-  Set up a fixed-dimensional optimization problem.
+Set up a fixed-dimensional optimization problem.
 
-  There are several `setup_problem()` method that accept different type of
-  `problem` argument:
+There are several `setup_problem()` method that accept different type of
+`problem` argument:
     * `OptimizationProblem`
     * function (`:NumDimensions` has to be specified in `parameters`)
     * `FunctionBasedProblemFamily` (`:NumDimensions` has to be specified in `parameters`)
@@ -44,19 +44,19 @@ function setup_problem(func::Function, parameters::Parameters)
 end
 
 """
-  `bboptimize(problem[; parameters::Associative, kwargs...])`
+    bboptimize(problem[; parameters::Associative, kwargs...])
 
-  Solve given optimization `problem`.
+Solve given optimization `problem`.
 
-  See `setup_problem()` for the types of `problem` supported.
-  In addition, the `problem` could be `OptController` containing the
-  results of the previous optimization runs.
+See `setup_problem()` for the types of `problem` supported.
+In addition, the `problem` could be `OptController` containing the
+results of the previous optimization runs.
 
-  The optimization method parameters could be specified via `kwargs` or `parameters` arguments.
+The optimization method parameters could be specified via `kwargs` or `parameters` arguments.
 
-  Returns `OptimizationResults` instance.
+Returns `OptimizationResults` instance.
 
-  See also `bbsetup()`.
+See also `bbsetup()`.
 """
 function bboptimize(optctrl::OptController; kwargs...)
   if length(kwargs) > 0
@@ -71,15 +71,15 @@ function bboptimize(functionOrProblem, parameters::Parameters = EMPTY_PARAMS; kw
 end
 
 """
-  `bbsetup(problem[; parameters::Associative, kwargs...])`
+    bbsetup(problem[; parameters::Associative, kwargs...])
 
-  Set up optimization method for a given problem.
+Set up optimization method for a given problem.
 
-  See `setup_problem()` for the types of `problem` supported.
-  The optimization method parameters could be specified via `kwargs` or `parameters` arguments.
+See `setup_problem()` for the types of `problem` supported.
+The optimization method parameters could be specified via `kwargs` or `parameters` arguments.
 
-  Returns the initialized `OptController` instance. To actually run the method
-  call `bboptimize()` or `run!()`.
+Returns the initialized `OptController` instance. To actually run the method
+call `bboptimize()` or `run!()`.
 """
 function bbsetup(functionOrProblem, parameters::Parameters = EMPTY_PARAMS; kwargs...)
   parameters = chain(convert(ParamsDict, parameters), convert(ParamsDict, kwargs))

--- a/src/bimodal_cauchy_distribution.jl
+++ b/src/bimodal_cauchy_distribution.jl
@@ -7,7 +7,7 @@ Random values are further constrained to `[0.0, 1.0]` range either by
 truncating the initial unconstrained value or by generating new random value
 until it fits the range.
 """
-immutable BimodalCauchy
+struct BimodalCauchy
     a::Cauchy
     b::Cauchy
     mix_prob::Float64

--- a/src/bimodal_cauchy_distribution.jl
+++ b/src/bimodal_cauchy_distribution.jl
@@ -2,10 +2,10 @@ using Distributions
 
 # FIXME implement actual distribution using Distributions.MixtureModel
 """
-    A mixture of 2 Cauchy distributions.
-    Random values are further constrained to `[0.0, 1.0]` range either by
-    truncating the initial unconstrained value or by generating new random value
-    until it fits the range.
+A mixture of 2 Cauchy distributions.
+Random values are further constrained to `[0.0, 1.0]` range either by
+truncating the initial unconstrained value or by generating new random value
+until it fits the range.
 """
 immutable BimodalCauchy
     a::Cauchy

--- a/src/borg_moea.jl
+++ b/src/borg_moea.jl
@@ -36,11 +36,12 @@ mutable struct BorgMOEA{FS<:FitnessScheme,V<:Evaluator,P<:Population,M<:GeneticO
     modify::M         # operator to mutate frontier element during restarts
     embed::E          # embedding operator
 
-    function (::Type{BorgMOEA}){O<:OptimizationProblem, P<:Population,
-                     M<:GeneticOperator, E<:EmbeddingOperator}(
+    function BorgMOEA(
         problem::O,
         pop::P, recombinate::Vector{CrossoverOperator},
-        modify::M = M(), embed::E = E(), params = EMPTY_PARAMS)
+        modify::M = M(), embed::E = E(), params = EMPTY_PARAMS) where
+            {O<:OptimizationProblem, P<:Population,
+             M<:GeneticOperator, E<:EmbeddingOperator}
         # NOTE if ϵ-dominance is used, params[:ϵ] has the priority
         fit_scheme = fitness_scheme(problem)
         isa(fit_scheme, TupleFitnessScheme) || throw(ArgumentError("BorgMOEA can only solve problems with `TupleFitnessScheme`"))

--- a/src/borg_moea.jl
+++ b/src/borg_moea.jl
@@ -5,88 +5,88 @@ Based on Hadka & Reed, "Borg: An Auto-Adaptive Many-Objective Evolutionary Compu
 Framework", Evol. Comp. 2013
 """
 type BorgMOEA{FS<:FitnessScheme,V<:Evaluator,P<:Population,M<:GeneticOperator,E<:EmbeddingOperator} <: SteppingOptimizer
-  evaluator::V
-  population::P     # candidates, NOTE index one is always reserved for one archive parent for recombination
-  rand_check_order::Vector{Int} # random population check order
+    evaluator::V
+    population::P     # candidates, NOTE index one is always reserved for one archive parent for recombination
+    rand_check_order::Vector{Int} # random population check order
 
-  n_restarts::Int
-  n_steps::Int
-  last_restart_check::Int
-  last_restart::Int
-  last_wrecombinate_update::Int
+    n_restarts::Int
+    n_steps::Int
+    last_restart_check::Int
+    last_restart::Int
+    last_wrecombinate_update::Int
 
-  τ::Float64        # tournament size, fraction of the population
-  γ::Float64        # recommended population-to-archive ratio
-  γ_δ::Float64      # the maximum allowed deviation of the population-to-archive ratio from γ
-  min_popsize::Int  # the minimal population size
+    τ::Float64        # tournament size, fraction of the population
+    γ::Float64        # recommended population-to-archive ratio
+    γ_δ::Float64      # the maximum allowed deviation of the population-to-archive ratio from γ
+    min_popsize::Int  # the minimal population size
 
-  recombinate_distr::Categorical # weights of the recombination operators
+    recombinate_distr::Categorical # weights of the recombination operators
 
-  # method parameters
-  θ::Float64        # restart-discounting coefficient for recombination operator weights
-  ζ::Float64        # dampening coefficient for recombination operator weights
-  wrecombinate_update_period::Int
-  restart_check_period::Int
-  max_steps_without_ϵ_progress::Int
+    # method parameters
+    θ::Float64        # restart-discounting coefficient for recombination operator weights
+    ζ::Float64        # dampening coefficient for recombination operator weights
+    wrecombinate_update_period::Int
+    restart_check_period::Int
+    max_steps_without_ϵ_progress::Int
 
-  recombinate::Vector{CrossoverOperator} # recombination operators
+    recombinate::Vector{CrossoverOperator} # recombination operators
 
-  # Set of operators that together define a specific DE strategy.
-  select::TournamentSelector{HatCompare{FS}}         # random individuals selector
-  modify::M         # operator to mutate frontier element during restarts
-  embed::E          # embedding operator
+    # Set of operators that together define a specific DE strategy.
+    select::TournamentSelector{HatCompare{FS}}         # random individuals selector
+    modify::M         # operator to mutate frontier element during restarts
+    embed::E          # embedding operator
 
-  function (::Type{BorgMOEA}){O<:OptimizationProblem, P<:Population,
+    function (::Type{BorgMOEA}){O<:OptimizationProblem, P<:Population,
                      M<:GeneticOperator, E<:EmbeddingOperator}(
         problem::O,
         pop::P, recombinate::Vector{CrossoverOperator},
         modify::M = M(), embed::E = E(), params = EMPTY_PARAMS)
-    # NOTE if ϵ-dominance is used, params[:ϵ] has the priority
-    fit_scheme = fitness_scheme(problem)
-    isa(fit_scheme, TupleFitnessScheme) || throw(ArgumentError("BorgMOEA can only solve problems with `TupleFitnessScheme`"))
-    !isempty(recombinate) || throw(ArgumentError("No recombinate operators specified"))
-    fit_scheme = convert(EpsBoxDominanceFitnessScheme, fit_scheme, params[:ϵ])
-    archive = EpsBoxArchive(fit_scheme, params)
-    evaluator = make_evaluator(problem, archive, params)
-    new{typeof(fit_scheme),typeof(evaluator),P,M,E}(evaluator, pop, Vector{Int}(), 0, 0, 0, 0, 0,
-           params[:τ], params[:γ], params[:γ_δ], params[:PopulationSize],
-           Categorical(ones(length(recombinate))/length(recombinate)),
-           params[:θ], params[:ζ], params[:OperatorsUpdatePeriod], params[:RestartCheckPeriod],
-           params[:MaxStepsWithoutProgress],
-           recombinate,
-           TournamentSelector(fit_scheme, ceil(Int, params[:τ]*popsize(pop))), modify, embed)
-  end
+        # NOTE if ϵ-dominance is used, params[:ϵ] has the priority
+        fit_scheme = fitness_scheme(problem)
+        isa(fit_scheme, TupleFitnessScheme) || throw(ArgumentError("BorgMOEA can only solve problems with `TupleFitnessScheme`"))
+        !isempty(recombinate) || throw(ArgumentError("No recombinate operators specified"))
+        fit_scheme = convert(EpsBoxDominanceFitnessScheme, fit_scheme, params[:ϵ])
+        archive = EpsBoxArchive(fit_scheme, params)
+        evaluator = make_evaluator(problem, archive, params)
+        new{typeof(fit_scheme),typeof(evaluator),P,M,E}(evaluator, pop, Vector{Int}(), 0, 0, 0, 0, 0,
+                params[:τ], params[:γ], params[:γ_δ], params[:PopulationSize],
+                Categorical(ones(length(recombinate))/length(recombinate)),
+                params[:θ], params[:ζ], params[:OperatorsUpdatePeriod], params[:RestartCheckPeriod],
+                params[:MaxStepsWithoutProgress],
+                recombinate,
+                TournamentSelector(fit_scheme, ceil(Int, params[:τ]*popsize(pop))), modify, embed)
+    end
 end
 
 const BorgMOEA_DefaultParameters = chain(EpsBoxArchive_DefaultParameters, ParamsDict(
-  :ϵ => 0.1,        # size of the ϵ-box
-  :τ => 0.02,       # selection ratio, fraction of population to use for tournament
-  :γ => 4.0,        # recommended population-to-archive ratio
-  :γ_δ => 0.25,     # the maximum allowed deviation of the population-to-archive ratio from γ
-  :θ => 0.9,        # restart-discounting coefficient for recombination operator weights
-  :ζ => 1.0,        # dampening coefficient for recombination operator weights
-  :RestartCheckPeriod => 1000,
-  :OperatorsUpdatePeriod => 100,
-  :MaxStepsWithoutProgress => 100
+    :ϵ => 0.1,        # size of the ϵ-box
+    :τ => 0.02,       # selection ratio, fraction of population to use for tournament
+    :γ => 4.0,        # recommended population-to-archive ratio
+    :γ_δ => 0.25,     # the maximum allowed deviation of the population-to-archive ratio from γ
+    :θ => 0.9,        # restart-discounting coefficient for recombination operator weights
+    :ζ => 1.0,        # dampening coefficient for recombination operator weights
+    :RestartCheckPeriod => 1000,
+    :OperatorsUpdatePeriod => 100,
+    :MaxStepsWithoutProgress => 100
 ))
 
 function borg_moea{FS<:TupleFitnessScheme}(problem::OptimizationProblem{FS}, options::Parameters = EMPTY_PARAMS)
-  opts = chain(BorgMOEA_DefaultParameters, options)
-  fs = fitness_scheme(problem)
-  N = numobjectives(fs)
-  F = fitness_eltype(fs)
-  pop = population(problem, opts, nafitness(IndexedTupleFitness{N,F}), ntransient=1)
-  BorgMOEA(problem, pop, CrossoverOperator[DiffEvoRandBin1(chain(DE_DefaultOptions, options)),
+    opts = chain(BorgMOEA_DefaultParameters, options)
+    fs = fitness_scheme(problem)
+    N = numobjectives(fs)
+    F = fitness_eltype(fs)
+    pop = population(problem, opts, nafitness(IndexedTupleFitness{N,F}), ntransient=1)
+    BorgMOEA(problem, pop, CrossoverOperator[DiffEvoRandBin1(chain(DE_DefaultOptions, options)),
                                            SimulatedBinaryCrossover(chain(SBX_DefaultOptions, options)),
                                            SimplexCrossover{3}(chain(SPX_DefaultOptions, options)),
                                            ParentCentricCrossover{2}(chain(PCX_DefaultOptions, options)),
                                            ParentCentricCrossover{3}(chain(PCX_DefaultOptions, options)),
                                            UnimodalNormalDistributionCrossover{2}(chain(UNDX_DefaultOptions, options)),
                                            UnimodalNormalDistributionCrossover{3}(chain(UNDX_DefaultOptions, options))],
-           FixedGeneticOperatorsMixture(GeneticOperator[
+            FixedGeneticOperatorsMixture(GeneticOperator[
                                             MutationClock(PolynomialMutation(search_space(problem), chain(PM_DefaultOptions, options)), 1/numdims(problem)),
                                             MutationClock(UniformMutation(search_space(problem)), 1/numdims(problem))], [0.75, 0.25]),
-           RandomBound(search_space(problem)), opts)
+            RandomBound(search_space(problem)), opts)
 end
 
 archive(alg::BorgMOEA) = alg.evaluator.archive
@@ -225,7 +225,8 @@ Update recombination operator probabilities based on the archive tag counts.
 function update_recombination_weights!(alg::BorgMOEA)
     op_counts = tagcounts(archive(alg), alg.θ)
     adj_op_counts = sum(values(op_counts)) + length(alg.recombinate)*alg.ζ
-    alg.recombinate_distr = Categorical([(get(op_counts, i, 0)+alg.ζ)/adj_op_counts for i in eachindex(alg.recombinate)])
+    alg.recombinate_distr = Categorical([(get(op_counts, i, 0)+alg.ζ)/adj_op_counts
+                                        for i in eachindex(alg.recombinate)])
     alg.last_wrecombinate_update = alg.n_steps
     return alg
 end

--- a/src/borg_moea.jl
+++ b/src/borg_moea.jl
@@ -46,7 +46,7 @@ mutable struct BorgMOEA{FS<:FitnessScheme,V<:Evaluator,P<:Population,M<:GeneticO
         fit_scheme = fitness_scheme(problem)
         isa(fit_scheme, TupleFitnessScheme) || throw(ArgumentError("BorgMOEA can only solve problems with `TupleFitnessScheme`"))
         !isempty(recombinate) || throw(ArgumentError("No recombinate operators specified"))
-        fit_scheme = convert(EpsBoxDominanceFitnessScheme, fit_scheme, params[:ϵ])
+        fit_scheme = EpsBoxDominanceFitnessScheme(fit_scheme, params[:ϵ])
         archive = EpsBoxArchive(fit_scheme, params)
         evaluator = make_evaluator(problem, archive, params)
         new{typeof(fit_scheme),typeof(evaluator),P,M,E}(evaluator, pop, Vector{Int}(), 0, 0, 0, 0, 0,

--- a/src/borg_moea.jl
+++ b/src/borg_moea.jl
@@ -4,7 +4,7 @@ Borg MOEA algorithm.
 Based on Hadka & Reed, "Borg: An Auto-Adaptive Many-Objective Evolutionary Computing
 Framework", Evol. Comp. 2013
 """
-type BorgMOEA{FS<:FitnessScheme,V<:Evaluator,P<:Population,M<:GeneticOperator,E<:EmbeddingOperator} <: SteppingOptimizer
+mutable struct BorgMOEA{FS<:FitnessScheme,V<:Evaluator,P<:Population,M<:GeneticOperator,E<:EmbeddingOperator} <: SteppingOptimizer
     evaluator::V
     population::P     # candidates, NOTE index one is always reserved for one archive parent for recombination
     rand_check_order::Vector{Int} # random population check order

--- a/src/borg_moea.jl
+++ b/src/borg_moea.jl
@@ -71,7 +71,7 @@ const BorgMOEA_DefaultParameters = chain(EpsBoxArchive_DefaultParameters, Params
     :MaxStepsWithoutProgress => 100
 ))
 
-function borg_moea{FS<:TupleFitnessScheme}(problem::OptimizationProblem{FS}, options::Parameters = EMPTY_PARAMS)
+function borg_moea(problem::OptimizationProblem, options::Parameters = EMPTY_PARAMS)
     opts = chain(BorgMOEA_DefaultParameters, options)
     fs = fitness_scheme(problem)
     N = numobjectives(fs)

--- a/src/borg_moea.jl
+++ b/src/borg_moea.jl
@@ -1,8 +1,8 @@
 """
-  Borg MOEA algorithm.
+Borg MOEA algorithm.
 
-  Based on Hadka & Reed, "Borg: An Auto-Adaptive Many-Objective Evolutionary Computing
-  Framework", Evol. Comp. 2013
+Based on Hadka & Reed, "Borg: An Auto-Adaptive Many-Objective Evolutionary Computing
+Framework", Evol. Comp. 2013
 """
 type BorgMOEA{FS<:FitnessScheme,V<:Evaluator,P<:Population,M<:GeneticOperator,E<:EmbeddingOperator} <: SteppingOptimizer
   evaluator::V
@@ -220,7 +220,7 @@ function update_population_fitness!(alg::BorgMOEA)
 end
 
 """
-  Update recombination operator probabilities based on the archive tag counts.
+Update recombination operator probabilities based on the archive tag counts.
 """
 function update_recombination_weights!(alg::BorgMOEA)
     op_counts = tagcounts(archive(alg), alg.θ)
@@ -252,9 +252,9 @@ function populate_by_mutants(alg::BorgMOEA, last_nonmutant::Int)
 end
 
 """
-    Restart Borg MOEA.
+Restart Borg MOEA.
 
-    Resize and refills the population from the archive.
+Resize and refills the population from the archive.
 """
 function restart!(alg::BorgMOEA)
     notify!(archive(alg), :restart)

--- a/src/compare_optimizers.jl
+++ b/src/compare_optimizers.jl
@@ -1,7 +1,7 @@
 function compare_optimizers(functionOrProblem, parameters::Parameters = EMPTY_PARAMS;
     Methods = BlackBoxOptim.SingleObjectiveMethodNames, kwargs...)
 
-    parameters = chain(convert(ParamsDict, parameters), convert(ParamsDict, kwargs))
+    parameters = chain(convert(ParamsDict, parameters), kwargs2dict(kwargs))
 
     results = Any[]
     for m in Methods
@@ -28,7 +28,7 @@ function compare_optimizers(problems::Dict{Any, OptimizationProblem},
                             parameters::Parameters = EMPTY_PARAMS;
                             Methods = BlackBoxOptim.SingleObjectiveMethodNames, kwargs...)
 
-    parameters = chain(convert(ParamsDict, parameters), convert(ParamsDict, kwargs))
+    parameters = chain(convert(ParamsDict, parameters), kwargs2dict(kwargs))
 
     # Lets create an array where we will save how the methods ranks per problem.
     ranks = zeros(length(Methods), length(problems))

--- a/src/compare_optimizers.jl
+++ b/src/compare_optimizers.jl
@@ -76,16 +76,16 @@ function compare_optimizers(problems::Dict{Any, OptimizationProblem},
 end
 
 """
-  Summarize a vector of float values by stating its mean, std dev and median.
+Summarize a vector of float values by stating its mean, std dev and median.
 """
 function report_on_values(desc, v, lpad = "", rpad = "", digits = 3)
   println("$(lpad)$(desc): $(signif(mean(v), digits)) (std. dev = $(signif(std(v), digits)), median = $(signif(median(v), digits)))")
 end
 
 """
-  Report the number of times each key was encountered in a count `dict`.
+Report the number of times each key was encountered in a count `dict`.
 
-  Returns a percentage dict calculated while iterating over the counted items.
+Returns a percentage dict calculated while iterating over the counted items.
 """
 function count_dict_report(dict, desc, lpad = "", rpad = "")
   println(desc, ":")
@@ -99,9 +99,9 @@ function count_dict_report(dict, desc, lpad = "", rpad = "")
 end
 
 """
-  Print a report based on a result dict from one set of repeated runs of
-  an optimization method. Returns the success rate, i.e. number of times the
-  termination reason was "Within fitness tolerance...".
+Print a report based on a result dict from one set of repeated runs of
+an optimization method. Returns the success rate, i.e. number of times the
+termination reason was "Within fitness tolerance...".
 """
 function report_from_result_dict(statsdict)
   println("Method: $(statsdict[:method])")

--- a/src/compare_optimizers.jl
+++ b/src/compare_optimizers.jl
@@ -1,85 +1,82 @@
 function compare_optimizers(functionOrProblem, parameters::Parameters = EMPTY_PARAMS;
-  Methods = BlackBoxOptim.SingleObjectiveMethodNames, kwargs...)
+    Methods = BlackBoxOptim.SingleObjectiveMethodNames, kwargs...)
 
-  parameters = chain(convert(ParamsDict, parameters),
-                     convert(ParamsDict, kwargs))
+    parameters = chain(convert(ParamsDict, parameters), convert(ParamsDict, kwargs))
 
-  results = Any[]
-  for m in Methods
-    tic()
-    res = bboptimize(functionOrProblem, parameters; Method = m)
-    push!( results,  (m, best_candidate(res), best_fitness(res), toq()) )
-  end
-
-  sorted = sort( results, by = (t) -> t[3] )
-
-  if get(parameters, :TraceMode, :compact) != :silent
-    println("\n********************************************************************************")
-    #println(describe(evaluator))
-    for i in 1:length(sorted)
-      println("$(i). $(sorted[i][1]), fitness = $(sorted[i][3]), time = $(sorted[i][4])")
+    results = Any[]
+    for m in Methods
+        tic()
+        res = bboptimize(functionOrProblem, parameters; Method = m)
+        push!( results,  (m, best_candidate(res), best_fitness(res), toq()) )
     end
-    println("********************************************************************************\n")
-  end
 
-  return sorted
+    sorted = sort( results, by = (t) -> t[3] )
 
+    if get(parameters, :TraceMode, :compact) != :silent
+        println("\n********************************************************************************")
+        #println(describe(evaluator))
+        for i in 1:length(sorted)
+            println("$(i). $(sorted[i][1]), fitness = $(sorted[i][3]), time = $(sorted[i][4])")
+        end
+        println("********************************************************************************\n")
+    end
+
+    return sorted
 end
 
 function compare_optimizers(problems::Dict{Any, OptimizationProblem},
-  parameters::Parameters = EMPTY_PARAMS;
-  Methods = BlackBoxOptim.SingleObjectiveMethodNames, kwargs...)
+                            parameters::Parameters = EMPTY_PARAMS;
+                            Methods = BlackBoxOptim.SingleObjectiveMethodNames, kwargs...)
 
-  parameters = chain(convert(ParamsDict, parameters),
-                     convert(ParamsDict, kwargs))
+    parameters = chain(convert(ParamsDict, parameters), convert(ParamsDict, kwargs))
 
-  # Lets create an array where we will save how the methods ranks per problem.
-  ranks = zeros(length(Methods), length(problems))
-  fitnesses = zeros(Float64, length(Methods), length(problems))
-  times = zeros(Float64, length(Methods), length(problems))
+    # Lets create an array where we will save how the methods ranks per problem.
+    ranks = zeros(length(Methods), length(problems))
+    fitnesses = zeros(Float64, length(Methods), length(problems))
+    times = zeros(Float64, length(Methods), length(problems))
 
-  problems = collect(problems)
+    problems = collect(problems)
 
-  for i in 1:length(problems)
-    name, p = problems[i]
-    res = compare_optimizers(p, parameters; Methods = Methods)
-    for j in 1:length(res)
-      method, best, fitness, elapsedtime = res[j]
-      index = findfirst(Methods, method)
-      ranks[index, i] = j
-      fitnesses[index, i] = fitness
-      times[index, i] = elapsedtime
+    for i in 1:length(problems)
+        name, p = problems[i]
+        res = compare_optimizers(p, parameters; Methods = Methods)
+        for j in 1:length(res)
+            method, best, fitness, elapsedtime = res[j]
+            index = findfirst(Methods, method)
+            ranks[index, i] = j
+            fitnesses[index, i] = fitness
+            times[index, i] = elapsedtime
+        end
     end
-  end
 
-  avg_ranks = round(mean(ranks, 2), 2)
-  avg_fitness = round(mean(fitnesses, 2), 3)
-  avg_times = round(mean(times, 2), 2)
+    avg_ranks = round(mean(ranks, 2), 2)
+    avg_fitness = round(mean(fitnesses, 2), 3)
+    avg_times = round(mean(times, 2), 2)
 
-  perm = sortperm(avg_ranks[:])
-  println("\nBy avg rank:")
-  for i in 1:length(methods)
-    j = perm[i]
-    print("\n$(i). $(methods[j]), avg rank = $(avg_ranks[j]), avg fitness = $(avg_fitness[j]), avg time = $(avg_times[j]), ranks = ")
-    showcompact(ranks[j,:][:])
-  end
+    perm = sortperm(avg_ranks[:])
+    println("\nBy avg rank:")
+    for i in 1:length(methods)
+        j = perm[i]
+        print("\n$(i). $(methods[j]), avg rank = $(avg_ranks[j]), avg fitness = $(avg_fitness[j]), avg time = $(avg_times[j]), ranks = ")
+        showcompact(ranks[j,:][:])
+    end
 
-  perm = sortperm(avg_fitness[:])
-  println("\n\nBy avg fitness:")
-  for i in 1:length(methods)
-    j = perm[i]
-    print("\n$(i). $(methods[j]), avg rank = $(avg_ranks[j]), avg fitness = $(avg_fitness[j]), avg time = $(avg_times[j]), ranks = ")
-    showcompact(ranks[j,:][:])
-  end
+    perm = sortperm(avg_fitness[:])
+    println("\n\nBy avg fitness:")
+    for i in 1:length(methods)
+        j = perm[i]
+        print("\n$(i). $(methods[j]), avg rank = $(avg_ranks[j]), avg fitness = $(avg_fitness[j]), avg time = $(avg_times[j]), ranks = ")
+        showcompact(ranks[j,:][:])
+    end
 
-  return ranks, fitnesses
+    return ranks, fitnesses
 end
 
 """
 Summarize a vector of float values by stating its mean, std dev and median.
 """
 function report_on_values(desc, v, lpad = "", rpad = "", digits = 3)
-  println("$(lpad)$(desc): $(signif(mean(v), digits)) (std. dev = $(signif(std(v), digits)), median = $(signif(median(v), digits)))")
+    println("$(lpad)$(desc): $(signif(mean(v), digits)) (std. dev = $(signif(std(v), digits)), median = $(signif(median(v), digits)))")
 end
 
 """
@@ -88,14 +85,14 @@ Report the number of times each key was encountered in a count `dict`.
 Returns a percentage dict calculated while iterating over the counted items.
 """
 function count_dict_report(dict, desc, lpad = "", rpad = "")
-  println(desc, ":")
-  total = sum(collect(values(dict))) # FIXME collect() should not be required
-  pdict = Dict()
-  for (r, c) in dict
-    pdict[r] = round(100.0*c/total, 2)
-    println(lpad, r, ": ", c, " (", pdict[r], "%)", rpad)
-  end
-  pdict
+    println(desc, ":")
+    total = sum(collect(values(dict))) # FIXME collect() should not be required
+    pdict = Dict()
+    for (r, c) in dict
+        pdict[r] = round(100.0*c/total, 2)
+        println(lpad, r, ": ", c, " (", pdict[r], "%)", rpad)
+    end
+    pdict
 end
 
 """
@@ -104,85 +101,78 @@ an optimization method. Returns the success rate, i.e. number of times the
 termination reason was "Within fitness tolerance...".
 """
 function report_from_result_dict(statsdict)
-  println("Method: $(statsdict[:method])")
-  pdict = count_dict_report(statsdict[:reasoncounts], "  Termination reasons", "    ")
-  report_on_values("Fitness", statsdict[:fitnesses], "  ")
-  report_on_values("Time", statsdict[:times], "  ")
-  report_on_values("Num function evals", statsdict[:numevals], "  ")
+    println("Method: $(statsdict[:method])")
+    pdict = count_dict_report(statsdict[:reasoncounts], "  Termination reasons", "    ")
+    report_on_values("Fitness", statsdict[:fitnesses], "  ")
+    report_on_values("Time", statsdict[:times], "  ")
+    report_on_values("Num function evals", statsdict[:numevals], "  ")
 
-  success_rate = round(get(pdict, "Within fitness tolerance of optimum", 0.0), 3)
-  println("  Success rate: ", success_rate, "%\n")
-  success_rate
+    success_rate = round(get(pdict, "Within fitness tolerance of optimum", 0.0), 3)
+    println("  Success rate: ", success_rate, "%\n")
+    success_rate
 end
 
 function rank_result_dicts_by(result_dicts, byfunc, desc; rev = false,
-  descsummary = "mean", digits = 3, rpad = "")
+        descsummary = "mean", digits = 3, rpad = "")
 
-  ranked = BlackBoxOptim.Utils.assign_ranks_within_tolerance(result_dicts; by = byfunc, tolerance = 1e-3, rev = rev)
-  println("Ranked by $(descsummary) $(desc):")
-  for (rank, rd, value) in ranked
-    println("  $(rank). $(rd[:method]), $(signif(value, digits))$(rpad)")
-  end
-  println("")
-
+    ranked = BlackBoxOptim.Utils.assign_ranks_within_tolerance(result_dicts; by = byfunc, tolerance = 1e-3, rev = rev)
+    println("Ranked by $(descsummary) $(desc):")
+    for (rank, rd, value) in ranked
+        println("  $(rank). $(rd[:method]), $(signif(value, digits))$(rpad)")
+    end
+    println("")
 end
 
 function report_on_methods_results_on_one_problem(problem, result_dicts, numrepeats, max_time, ftol)
+    println("********************************************************************************\n")
 
-  println("********************************************************************************\n")
+    println("Problem: $(name(problem)), num dims = $(numdims(problem))")
+    println("  Num repeats per method = ", numrepeats)
+    println("  Fitness tolerance = ", ftol, " (a run is a success if it reaches to within this value of true optimum)")
+    println("  Max time budget per run = ", max_time, " secs\n")
 
-  println("Problem: $(name(problem)), num dims = $(numdims(problem))")
-  println("  Num repeats per method = ", numrepeats)
-  println("  Fitness tolerance = ", ftol, " (a run is a success if it reaches to within this value of true optimum)")
-  println("  Max time budget per run = ", max_time, " secs\n")
+    rank_result_dicts_by(result_dicts, (d) -> d[:success_rate], "success rate (to reach within $(ftol) of optimum)";
+            descsummary = "median", rev = true, rpad = "%")
+    rank_result_dicts_by(result_dicts, (d) -> median(d[:fitnesses]), "fitness"; descsummary = "median")
+    rank_result_dicts_by(result_dicts, (d) -> median(d[:times]), "time (in seconds)";
+            descsummary = "median", rpad = " secs")
+    rank_result_dicts_by(result_dicts, (d) -> round(Int, median(d[:numevals])), "num function evals"; descsummary = "median")
 
-  rank_result_dicts_by(result_dicts, (d) -> d[:success_rate], "success rate (to reach within $(ftol) of optimum)";
-    descsummary = "median", rev = true, rpad = "%")
-  rank_result_dicts_by(result_dicts, (d) -> median(d[:fitnesses]), "fitness"; descsummary = "median")
-  rank_result_dicts_by(result_dicts, (d) -> median(d[:times]), "time (in seconds)";
-    descsummary = "median", rpad = " secs")
-  rank_result_dicts_by(result_dicts, (d) -> round(Int, median(d[:numevals])), "num function evals"; descsummary = "median")
-
-  for rd in result_dicts
-    report_from_result_dict(rd)
-  end
-
+    for rd in result_dicts
+        report_from_result_dict(rd)
+    end
 end
 
 function repeated_bboptimize(numrepeats, problem, dim, methods, max_time, ftol = 1e-5, extraparams::Parameters = EMPTY_PARAMS)
+    fp = instantiate(problem, dim)
+    result_dicts = ParamsDict[]
 
-  fp = instantiate(problem, dim)
-  result_dicts = ParamsDict[]
+    # Just so they are declared
+    ps = best_so_far = nothing
 
-  # Just so they are declared
-  ps = best_so_far = nothing
+    params = chain(extraparams, ParamsDict(:FitnessTolerance => ftol))
 
-  params = chain(extraparams, ParamsDict(:FitnessTolerance => ftol))
+    for m in methods
+        ts, fs, nes = zeros(numrepeats), zeros(numrepeats), zeros(Int, numrepeats)
+        rcounts = Dict{String,Int}()
 
-  for m in methods
+        results = map(1:numrepeats) do i
+            result = bboptimize(fp, params; MaxTime = max_time, Method = m)
 
-    ts, fs, nes = zeros(numrepeats), zeros(numrepeats), zeros(Int, numrepeats)
-    rcounts = Dict{String,Int}()
+            # Save key data about this run:
+            ts[i]  = elapsed_time(result)
+            fs[i]  = best_fitness(result)
+            nes[i] = f_calls(result)
 
-    results = map(1:numrepeats) do i
-      result = bboptimize(fp, params; MaxTime = max_time, Method = m)
+            # And count only the general stop reasons
+            reason = general_stop_reason(result)
+            rcounts[reason] = 1 + get(rcounts, reason, 0)
+        end
 
-      # Save key data about this run:
-      ts[i]  = elapsed_time(result)
-      fs[i]  = best_fitness(result)
-      nes[i] = f_calls(result)
-
-      # And count only the general stop reasons
-      reason = general_stop_reason(result)
-      rcounts[reason] = 1 + get(rcounts, reason, 0)
+        rdict = ParamsDict(:method => m, :fitnesses => fs, :times => ts, :numevals => nes, :reasoncounts => rcounts)
+        rdict[:success_rate] = report_from_result_dict(rdict)
+        push!(result_dicts, rdict)
     end
 
-    rdict = ParamsDict(:method => m, :fitnesses => fs, :times => ts, :numevals => nes, :reasoncounts => rcounts)
-    rdict[:success_rate] = report_from_result_dict(rdict)
-    push!(result_dicts, rdict)
-
-  end
-
-  report_on_methods_results_on_one_problem(fp, result_dicts, numrepeats, max_time, ftol)
-
+    report_on_methods_results_on_one_problem(fp, result_dicts, numrepeats, max_time, ftol)
 end

--- a/src/default_parameters.jl
+++ b/src/default_parameters.jl
@@ -4,124 +4,124 @@ Default parameters for all convenience methods that are exported to the end user
 See `OptRunController` for the description.
 """
 const DefaultParameters = ParamsDict(
-  :NumDimensions  => :NotSpecified, # Dimension of problem to be optimized
-  :SearchRange    => (-1.0, 1.0), # Default search range to use per dimension unless specified
-  :SearchSpace    => false, # Search space can be directly specified and will then take precedence over NumDimensions and SearchRange.
-  :FitnessScheme  => MinimizingFitnessScheme, # fitness scheme to be used
-  :TargetFitness => nothing, # optimal (target) fitness, if known
+    :NumDimensions  => :NotSpecified, # Dimension of problem to be optimized
+    :SearchRange    => (-1.0, 1.0), # Default search range to use per dimension unless specified
+    :SearchSpace    => false, # Search space can be directly specified and will then take precedence over NumDimensions and SearchRange.
+    :FitnessScheme  => MinimizingFitnessScheme, # fitness scheme to be used
+    :TargetFitness => nothing, # optimal (target) fitness, if known
 
-  :Method => :adaptive_de_rand_1_bin_radiuslimited,
+    :Method => :adaptive_de_rand_1_bin_radiuslimited,
 
-  :MaxTime        => 0.0,
-  :MaxFuncEvals   => 0,
-  :MaxSteps       => 10000,
-  :MaxStepsWithoutProgress => 10000,
-  :MinDeltaFitnessTolerance => 1e-50,
-  :FitnessTolerance => 1e-8,
+    :MaxTime        => 0.0,
+    :MaxFuncEvals   => 0,
+    :MaxSteps       => 10000,
+    :MaxStepsWithoutProgress => 10000,
+    :MinDeltaFitnessTolerance => 1e-50,
+    :FitnessTolerance => 1e-8,
 
-  :MaxNumStepsWithoutFuncEvals => 100,
+    :MaxNumStepsWithoutFuncEvals => 100,
 
-  :NumRepetitions => 1,     # Number of repetitions to run for each optimizer for each problem
+    :NumRepetitions => 1,     # Number of repetitions to run for each optimizer for each problem
 
-  :TraceMode      => :compact,  # Print tracing information during the optimization
-  :TraceInterval  => 0.50,  # Minimum number of seconds between consecutive trace messages printed to STDOUT
-  :SaveTrace      => false,
-  :SaveFitnessTraceToCsv => false, # Save a csv file with information about the major fitness improvement events (only the first event in each fitness magnitude class is saved)
-  :SaveParameters => false, # Save parameters to a json file for later scrutiny
+    :TraceMode      => :compact,  # Print tracing information during the optimization
+    :TraceInterval  => 0.50,  # Minimum number of seconds between consecutive trace messages printed to STDOUT
+    :SaveTrace      => false,
+    :SaveFitnessTraceToCsv => false, # Save a csv file with information about the major fitness improvement events (only the first event in each fitness magnitude class is saved)
+    :SaveParameters => false, # Save parameters to a json file for later scrutiny
 
-  :RandomizeRngSeed => true, # Randomize the RngSeed value before using any random numbers.
-  :RngSeed        => 1234,   # The specific random seed to set before any random numbers are generated. The seed is randomly selected if RandomizeRngSeed is true, and this parameter is updated with its actual value.
+    :RandomizeRngSeed => true, # Randomize the RngSeed value before using any random numbers.
+    :RngSeed        => 1234,   # The specific random seed to set before any random numbers are generated. The seed is randomly selected if RandomizeRngSeed is true, and this parameter is updated with its actual value.
 
-  :PopulationSize => 50
+    :PopulationSize => 50
 )
 
 function check_and_create_search_space(params::Parameters)
-  # If an explicit SearchSpace has been given we use that. It takes precedence.
-  if haskey(params, :SearchSpace)
-    ss = params[:SearchSpace]
-    if isa(ss, SearchSpace)
-      return ss
-    elseif isa(ss, typeof([(0.0, 1.0)]))
-      return RangePerDimSearchSpace(ss)
-    elseif ss == false
-      # silently fallthrough to the other means of search space specification
-    else
-      throw(ArgumentError("Using $(typeof(ss)) for SearchSpace is not supported"))
+    # If an explicit SearchSpace has been given we use that. It takes precedence.
+    if haskey(params, :SearchSpace)
+        ss = params[:SearchSpace]
+        if isa(ss, SearchSpace)
+            return ss
+        elseif isa(ss, typeof([(0.0, 1.0)]))
+            return RangePerDimSearchSpace(ss)
+        elseif ss == false
+            # silently fallthrough to the other means of search space specification
+        else
+            throw(ArgumentError("Using $(typeof(ss)) for SearchSpace is not supported"))
+        end
     end
-  end
 
-  # If no explicit search space has been given we must create one from the
-  # other related parameters.
-  if haskey(params, :SearchRange)
-    sr = params[:SearchRange]
-    # Check that a valid search range has been stated and create the search_space
-    # based on it, or bail out.
-    if isa(sr, typeof((0.0, 1.0)))
-      ndim = params[:NumDimensions]
-      if ndim == :NotSpecified
-          throw(ArgumentError("You MUST specify NumDimensions= in a solution when giving a SearchRange=$(sr)"))
-      end
-      return symmetric_search_space(params[:NumDimensions], sr)
-    elseif isa(sr, typeof([(0.0, 1.0)]))
-      return RangePerDimSearchSpace(sr)
-    else
-      throw(ArgumentError("Using $(typeof(sr)) for SearchRange is not supported."))
+    # If no explicit search space has been given we must create one from the
+    # other related parameters.
+    if haskey(params, :SearchRange)
+        sr = params[:SearchRange]
+        # Check that a valid search range has been stated and create the search_space
+        # based on it, or bail out.
+        if isa(sr, typeof((0.0, 1.0)))
+            ndim = params[:NumDimensions]
+            if ndim == :NotSpecified
+                throw(ArgumentError("You MUST specify NumDimensions= in a solution when giving a SearchRange=$(sr)"))
+            end
+            return symmetric_search_space(params[:NumDimensions], sr)
+        elseif isa(sr, typeof([(0.0, 1.0)]))
+            return RangePerDimSearchSpace(sr)
+        else
+            throw(ArgumentError("Using $(typeof(sr)) for SearchRange is not supported."))
+        end
     end
-  end
 
-  # No valid search space have been specified => bail.
-  throw(ArgumentError("Invalid search space specification ("*
-                      "SearchSpace = $(params[:SearchSpace]), "*
-                      "SearchRange = $(params[:SearchRange]), "*
-                      "NumDimensions = $(params[:NumDimensions]))"))
+    # No valid search space have been specified => bail.
+    throw(ArgumentError("Invalid search space specification ("*
+                        "SearchSpace = $(params[:SearchSpace]), "*
+                        "SearchRange = $(params[:SearchRange]), "*
+                        "NumDimensions = $(params[:NumDimensions]))"))
 end
 
 function check_valid!(params::Parameters)
-  # Check that max_time is larger than zero if it has been specified.
-  if haskey(params, :MaxTime)
-    if !isa(params[:MaxTime], Number) || params[:MaxTime] < 0.0
-      throw(ArgumentError("MaxTime parameter must be a non-negative number"))
-    elseif params[:MaxTime] > 0.0
-      params[:MaxTime] = convert(Float64, params[:MaxTime])
-      params[:MaxFuncEvals] = 0
-      params[:MaxSteps] = 0
+    # Check that max_time is larger than zero if it has been specified.
+    if haskey(params, :MaxTime)
+        if !isa(params[:MaxTime], Number) || params[:MaxTime] < 0.0
+            throw(ArgumentError("MaxTime parameter must be a non-negative number"))
+        elseif params[:MaxTime] > 0.0
+            params[:MaxTime] = convert(Float64, params[:MaxTime])
+            params[:MaxFuncEvals] = 0
+            params[:MaxSteps] = 0
+        end
     end
-  end
 
-  # Check that a valid number of fevals has been specified. Print warning if higher than 1e8.
-  if haskey(params,:MaxFuncEvals)
-    if !isa(params[:MaxFuncEvals], Integer) || params[:MaxFuncEvals] < 0.0
-      throw(ArgumentError("MaxFuncEvals parameter MUST be a non-negative integer"))
-    elseif params[:MaxFuncEvals] > 0.0
-      if params[:MaxFuncEvals] >= 1e8
-        warn("Number of allowed function evals is $(params[:MaxFuncEvals]); this can take a LONG   time")
-      end
-      params[:MaxFuncEvals] = convert(Int, params[:MaxFuncEvals])
-      params[:MaxSteps] = 0
+    # Check that a valid number of fevals has been specified. Print warning if higher than 1e8.
+    if haskey(params,:MaxFuncEvals)
+        if !isa(params[:MaxFuncEvals], Integer) || params[:MaxFuncEvals] < 0.0
+            throw(ArgumentError("MaxFuncEvals parameter MUST be a non-negative integer"))
+        elseif params[:MaxFuncEvals] > 0.0
+            if params[:MaxFuncEvals] >= 1e8
+                warn("Number of allowed function evals is $(params[:MaxFuncEvals]); this can take a LONG   time")
+            end
+            params[:MaxFuncEvals] = convert(Int, params[:MaxFuncEvals])
+            params[:MaxSteps] = 0
+        end
     end
-  end
 
-  # Check that a valid number of iterations has been specified. Print warning if higher than 1e8.
-  if haskey(params, :MaxSteps)
-    if !isa(params[:MaxSteps], Number) || params[:MaxSteps] < 0.0
-      throw(ArgumentError("The number of iterations (MaxSteps) MUST be a non-negative number"))
-    elseif params[:MaxSteps] > 0.0
-      if params[:MaxSteps] >= 1e8
-        warn("Number of allowed iterations is $(params[:MaxSteps]); this can take a LONG time")
-      end
-      params[:MaxSteps] = convert(Int, params[:MaxSteps])
+    # Check that a valid number of iterations has been specified. Print warning if higher than 1e8.
+    if haskey(params, :MaxSteps)
+        if !isa(params[:MaxSteps], Number) || params[:MaxSteps] < 0.0
+            throw(ArgumentError("The number of iterations (MaxSteps) MUST be a non-negative number"))
+        elseif params[:MaxSteps] > 0.0
+            if params[:MaxSteps] >= 1e8
+                warn("Number of allowed iterations is $(params[:MaxSteps]); this can take a LONG time")
+            end
+            params[:MaxSteps] = convert(Int, params[:MaxSteps])
+        end
     end
-  end
 
-  # Check that a valid population size has been given.
-  if params[:PopulationSize] < 2
-    # FIXME why? What if we use popsize of 1 for optimizers that improve on one solution?
-    throw(ArgumentError("The population size MUST be at least 2"))
-  end
+    # Check that a valid population size has been given.
+    if params[:PopulationSize] < 2
+        # FIXME why? What if we use popsize of 1 for optimizers that improve on one solution?
+        throw(ArgumentError("The population size MUST be at least 2"))
+    end
 
-  method = params[:Method]
-  # Check that a valid method has been specified and then set up the optimizer
-  if !isa(method, Symbol) || method ∉ BlackBoxOptim.MethodNames
-    throw(ArgumentError("The method specified, $(method), is NOT among the valid methods:   $(MethodNames)"))
-  end
+    method = params[:Method]
+    # Check that a valid method has been specified and then set up the optimizer
+    if !isa(method, Symbol) || method ∉ BlackBoxOptim.MethodNames
+        throw(ArgumentError("The method specified, $(method), is NOT among the valid methods:   $(MethodNames)"))
+    end
 end

--- a/src/default_parameters.jl
+++ b/src/default_parameters.jl
@@ -1,7 +1,7 @@
 """
-  Default parameters for all convenience methods that are exported to the end user.
+Default parameters for all convenience methods that are exported to the end user.
 
-  See `OptRunController` for the description.
+See `OptRunController` for the description.
 """
 const DefaultParameters = ParamsDict(
   :NumDimensions  => :NotSpecified, # Dimension of problem to be optimized

--- a/src/differential_evolution.jl
+++ b/src/differential_evolution.jl
@@ -17,10 +17,10 @@ mutable struct DiffEvoOpt{P<:Population,S<:IndividualsSelector,M<:GeneticOperato
     modify::M        # genetic operator
     embed::E         # embedding operator
 
-    function (::Type{DiffEvoOpt}){P<:Population, S<:IndividualsSelector,
-                     M<:GeneticOperator, E<:EmbeddingOperator}(
-        name::String, pop::P,
-        select::S = S(), modify::M = M(), embed::E = E())
+    function DiffEvoOpt(name::String, pop::P,
+                        select::S = S(), modify::M = M(), embed::E = E()) where
+            {P<:Population, S<:IndividualsSelector,
+             M<:GeneticOperator, E<:EmbeddingOperator}
         new{P,S,M,E}(name, pop, select, modify, embed)
     end
 end

--- a/src/differential_evolution.jl
+++ b/src/differential_evolution.jl
@@ -73,7 +73,7 @@ function evolve(de::DiffEvoOpt, crossover::CrossoverOperator)
 end
 
 """
-  Post-process the evolved pair.
+Post-process the evolved pair.
 """
 function evolved_pair{F}(de::DiffEvoOpt, target::Candidate{F}, trial::Candidate{F}, op::GeneticOperator, tag::Int = 0)
   # embed the trial parameter vector into the search space
@@ -117,7 +117,7 @@ function tell!{F}(de::DiffEvoOpt,
 end
 
 """
-  Adjust the parameters of the method after the candidate evaluation.
+Adjust the parameters of the method after the candidate evaluation.
 """
 function adjust!(de::DiffEvoOpt, candi::Candidate, is_improved::Bool)
   # adjust the parameters of the operation
@@ -142,7 +142,9 @@ function diffevo(problem::OptimizationProblem, options::Parameters, name::String
              RandomBound(search_space(problem)))
 end
 
-""" The most used `DE/rand/1/bin` variant of differential evolution. """
+"""
+The most used `DE/rand/1/bin` variant of differential evolution.
+"""
 de_rand_1_bin(problem::OptimizationProblem,
               options::Parameters = EMPTY_PARAMS,
               name = "DE/rand/1/bin") = diffevo(problem, options, name)
@@ -153,7 +155,9 @@ de_rand_2_bin(problem::OptimizationProblem,
                                                 SimpleSelector(),
                                                 DiffEvoRandBin2(chain(DE_DefaultOptions, options)))
 
-""" The most used `DE/rand/1/bin` variant with "local geography" via radius-limited sampling. """
+"""
+The most used `DE/rand/1/bin` variant with "local geography" via radius-limited sampling.
+"""
 de_rand_1_bin_radiuslimited(problem::OptimizationProblem,
                             options::Parameters = EMPTY_PARAMS,
                             name = "DE/rand/1/bin/radiuslimited") =

--- a/src/differential_evolution.jl
+++ b/src/differential_evolution.jl
@@ -1,28 +1,28 @@
 using Distributions
 
 const DE_DefaultOptions = chain(DEX_DefaultOptions, ParamsDict(
-  :SamplerRadius => 8,
+    :SamplerRadius => 8,
 ))
 
 # FIXME DifferentialEvolution is just a specific case of this optimizer,
 # should it be called EvolutionaryOptimizer?
 type DiffEvoOpt{P<:Population,S<:IndividualsSelector,M<:GeneticOperator,E<:EmbeddingOperator} <: PopulationOptimizer
-  # TODO when sampler and bound would be parameterized, name is no longer required -- as everything is seen in the type name
-  name::String
+    # TODO when sampler and bound would be parameterized, name is no longer required -- as everything is seen in the type name
+    name::String
 
-  population::P
+    population::P
 
-  # Set of operators that together define a specific DE strategy.
-  select::S        # random individuals selector
-  modify::M        # genetic operator
-  embed::E         # embedding operator
+    # Set of operators that together define a specific DE strategy.
+    select::S        # random individuals selector
+    modify::M        # genetic operator
+    embed::E         # embedding operator
 
-  function (::Type{DiffEvoOpt}){P<:Population, S<:IndividualsSelector,
+    function (::Type{DiffEvoOpt}){P<:Population, S<:IndividualsSelector,
                      M<:GeneticOperator, E<:EmbeddingOperator}(
         name::String, pop::P,
         select::S = S(), modify::M = M(), embed::E = E())
-    new{P,S,M,E}(name, pop, select, modify, embed)
-  end
+        new{P,S,M,E}(name, pop, select, modify, embed)
+    end
 end
 
 # trace current optimization state,
@@ -37,97 +37,98 @@ end
 ask(de::DiffEvoOpt) = evolve(de, de.modify)
 
 function evolve(de::DiffEvoOpt, op::GeneticOperatorsMixture)
-  sel_op, tag = next(op)
-  candidates = evolve(de, sel_op) # use the selected operator of the mixture
-  # override what was set by sel_op so that adjust!() gets called for the mixture op
-  for candi in candidates
-    candi.extra = op
-    candi.tag = tag
-  end
-  return candidates
+    sel_op, tag = next(op)
+    candidates = evolve(de, sel_op) # use the selected operator of the mixture
+    # override what was set by sel_op so that adjust!() gets called for the mixture op
+    for candi in candidates
+        candi.extra = op
+        candi.tag = tag
+    end
+    return candidates
 end
 
 function evolve(de::DiffEvoOpt, mutate::MutationOperator)
-  target_index = select(de.select, de.population, 1)[1]
-  target = acquire_candi(de.population, target_index)
-  trial = acquire_candi(de.population, target)
-  apply!(mutate, trial.params, target_index)
-  return evolved_pair(de, target, trial, mutate, 0)
+    target_index = select(de.select, de.population, 1)[1]
+    target = acquire_candi(de.population, target_index)
+    trial = acquire_candi(de.population, target)
+    apply!(mutate, trial.params, target_index)
+    return evolved_pair(de, target, trial, mutate, 0)
 end
 
 function evolve(de::DiffEvoOpt, crossover::CrossoverOperator)
-  # Sample parents and target
-  indices = select(de.select, de.population, 1 + numparents(crossover))
-  parent_indices = indices[1:numparents(crossover)]
-  #println("parent_indices = $(parent_indices)")
-  target_index = indices[end]
-  target = acquire_candi(de.population, target_index)
-  #println("target[$(target_index)] = $(target)")
+    # Sample parents and target
+    indices = select(de.select, de.population, 1 + numparents(crossover))
+    parent_indices = indices[1:numparents(crossover)]
+    #println("parent_indices = $(parent_indices)")
+    target_index = indices[end]
+    target = acquire_candi(de.population, target_index)
+    #println("target[$(target_index)] = $(target)")
 
-  # Crossover parents and target
-  @assert numchildren(crossover)==1
-  trial = acquire_candi(de.population, target)
-  apply!(crossover, trial.params, target_index,
-         de.population, parent_indices)
-  return evolved_pair(de, target, trial, crossover, 0)
+    # Crossover parents and target
+    @assert numchildren(crossover)==1
+    trial = acquire_candi(de.population, target)
+    apply!(crossover, trial.params, target_index,
+           de.population, parent_indices)
+    return evolved_pair(de, target, trial, crossover, 0)
 end
 
 """
 Post-process the evolved pair.
 """
-function evolved_pair{F}(de::DiffEvoOpt, target::Candidate{F}, trial::Candidate{F}, op::GeneticOperator, tag::Int = 0)
-  # embed the trial parameter vector into the search space
-  apply!(de.embed, trial.params, de.population, target.index)
-  target.extra = trial.extra = op
-  target.tag = trial.tag = tag
-  if trial.params != target.params
-    reset_fitness!(trial, de.population)
-  end
+function evolved_pair{F}(de::DiffEvoOpt, target::Candidate{F}, trial::Candidate{F},
+                         op::GeneticOperator, tag::Int = 0)
+    # embed the trial parameter vector into the search space
+    apply!(de.embed, trial.params, de.population, target.index)
+    target.extra = trial.extra = op
+    target.tag = trial.tag = tag
+    if trial.params != target.params
+        reset_fitness!(trial, de.population)
+    end
 
-  return Candidate{F}[trial, target]
+    return Candidate{F}[trial, target]
 end
 
 function tell!{F}(de::DiffEvoOpt,
-  # archive::Archive, # Skip for now
-  rankedCandidates::Vector{Candidate{F}})
-  n_acceptable_candidates = length(rankedCandidates)÷2
-  num_better = 0
-  for i in eachindex(rankedCandidates)
-    candi = rankedCandidates[i]
-    # accept the modified individuals from the top ranked half
-    if i <= n_acceptable_candidates
-      is_improved = candi.params != viewer(population(de), candi.index)
-      adjust!(de, candi, is_improved)
-    else
-      is_improved = false
+        # archive::Archive, # Skip for now
+        rankedCandidates::Vector{Candidate{F}})
+    n_acceptable_candidates = length(rankedCandidates)÷2
+    num_better = 0
+    for i in eachindex(rankedCandidates)
+        candi = rankedCandidates[i]
+        # accept the modified individuals from the top ranked half
+        if i <= n_acceptable_candidates
+            is_improved = candi.params != viewer(population(de), candi.index)
+            adjust!(de, candi, is_improved)
+        else
+            is_improved = false
+        end
+        if is_improved
+            num_better += 1
+            #print("candidate = "); show(candidate); println("")
+            #print("index = "); show(index); println("")
+            #print("target = "); show(de.population[index,:]); println("")
+            #old = de.population[:,index]
+            accept_candi!(de.population, candi)
+        else
+            # just return candidate to the pool
+            release_candi(de.population, candi)
+        end
     end
-    if is_improved
-      num_better += 1
-      #print("candidate = "); show(candidate); println("")
-      #print("index = "); show(index); println("")
-      #print("target = "); show(de.population[index,:]); println("")
-      #old = de.population[:,index]
-      accept_candi!(de.population, candi)
-    else
-      # just return candidate to the pool
-      release_candi(de.population, candi)
-    end
-  end
-  num_better
+    num_better
 end
 
 """
 Adjust the parameters of the method after the candidate evaluation.
 """
 function adjust!(de::DiffEvoOpt, candi::Candidate, is_improved::Bool)
-  # adjust the parameters of the operation
-  old_fitness = fitness(population(de), candi.index)
-  if isnan(old_fitness)
-    old_fitness = candi.fitness
-  end
+    # adjust the parameters of the operation
+    old_fitness = fitness(population(de), candi.index)
+    if isnan(old_fitness)
+        old_fitness = candi.fitness
+    end
 
-  adjust!(candi.extra::GeneticOperator, candi.tag, candi.index, candi.fitness,
-          fitness(population(de), candi.index), is_improved)
+    adjust!(candi.extra::GeneticOperator, candi.tag, candi.index, candi.fitness,
+            fitness(population(de), candi.index), is_improved)
 end
 
 # Now we can create specific DE optimizers that are commonly used in the
@@ -136,10 +137,10 @@ end
 function diffevo(problem::OptimizationProblem, options::Parameters, name::String,
                  select::IndividualsSelector = SimpleSelector(),
                  crossover::DiffEvoCrossoverOperator = DiffEvoRandBin1(chain(DE_DefaultOptions, options)))
-  opts = chain(DE_DefaultOptions, options)
-  pop = population(problem, opts)
-  DiffEvoOpt(name, pop, select, crossover,
-             RandomBound(search_space(problem)))
+    opts = chain(DE_DefaultOptions, options)
+    pop = population(problem, opts)
+    DiffEvoOpt(name, pop, select, crossover,
+               RandomBound(search_space(problem)))
 end
 
 """

--- a/src/differential_evolution.jl
+++ b/src/differential_evolution.jl
@@ -6,7 +6,7 @@ const DE_DefaultOptions = chain(DEX_DefaultOptions, ParamsDict(
 
 # FIXME DifferentialEvolution is just a specific case of this optimizer,
 # should it be called EvolutionaryOptimizer?
-type DiffEvoOpt{P<:Population,S<:IndividualsSelector,M<:GeneticOperator,E<:EmbeddingOperator} <: PopulationOptimizer
+mutable struct DiffEvoOpt{P<:Population,S<:IndividualsSelector,M<:GeneticOperator,E<:EmbeddingOperator} <: PopulationOptimizer
     # TODO when sampler and bound would be parameterized, name is no longer required -- as everything is seen in the type name
     name::String
 

--- a/src/differential_evolution.jl
+++ b/src/differential_evolution.jl
@@ -75,8 +75,8 @@ end
 """
 Post-process the evolved pair.
 """
-function evolved_pair{F}(de::DiffEvoOpt, target::Candidate{F}, trial::Candidate{F},
-                         op::GeneticOperator, tag::Int = 0)
+function evolved_pair(de::DiffEvoOpt, target::Candidate{F}, trial::Candidate{F},
+                      op::GeneticOperator, tag::Int = 0) where F
     # embed the trial parameter vector into the search space
     apply!(de.embed, trial.params, de.population, target.index)
     target.extra = trial.extra = op
@@ -88,9 +88,9 @@ function evolved_pair{F}(de::DiffEvoOpt, target::Candidate{F}, trial::Candidate{
     return Candidate{F}[trial, target]
 end
 
-function tell!{F}(de::DiffEvoOpt,
+function tell!(de::DiffEvoOpt,
         # archive::Archive, # Skip for now
-        rankedCandidates::Vector{Candidate{F}})
+        rankedCandidates::Vector{Candidate{F}}) where F
     n_acceptable_candidates = length(rankedCandidates)÷2
     num_better = 0
     for i in eachindex(rankedCandidates)

--- a/src/direct_search_with_probabilistic_descent.jl
+++ b/src/direct_search_with_probabilistic_descent.jl
@@ -6,9 +6,8 @@
 #
 
 """
-  Generate `num` random vectors on the `n`-dimensional, unit (hyper)sphere.
-  This is the Muller-Marsaglia method as described on the page:
-    http://mathworld.wolfram.com/HyperspherePointPicking.html
+Generate `num` random vectors on the `n`-dimensional, unit (hyper)sphere.
+This is the Muller-Marsaglia method as described [here](http://mathworld.wolfram.com/HyperspherePointPicking.html).
 """
 function sample_unit_hypersphere(n, num = 1)
   X = randn(n, num)
@@ -26,8 +25,8 @@ function directions_for_k(rdg::RandomDirectionGen, k)
 end
 
 """
-  Generate half of the directions randomly and then
-  mirrors by negating them.
+Generate half of the directions randomly and then
+mirrors by negating them.
 """
 immutable MirroredRandomDirectionGen <: DirectionGenerator
   numDimensions::Int

--- a/src/direct_search_with_probabilistic_descent.jl
+++ b/src/direct_search_with_probabilistic_descent.jl
@@ -10,47 +10,45 @@ Generate `num` random vectors on the `n`-dimensional, unit (hyper)sphere.
 This is the Muller-Marsaglia method as described [here](http://mathworld.wolfram.com/HyperspherePointPicking.html).
 """
 function sample_unit_hypersphere(n, num = 1)
-  X = randn(n, num)
-  sqrootsums = 1 ./ sqrt.(sum(abs2, X, 1))
-  broadcast(*, sqrootsums, X)
+    X = randn(n, num)
+    sqrootsums = 1 ./ sqrt.(sum(abs2, X, 1))
+    broadcast(*, sqrootsums, X)
 end
 
 immutable RandomDirectionGen <: DirectionGenerator
-  numDimensions::Int
-  numDirections::Int
+    numDimensions::Int
+    numDirections::Int
 end
 
-function directions_for_k(rdg::RandomDirectionGen, k)
-  sample_unit_hypersphere(rdg.numDimensions, rdg.numDirections)
-end
+directions_for_k(rdg::RandomDirectionGen, k) =
+    sample_unit_hypersphere(rdg.numDimensions, rdg.numDirections)
 
 """
 Generate half of the directions randomly and then
 mirrors by negating them.
 """
 immutable MirroredRandomDirectionGen <: DirectionGenerator
-  numDimensions::Int
-  numDirections::Int
+    numDimensions::Int
+    numDirections::Int
 
-  MirroredRandomDirectionGen(numDims, numDirections) = begin
-    if !iseven(numDirections)
-      throw(ArgumentError("the number of directions must be even"))
+    function MirroredRandomDirectionGen(numDims, numDirections)
+        iseven(numDirections) ||
+            throw(ArgumentError("the number of directions must be even"))
+        new(numDims, numDirections)
     end
-    new(numDims, numDirections)
-  end
 end
 
 function directions_for_k(rdg::MirroredRandomDirectionGen, k)
-  r = sample_unit_hypersphere(rdg.numDimensions, rdg.numDirections÷2)
-  [r -r]
+    r = sample_unit_hypersphere(rdg.numDimensions, rdg.numDirections÷2)
+    [r -r]
 end
 
 const DirectSearchProbabilisticDescentDefaultParameters = ParamsDict(
-  :NumDirections => 2, # This should be a function of Gamma and Phi for the GSS but 2 is often enough
+    :NumDirections => 2, # This should be a function of Gamma and Phi for the GSS but 2 is often enough
 )
 
 function direct_search_probabilistic_descent(problem::OptimizationProblem, parameters::Parameters)
-  params = chain(DirectSearchProbabilisticDescentDefaultParameters, parameters)
-  params[:DirectionGenerator] = MirroredRandomDirectionGen(numdims(problem), params[:NumDirections])
-  GeneratingSetSearcher(problem, params)
+    params = chain(DirectSearchProbabilisticDescentDefaultParameters, parameters)
+    params[:DirectionGenerator] = MirroredRandomDirectionGen(numdims(problem), params[:NumDirections])
+    GeneratingSetSearcher(problem, params)
 end

--- a/src/direct_search_with_probabilistic_descent.jl
+++ b/src/direct_search_with_probabilistic_descent.jl
@@ -15,7 +15,7 @@ function sample_unit_hypersphere(n, num = 1)
     broadcast(*, sqrootsums, X)
 end
 
-immutable RandomDirectionGen <: DirectionGenerator
+struct RandomDirectionGen <: DirectionGenerator
     numDimensions::Int
     numDirections::Int
 end
@@ -27,7 +27,7 @@ directions_for_k(rdg::RandomDirectionGen, k) =
 Generate half of the directions randomly and then
 mirrors by negating them.
 """
-immutable MirroredRandomDirectionGen <: DirectionGenerator
+struct MirroredRandomDirectionGen <: DirectionGenerator
     numDimensions::Int
     numDirections::Int
 

--- a/src/dx_nes.jl
+++ b/src/dx_nes.jl
@@ -1,7 +1,7 @@
 """
 DX-NES: distance-weighted extensions of xNES by Fukushima et al.
 """
-type DXNESOpt{F,E<:EmbeddingOperator} <: ExponentialNaturalEvolutionStrategyOpt
+mutable struct DXNESOpt{F,E<:EmbeddingOperator} <: ExponentialNaturalEvolutionStrategyOpt
     embed::E                        # operator embedding into the search space
     lambda::Int                     # Number of samples to take per iteration
     sortedUtilities::Vector{Float64}# Fitness utility to give to each rank

--- a/src/dx_nes.jl
+++ b/src/dx_nes.jl
@@ -2,65 +2,65 @@
 DX-NES: distance-weighted extensions of xNES by Fukushima et al.
 """
 type DXNESOpt{F,E<:EmbeddingOperator} <: ExponentialNaturalEvolutionStrategyOpt
-  embed::E                        # operator embedding into the search space
-  lambda::Int                     # Number of samples to take per iteration
-  sortedUtilities::Vector{Float64}# Fitness utility to give to each rank
-  tmp_Utilities::Vector{Float64}  # Fitness utilities assigned to current population
-  x_learnrate::Float64
-  B_learnrate::Float64
-  sigma_learnrate::Float64
-  max_sigma::Float64
-  moving_threshold::Float64       # threshold of |evolutionary path| to detect movement
-  evol_discount::Float64
-  evol_Zscale::Float64
-  uZscale::Float64                # distance scale for the weights
-  evol_path::Vector{Float64}      # evolution path, discounted coordinates of population center
-  # TODO use Symmetric{Float64} to inmprove exponent etc calculation
-  ln_B::Matrix{Float64}           # exponential of lnB
-  sigma::Float64                  # step size
-  x::Individual                   # The current incumbent (aka most likely value, mu etc)
-  Z::Matrix{Float64}              # current N(0,I) samples
-  candidates::Vector{Candidate{F}}# The last sampled values, now being evaluated
+    embed::E                        # operator embedding into the search space
+    lambda::Int                     # Number of samples to take per iteration
+    sortedUtilities::Vector{Float64}# Fitness utility to give to each rank
+    tmp_Utilities::Vector{Float64}  # Fitness utilities assigned to current population
+    x_learnrate::Float64
+    B_learnrate::Float64
+    sigma_learnrate::Float64
+    max_sigma::Float64
+    moving_threshold::Float64       # threshold of |evolutionary path| to detect movement
+    evol_discount::Float64
+    evol_Zscale::Float64
+    uZscale::Float64                # distance scale for the weights
+    evol_path::Vector{Float64}      # evolution path, discounted coordinates of population center
+    # TODO use Symmetric{Float64} to inmprove exponent etc calculation
+    ln_B::Matrix{Float64}           # exponential of lnB
+    sigma::Float64                  # step size
+    x::Individual                   # The current incumbent (aka most likely value, mu etc)
+    Z::Matrix{Float64}              # current N(0,I) samples
+    candidates::Vector{Candidate{F}}# The last sampled values, now being evaluated
 
-  # temporary variables to minimize GC overhead
-  tmp_x::Individual
-  tmp_dz::Individual
-  tmp_dx::Individual
-  tmp_lndB::Matrix{Float64}
-  tmp_Zu::Matrix{Float64}
-  tmp_sBZ::Matrix{Float64}
+    # temporary variables to minimize GC overhead
+    tmp_x::Individual
+    tmp_dz::Individual
+    tmp_dx::Individual
+    tmp_lndB::Matrix{Float64}
+    tmp_Zu::Matrix{Float64}
+    tmp_sBZ::Matrix{Float64}
 
-  function DXNESOpt(embed::E; lambda::Int = 0,
-                   mu_learnrate::Float64 = 1.0,
-                   ini_x = nothing, ini_sigma::Float64 = 1.0,
-                   ini_lnB = nothing,
-                   max_sigma::Float64 = 1.0E+10)
-    iseven(lambda) || throw(ArgumentError("lambda needs to be even"))
-    d = numdims(search_space(embed))
-    if lambda == 0
-      lambda = 4 + 3*floor(Int, log(d))
+    function DXNESOpt(embed::E; lambda::Int = 0,
+            mu_learnrate::Float64 = 1.0,
+            ini_x = nothing, ini_sigma::Float64 = 1.0,
+            ini_lnB = nothing,
+            max_sigma::Float64 = 1.0E+10)
+        iseven(lambda) || throw(ArgumentError("lambda needs to be even"))
+        d = numdims(search_space(embed))
+        if lambda == 0
+            lambda = 4 + 3*floor(Int, log(d))
+        end
+        if ini_x === nothing
+            ini_x = rand_individual(search_space(embed))
+        else
+            ini_x = copy(ini_x::Individual)
+            apply!(embed, ini_x, rand_individual(search_space(embed)))
+        end
+        u = fitness_shaping_utilities_log(lambda)
+        moving_threshold, evol_discount, evol_Zscale = calculate_evol_path_params(d, u)
+
+        new(embed, lambda, u, Vector{Float64}(lambda),
+            mu_learnrate, 0.0, 0.0, max_sigma,
+            moving_threshold, evol_discount, evol_Zscale, 0.9 + 0.15 * log(d),
+            zeros(d), ini_lnB === nothing ? ini_xnes_B(search_space(embed)) : ini_lnB, ini_sigma, ini_x,
+            zeros(d, lambda),
+            Candidate{F}[Candidate{F}(Vector{Float64}(d), i) for i in 1:lambda],
+            # temporaries
+            zeros(d), zeros(d), zeros(d),
+            zeros(d, d),
+            zeros(d, lambda), zeros(d, lambda)
+        )
     end
-    if ini_x === nothing
-      ini_x = rand_individual(search_space(embed))
-    else
-      ini_x = copy(ini_x::Individual)
-      apply!(embed, ini_x, rand_individual(search_space(embed)))
-    end
-    u = fitness_shaping_utilities_log(lambda)
-    moving_threshold, evol_discount, evol_Zscale = calculate_evol_path_params(d, u)
-
-    new(embed, lambda, u, Vector{Float64}(lambda),
-      mu_learnrate, 0.0, 0.0, max_sigma,
-      moving_threshold, evol_discount, evol_Zscale, 0.9 + 0.15 * log(d),
-      zeros(d), ini_lnB === nothing ? ini_xnes_B(search_space(embed)) : ini_lnB, ini_sigma, ini_x,
-      zeros(d, lambda),
-      Candidate{F}[Candidate{F}(Vector{Float64}(d), i) for i in 1:lambda],
-      # temporaries
-      zeros(d), zeros(d), zeros(d),
-      zeros(d, d),
-      zeros(d, lambda), zeros(d, lambda)
-    )
-  end
 end
 
 function trace_state(io::IO, dxnes::DXNESOpt, mode::Symbol)
@@ -76,44 +76,44 @@ function trace_state(io::IO, dxnes::DXNESOpt, mode::Symbol)
 end
 
 const DXNES_DefaultOptions = chain(NES_DefaultOptions, ParamsDict(
-  :ini_sigma => 1.0,      # Initial sigma (step size)
-  :ini_lnB => nothing     # Initial log(B) (log of parameters covariation)
+    :ini_sigma => 1.0,      # Initial sigma (step size)
+    :ini_lnB => nothing     # Initial log(B) (log of parameters covariation)
 ))
 
 function dxnes(problem::OptimizationProblem, parameters)
-  params = chain(DXNES_DefaultOptions, parameters)
-  embed = RandomBound(search_space(problem))
-  DXNESOpt{fitness_type(problem), typeof(embed)}(embed; lambda = params[:lambda],
-                                                 ini_x = params[:ini_x],
-                                                 ini_sigma = params[:ini_sigma],
-                                                 ini_lnB = params[:ini_lnB],
-                                                 max_sigma = params[:max_sigma])
+    params = chain(DXNES_DefaultOptions, parameters)
+    embed = RandomBound(search_space(problem))
+    DXNESOpt{fitness_type(problem), typeof(embed)}(embed; lambda = params[:lambda],
+                                                   ini_x = params[:ini_x],
+                                                   ini_sigma = params[:ini_sigma],
+                                                   ini_lnB = params[:ini_lnB],
+                                                   max_sigma = params[:max_sigma])
 end
 
 function ask(dxnes::DXNESOpt)
-  hlambda = dxnes.lambda÷2
-  for i in 1:hlambda
-    for j in 1:size(dxnes.Z, 1)
-      dxnes.Z[j, i] = randn()
-      dxnes.Z[j, i+hlambda] = -dxnes.Z[j, i]
+    hlambda = dxnes.lambda÷2
+    for i in 1:hlambda
+        for j in 1:size(dxnes.Z, 1)
+            dxnes.Z[j, i] = randn()
+            dxnes.Z[j, i+hlambda] = -dxnes.Z[j, i]
+        end
     end
-  end
-  update_candidates!(dxnes, dxnes.Z)
+    update_candidates!(dxnes, dxnes.Z)
 end
 
 function tell!{F}(dxnes::DXNESOpt{F}, rankedCandidates::Vector{Candidate{F}})
-  u = assign_weights!(dxnes.tmp_Utilities, rankedCandidates, dxnes.sortedUtilities)
-  dxnes.evol_path *= dxnes.evol_discount
-  dxnes.evol_path += dxnes.evol_Zscale * squeeze(wsum(dxnes.Z, u, 2), 2)
-  evol_speed = norm(dxnes.evol_path)/dxnes.moving_threshold
-  if evol_speed > 1.0
-    # the center is moving, adjust weights
-    u = assign_distance_weights!(dxnes.tmp_Utilities, dxnes.uZscale, rankedCandidates, dxnes.Z)
-  end
-  update_learning_rates!(dxnes, evol_speed)
-  update_parameters!(dxnes, u)
+    u = assign_weights!(dxnes.tmp_Utilities, rankedCandidates, dxnes.sortedUtilities)
+    dxnes.evol_path *= dxnes.evol_discount
+    dxnes.evol_path += dxnes.evol_Zscale * squeeze(wsum(dxnes.Z, u, 2), 2)
+    evol_speed = norm(dxnes.evol_path)/dxnes.moving_threshold
+    if evol_speed > 1.0
+        # the center is moving, adjust weights
+        u = assign_distance_weights!(dxnes.tmp_Utilities, dxnes.uZscale, rankedCandidates, dxnes.Z)
+    end
+    update_learning_rates!(dxnes, evol_speed)
+    update_parameters!(dxnes, u)
 
-  return 0
+    return 0
 end
 
 """
@@ -125,50 +125,50 @@ Returns the tuple:
   * current Z scale
 """
 function calculate_evol_path_params(n::Int, u::Vector{Float64})
-  lambda = length(u)
-  mu = 1/sum(i -> (u[i]+1/lambda)^2, 1:(lambda÷2))
-  c = (mu + 2.0)/(sqrt(n)*(n+mu+5.0))
-  discount = 1-c
-  Zscale = sqrt(c*(2-c)*mu)
-  # Expected length of evol.path, if uZ ~ α N(0,I), based on AR model:
-  # E|path|^2 = α*Zscale^2 / (1-discount^2),
-  # where α ≈ 1 if the population does not cover the minimum and lies on the slope
-  # (so that |uZ| is large), but σ is too large and the method is diverging
-  threshold = Zscale*sqrt(n/(1-discount^2))
-  #info("DX-NES params: moving_threshold=", threshold,
-  #     " μ=", mu, " c=", c, " discount=", discount, " Zscale=", Zscale)
-  return threshold, discount, Zscale
+    lambda = length(u)
+    mu = 1/sum(i -> (u[i]+1/lambda)^2, 1:(lambda÷2))
+    c = (mu + 2.0)/(sqrt(n)*(n+mu+5.0))
+    discount = 1-c
+    Zscale = sqrt(c*(2-c)*mu)
+    # Expected length of evol.path, if uZ ~ α N(0,I), based on AR model:
+    # E|path|^2 = α*Zscale^2 / (1-discount^2),
+    # where α ≈ 1 if the population does not cover the minimum and lies on the slope
+    # (so that |uZ| is large), but σ is too large and the method is diverging
+    threshold = Zscale*sqrt(n/(1-discount^2))
+    #info("DX-NES params: moving_threshold=", threshold,
+    #     " μ=", mu, " c=", c, " discount=", discount, " Zscale=", Zscale)
+    return threshold, discount, Zscale
 end
 
 function assign_distance_weights!{F}(weights::Vector{Float64}, scale::Float64,
                                      rankedCandidates::Vector{Candidate{F}},
                                      Z::Matrix{Float64})
-  @assert length(weights) == length(rankedCandidates) == size(Z, 2)
-  lambda = size(Z, 2)
-  u0 = log(0.5*lambda+1)
-  for i in 1:lambda
-    cand_ix = rankedCandidates[i].index
-    weights[cand_ix] = max(u0-log(i), 0) * exp(scale*norm(Z[:,cand_ix]))
-  end
-  wsum = sum(weights)
-  for i in 1:lambda
-    weights[i] = weights[i]/wsum - 1/lambda
-  end
-  return weights
+    @assert length(weights) == length(rankedCandidates) == size(Z, 2)
+    lambda = size(Z, 2)
+    u0 = log(0.5*lambda+1)
+    for i in 1:lambda
+        cand_ix = rankedCandidates[i].index
+        weights[cand_ix] = max(u0-log(i), 0) * exp(scale*norm(Z[:,cand_ix]))
+    end
+    wsum = sum(weights)
+    for i in 1:lambda
+        weights[i] = weights[i]/wsum - 1/lambda
+    end
+    return weights
 end
 
 function update_learning_rates!(dxnes::DXNESOpt, evol_speed::Float64)
-  n = numdims(dxnes)
-  if evol_speed > 1.0
-    dxnes.sigma_learnrate = 1.0
-    dxnes.B_learnrate = (dxnes.lambda + 2n)/(dxnes.lambda+2*n^2+100) *
-                        min(1.0, sqrt(dxnes.lambda/numdims(dxnes)))
-  else
-    dxnes.sigma_learnrate = 1.0 + dxnes.lambda/(dxnes.lambda+2*n)
-    if evol_speed > 0.1
-      dxnes.sigma_learnrate *= 0.5
+    n = numdims(dxnes)
+    if evol_speed > 1.0
+        dxnes.sigma_learnrate = 1.0
+        dxnes.B_learnrate = (dxnes.lambda + 2n)/(dxnes.lambda+2*n^2+100) *
+                            min(1.0, sqrt(dxnes.lambda/numdims(dxnes)))
+    else
+        dxnes.sigma_learnrate = 1.0 + dxnes.lambda/(dxnes.lambda+2*n)
+        if evol_speed > 0.1
+            dxnes.sigma_learnrate *= 0.5
+        end
+        dxnes.B_learnrate = dxnes.lambda/(dxnes.lambda+2*n^2+100)
     end
-    dxnes.B_learnrate = dxnes.lambda/(dxnes.lambda+2*n^2+100)
-  end
-  dxnes
+    return dxnes
 end

--- a/src/dx_nes.jl
+++ b/src/dx_nes.jl
@@ -1,5 +1,5 @@
 """
-  DX-NES: distance-weighted extensions of xNES by Fukushima et al.
+DX-NES: distance-weighted extensions of xNES by Fukushima et al.
 """
 type DXNESOpt{F,E<:EmbeddingOperator} <: ExponentialNaturalEvolutionStrategyOpt
   embed::E                        # operator embedding into the search space
@@ -117,12 +117,12 @@ function tell!{F}(dxnes::DXNESOpt{F}, rankedCandidates::Vector{Candidate{F}})
 end
 
 """
-  Calculate the parameters for evolutionary path.
+Calculate the parameters for evolutionary path.
 
-  Returns the tuple:
-    * moving threshold
-    * path discount
-    * current Z scale
+Returns the tuple:
+  * moving threshold
+  * path discount
+  * current Z scale
 """
 function calculate_evol_path_params(n::Int, u::Vector{Float64})
   lambda = length(u)

--- a/src/dx_nes.jl
+++ b/src/dx_nes.jl
@@ -54,7 +54,7 @@ mutable struct DXNESOpt{F,E<:EmbeddingOperator} <: ExponentialNaturalEvolutionSt
             moving_threshold, evol_discount, evol_Zscale, 0.9 + 0.15 * log(d),
             zeros(d), ini_lnB === nothing ? ini_xnes_B(search_space(embed)) : ini_lnB, ini_sigma, ini_x,
             zeros(d, lambda),
-            Candidate{F}[Candidate{F}(Vector{Float64}(d), i) for i in 1:lambda],
+            [Candidate{F}(Vector{Float64}(d), i) for i in 1:lambda],
             # temporaries
             zeros(d), zeros(d), zeros(d),
             zeros(d, d),

--- a/src/dx_nes.jl
+++ b/src/dx_nes.jl
@@ -101,7 +101,7 @@ function ask(dxnes::DXNESOpt)
     update_candidates!(dxnes, dxnes.Z)
 end
 
-function tell!{F}(dxnes::DXNESOpt{F}, rankedCandidates::Vector{Candidate{F}})
+function tell!(dxnes::DXNESOpt{F}, rankedCandidates::Vector{Candidate{F}}) where F
     u = assign_weights!(dxnes.tmp_Utilities, rankedCandidates, dxnes.sortedUtilities)
     dxnes.evol_path *= dxnes.evol_discount
     dxnes.evol_path += dxnes.evol_Zscale * squeeze(wsum(dxnes.Z, u, 2), 2)
@@ -140,9 +140,9 @@ function calculate_evol_path_params(n::Int, u::Vector{Float64})
     return threshold, discount, Zscale
 end
 
-function assign_distance_weights!{F}(weights::Vector{Float64}, scale::Float64,
-                                     rankedCandidates::Vector{Candidate{F}},
-                                     Z::Matrix{Float64})
+function assign_distance_weights!(weights::Vector{Float64}, scale::Float64,
+                                  rankedCandidates::Vector{Candidate{F}},
+                                  Z::Matrix{Float64}) where F
     @assert length(weights) == length(rankedCandidates) == size(Z, 2)
     lambda = size(Z, 2)
     u0 = log(0.5*lambda+1)

--- a/src/dx_nes.jl
+++ b/src/dx_nes.jl
@@ -30,11 +30,11 @@ mutable struct DXNESOpt{F,E<:EmbeddingOperator} <: ExponentialNaturalEvolutionSt
     tmp_Zu::Matrix{Float64}
     tmp_sBZ::Matrix{Float64}
 
-    function DXNESOpt(embed::E; lambda::Int = 0,
+    function DXNESOpt{F}(embed::E; lambda::Int = 0,
             mu_learnrate::Float64 = 1.0,
             ini_x = nothing, ini_sigma::Float64 = 1.0,
             ini_lnB = nothing,
-            max_sigma::Float64 = 1.0E+10)
+            max_sigma::Float64 = 1.0E+10) where {F, E<:EmbeddingOperator}
         iseven(lambda) || throw(ArgumentError("lambda needs to be even"))
         d = numdims(search_space(embed))
         if lambda == 0
@@ -49,7 +49,7 @@ mutable struct DXNESOpt{F,E<:EmbeddingOperator} <: ExponentialNaturalEvolutionSt
         u = fitness_shaping_utilities_log(lambda)
         moving_threshold, evol_discount, evol_Zscale = calculate_evol_path_params(d, u)
 
-        new(embed, lambda, u, Vector{Float64}(lambda),
+        new{F,E}(embed, lambda, u, Vector{Float64}(lambda),
             mu_learnrate, 0.0, 0.0, max_sigma,
             moving_threshold, evol_discount, evol_Zscale, 0.9 + 0.15 * log(d),
             zeros(d), ini_lnB === nothing ? ini_xnes_B(search_space(embed)) : ini_lnB, ini_sigma, ini_x,
@@ -83,11 +83,11 @@ const DXNES_DefaultOptions = chain(NES_DefaultOptions, ParamsDict(
 function dxnes(problem::OptimizationProblem, parameters)
     params = chain(DXNES_DefaultOptions, parameters)
     embed = RandomBound(search_space(problem))
-    DXNESOpt{fitness_type(problem), typeof(embed)}(embed; lambda = params[:lambda],
-                                                   ini_x = params[:ini_x],
-                                                   ini_sigma = params[:ini_sigma],
-                                                   ini_lnB = params[:ini_lnB],
-                                                   max_sigma = params[:max_sigma])
+    DXNESOpt{fitness_type(problem)}(embed; lambda = params[:lambda],
+                                    ini_x = params[:ini_x],
+                                    ini_sigma = params[:ini_sigma],
+                                    ini_lnB = params[:ini_lnB],
+                                    max_sigma = params[:max_sigma])
 end
 
 function ask(dxnes::DXNESOpt)

--- a/src/evaluator.jl
+++ b/src/evaluator.jl
@@ -23,20 +23,19 @@ Default implementation of the `Evaluator`.
 # FIXME F is the fitness type of the problem, but with current Julia it's
 # not possible to get and use it at declaration type
 type ProblemEvaluator{FP, FA, A<:Archive, P<:OptimizationProblem} <: Evaluator{P}
-  problem::P
-  archive::A
-  num_evals::Int
-  last_fitness::FP
+    problem::P
+    archive::A
+    num_evals::Int
+    last_fitness::FP
 
-  (::Type{ProblemEvaluator}){P<:OptimizationProblem, A<:Archive}(
-      problem::P, archive::A) =
-    new{fitness_type(fitness_scheme(problem)),fitness_type(archive),A,P}(problem, archive,
-        0, nafitness(fitness_scheme(problem)))
+    (::Type{ProblemEvaluator}){P<:OptimizationProblem, A<:Archive}(
+            problem::P, archive::A) =
+        new{fitness_type(fitness_scheme(problem)),fitness_type(archive),A,P}(problem, archive,
+                0, nafitness(fitness_scheme(problem)))
 
-  (::Type{ProblemEvaluator}){P<:OptimizationProblem}(
-      problem::P; archiveCapacity::Int = 10) =
-    ProblemEvaluator(problem, TopListArchive(fitness_scheme(problem), numdims(problem), archiveCapacity))
-
+    (::Type{ProblemEvaluator}){P<:OptimizationProblem}(
+            problem::P; archiveCapacity::Int = 10) =
+        ProblemEvaluator(problem, TopListArchive(fitness_scheme(problem), numdims(problem), archiveCapacity))
 end
 
 problem(e::Evaluator) = e.problem
@@ -51,11 +50,11 @@ parameters and calculated fitness.
 Returns the fitness in the archived format.
 """
 function fitness(params::Individual, e::ProblemEvaluator, tag::Int=0)
-  e.last_fitness = fit = fitness(params, e.problem)
-  e.num_evals += 1
-  fita = archived_fitness(fit, e.archive)
-  candi = add_candidate!(e.archive, fita, params, tag, e.num_evals)
-  fita
+    e.last_fitness = fit = fitness(params, e.problem)
+    e.num_evals += 1
+    fita = archived_fitness(fit, e.archive)
+    candi = add_candidate!(e.archive, fita, params, tag, e.num_evals)
+    return fita
 end
 
 """
@@ -73,35 +72,35 @@ is_better{F}(f1::F, f2::F, e::Evaluator) = is_better(f1, f2, fitness_scheme(e))
 is_better(candidate, f, e::Evaluator) = is_better(fitness(candidate, e), f, fitness_scheme(e))
 
 function best_of(candidate1::Individual, candidate2::Individual, e::Evaluator)
-  f1 = fitness(candidate1, e)
-  f2 = fitness(candidate2, e)
-  if is_better(f1, f2, e)
-    return candidate1, f1
-  else
-    return candidate2, f2
-  end
+    f1 = fitness(candidate1, e)
+    f2 = fitness(candidate2, e)
+    if is_better(f1, f2, e)
+        return candidate1, f1
+    else
+        return candidate2, f2
+    end
 end
 
 function update_fitness!{FP,FA}(e::ProblemEvaluator{FP,FA}, candidate::Candidate{FA})
-  # evaluate fitness if not known yet
-  if isnafitness(candidate.fitness, fitness_scheme(e.archive))
-      candidate.fitness = fitness(candidate.params, e, candidate.tag)
-  end
-  candidate
+    # evaluate fitness if not known yet
+    if isnafitness(candidate.fitness, fitness_scheme(e.archive))
+        candidate.fitness = fitness(candidate.params, e, candidate.tag)
+    end
+    return candidate
 end
 
 function update_fitness!{FP,FA}(e::ProblemEvaluator{FP,FA}, candidates::Vector{Candidate{FA}})
-  @inbounds for candidate in candidates
-      update_fitness!(e, candidate)
-  end
-  candidates
+    @inbounds for candidate in candidates
+        update_fitness!(e, candidate)
+    end
+    return candidates
 end
 
 function rank_by_fitness!{F,P<:OptimizationProblem}(e::Evaluator{P}, candidates::Vector{Candidate{F}})
-  fs = fitness_scheme(e)
-  sort!(update_fitness!(e, candidates);
-        # FIXME use lt=fitness_scheme(a) when v0.5 #14919 would be fixed
-        by=fitness, lt=(x, y) -> is_better(x, y, fs))
+    fs = fitness_scheme(e)
+    sort!(update_fitness!(e, candidates);
+          # FIXME use lt=fitness_scheme(a) when v0.5 #14919 would be fixed
+          by=fitness, lt=(x, y) -> is_better(x, y, fs))
 end
 
 # called by check_stop_condition(OptRunController)

--- a/src/evaluator.jl
+++ b/src/evaluator.jl
@@ -88,14 +88,14 @@ function update_fitness!(e::ProblemEvaluator{FP,FA}, candidate::Candidate{FA}) w
     return candidate
 end
 
-function update_fitness!(e::ProblemEvaluator{FP,FA}, candidates::Vector{Candidate{FA}}) where {FP,FA}
+function update_fitness!(e::ProblemEvaluator{FP,FA}, candidates::AbstractVector{Candidate{FA}}) where {FP,FA}
     @inbounds for candidate in candidates
         update_fitness!(e, candidate)
     end
     return candidates
 end
 
-function rank_by_fitness!(e::Evaluator, candidates::Vector{<:Candidate})
+function rank_by_fitness!(e::Evaluator, candidates::AbstractVector{<:Candidate})
     fs = fitness_scheme(e)
     sort!(update_fitness!(e, candidates);
           # FIXME use lt=fitness_scheme(a) when v0.5 #14919 would be fixed

--- a/src/evaluator.jl
+++ b/src/evaluator.jl
@@ -28,15 +28,14 @@ mutable struct ProblemEvaluator{FP, FA, A<:Archive, P<:OptimizationProblem} <: E
     num_evals::Int
     last_fitness::FP
 
-    (::Type{ProblemEvaluator}){P<:OptimizationProblem, A<:Archive}(
-            problem::P, archive::A) =
-        new{fitness_type(fitness_scheme(problem)),fitness_type(archive),A,P}(problem, archive,
+    ProblemEvaluator(problem::P, archive::A) where {P<:OptimizationProblem, A<:Archive} =
+        new{fitness_type(fitness_scheme(problem)),fitness_type(archive),A,P}(
+                problem, archive,
                 0, nafitness(fitness_scheme(problem)))
-
-    (::Type{ProblemEvaluator}){P<:OptimizationProblem}(
-            problem::P; archiveCapacity::Int = 10) =
-        ProblemEvaluator(problem, TopListArchive(fitness_scheme(problem), numdims(problem), archiveCapacity))
 end
+
+ProblemEvaluator(problem::OptimizationProblem; archiveCapacity::Int = 10) =
+    ProblemEvaluator(problem, TopListArchive(fitness_scheme(problem), numdims(problem), archiveCapacity))
 
 problem(e::Evaluator) = e.problem
 num_evals(e::ProblemEvaluator) = e.num_evals

--- a/src/evaluator.jl
+++ b/src/evaluator.jl
@@ -80,7 +80,7 @@ function best_of(candidate1::Individual, candidate2::Individual, e::Evaluator)
     end
 end
 
-function update_fitness!{FP,FA}(e::ProblemEvaluator{FP,FA}, candidate::Candidate{FA})
+function update_fitness!(e::ProblemEvaluator{FP,FA}, candidate::Candidate{FA}) where {FP,FA}
     # evaluate fitness if not known yet
     if isnafitness(candidate.fitness, fitness_scheme(e.archive))
         candidate.fitness = fitness(candidate.params, e, candidate.tag)
@@ -88,14 +88,14 @@ function update_fitness!{FP,FA}(e::ProblemEvaluator{FP,FA}, candidate::Candidate
     return candidate
 end
 
-function update_fitness!{FP,FA}(e::ProblemEvaluator{FP,FA}, candidates::Vector{Candidate{FA}})
+function update_fitness!(e::ProblemEvaluator{FP,FA}, candidates::Vector{Candidate{FA}}) where {FP,FA}
     @inbounds for candidate in candidates
         update_fitness!(e, candidate)
     end
     return candidates
 end
 
-function rank_by_fitness!{F,P<:OptimizationProblem}(e::Evaluator{P}, candidates::Vector{Candidate{F}})
+function rank_by_fitness!(e::Evaluator, candidates::Vector{<:Candidate})
     fs = fitness_scheme(e)
     sort!(update_fitness!(e, candidates);
           # FIXME use lt=fitness_scheme(a) when v0.5 #14919 would be fixed

--- a/src/evaluator.jl
+++ b/src/evaluator.jl
@@ -1,6 +1,6 @@
 """
-  The abstract base for types that manage the objective function evaluation.
-  `P` is the optimization problem it is used for.
+The abstract base for types that manage the objective function evaluation.
+`P` is the optimization problem it is used for.
 """
 abstract type Evaluator{P <: OptimizationProblem} end
 
@@ -15,10 +15,10 @@ problem_summary(e::Evaluator) = "$(name(e.problem))_$(numdims(e))d"
 shutdown!(e::Evaluator) = e # do nothing
 
 """
-  Default implementation of the `Evaluator`.
+Default implementation of the `Evaluator`.
 
-  `FP` is the original problem's fitness type
-  `FA` is the fitness type actually stored by the archive.
+`FP` is the original problem's fitness type
+`FA` is the fitness type actually stored by the archive.
 """
 # FIXME F is the fitness type of the problem, but with current Julia it's
 # not possible to get and use it at declaration type
@@ -45,10 +45,10 @@ num_evals(e::ProblemEvaluator) = e.num_evals
 """
     fitness(params::Individual, e::ProblemEvaluator, tag::Int=0)
 
-    Evaluate the fitness and implicitly update the archive with the provided
-    parameters and calculated fitness.
+Evaluate the fitness and implicitly update the archive with the provided
+parameters and calculated fitness.
 
-    Returns the fitness in the archived format.
+Returns the fitness in the archived format.
 """
 function fitness(params::Individual, e::ProblemEvaluator, tag::Int=0)
   e.last_fitness = fit = fitness(params, e.problem)
@@ -61,10 +61,10 @@ end
 """
     last_fitness(e::Evaluator)
 
-  Get the fitness of the last evaluated candidate.
+Get the fitness of the last evaluated candidate.
 
-  Leads to nicer code if we can first test if it is better or worse than existing candidates
-  and only want the fitness itself if the criteria fulfilled.
+Leads to nicer code if we can first test if it is better or worse than existing candidates
+and only want the fitness itself if the criteria fulfilled.
 """
 last_fitness(e::Evaluator) = e.last_fitness
 

--- a/src/evaluator.jl
+++ b/src/evaluator.jl
@@ -2,7 +2,7 @@
   The abstract base for types that manage the objective function evaluation.
   `P` is the optimization problem it is used for.
 """
-@compat abstract type Evaluator{P <: OptimizationProblem} end
+abstract type Evaluator{P <: OptimizationProblem} end
 
 fitness_scheme(e::Evaluator) = fitness_scheme(problem(e))
 fitness_type(e::Evaluator) = fitness_type(fitness_scheme(e))

--- a/src/evaluator.jl
+++ b/src/evaluator.jl
@@ -22,7 +22,7 @@ Default implementation of the `Evaluator`.
 """
 # FIXME F is the fitness type of the problem, but with current Julia it's
 # not possible to get and use it at declaration type
-type ProblemEvaluator{FP, FA, A<:Archive, P<:OptimizationProblem} <: Evaluator{P}
+mutable struct ProblemEvaluator{FP, FA, A<:Archive, P<:OptimizationProblem} <: Evaluator{P}
     problem::P
     archive::A
     num_evals::Int

--- a/src/experiments/parameter_experiment.jl
+++ b/src/experiments/parameter_experiment.jl
@@ -1,218 +1,217 @@
 using JSON
 
 type ParameterExperiment
-  parameters::Vector{String}               # Parameter names
-  mappers::Vector{Function}                     # One function per param mapping a design value to a param value
-  design_ranges::Vector{Tuple{Float64, Float64}}# Design range per parameter
+    parameters::Vector{String}               # Parameter names
+    mappers::Vector{Function}                     # One function per param mapping a design value to a param value
+    design_ranges::Vector{Tuple{Float64, Float64}}# Design range per parameter
 end
 
 numparams(pe::ParameterExperiment) = length(pe.parameters)
 
 function write_csv_header_to_file(pe::ParameterExperiment, filepath)
-  header = join([
-    map((i) -> "d$(i)", 1:numparams(pe)),
-    pe.parameters,
-    ["MedianFitness", "MedianFitnessMagnitude", "MedianNumFuncEvals", "MedianTime", "SuccessRate"]],
-    ",")
-  fh = open(filepath, "w")
-  println(fh, header)
-  close(fh)
+    header = join([
+        map((i) -> "d$(i)", 1:numparams(pe)),
+        pe.parameters,
+        ["MedianFitness", "MedianFitnessMagnitude", "MedianNumFuncEvals", "MedianTime", "SuccessRate"]],
+        ",")
+    fh = open(filepath, "w")
+    println(fh, header)
+    close(fh)
 end
 
 # The result from running the R tgp script is saved as a list to a json file
 # that we read into a dict.
 function read_json_design_list_from_file(filename)
-  fh = open(filename, "r")
-  fromR = JSON.parse(readall(fh))
-  close(fh)
-  fromR
+    fh = open(filename, "r")
+    fromR = JSON.parse(readall(fh))
+    close(fh)
+    fromR
 end
 
 function design01_matrix_from_R_list(fromR, matrix_name = "best")
-  reshape(fromR[matrix_name], fromR["num_rows"], fromR["num_cols"])
+    reshape(fromR[matrix_name], fromR["num_rows"], fromR["num_cols"])
 end
 
 function map01_range_to_design_range(value01, design_min, design_max)
-  design_min + value01 * (design_max - design_min)
+    design_min + value01 * (design_max - design_min)
 end
 
 function design_matrix_from_design01_matrix(pe::ParameterExperiment, design01)
-  ds = zeros(Float64, size(design01))
-  next_design_col = 1
+    ds = zeros(Float64, size(design01))
+    next_design_col = 1
 
-  for i in 1:numparams(pe)
-    #if is_fixed_param(pe, i)
-    #  ds[:, i] = value_for_fixed_param(pe, i) * ones(num_rows)
-    #else
-      dmin, dmax = pe.design_ranges[i]
-      ds[:, i] = map01_range_to_design_range(design01[:,next_design_col], dmin, dmax)
-      next_design_col += 1
-    #end
-  end
+    for i in 1:numparams(pe)
+        #if is_fixed_param(pe, i)
+        #  ds[:, i] = value_for_fixed_param(pe, i) * ones(num_rows)
+        #else
+        dmin, dmax = pe.design_ranges[i]
+        ds[:, i] = map01_range_to_design_range(design01[:,next_design_col], dmin, dmax)
+        next_design_col += 1
+        #end
+    end
 
-  ds
+    return ds
 end
 
 function parameter_values_from_design_matrix(pe::ParameterExperiment, design)
-  pvs = Any[]
+    pvs = Any[]
 
-  for i in 1:size(design,1)
-    ds = design[i,:]
-    ps = Any[]
-    param_dict = ParamsDict()
+    for i in 1:size(design,1)
+        ds = design[i,:]
+        ps = Any[]
+        param_dict = ParamsDict()
 
-    # Calc the parameter values from the design values.
-    for j in 1:numparams(pe)
-      param_dict[symbol(pe.parameters[j])] = pv = pe.mappers[j](ds, ps)
-      push!(ps, pv)
+        # Calc the parameter values from the design values.
+        for j in 1:numparams(pe)
+            param_dict[symbol(pe.parameters[j])] = pv = pe.mappers[j](ds, ps)
+            push!(ps, pv)
+        end
+
+        push!(pvs, param_dict)
     end
 
-    push!(pvs, param_dict)
-  end
-
-  return pvs
+    return pvs
 end
 
 function summary_of_R_output(pe::ParameterExperiment, designfile = "new_runs.json")
-  res = read_json_design_list_from_file(designfile)
-  for d01name in ["best", "top5_max", "top5_mean", "top5_min"]
+    res = read_json_design_list_from_file(designfile)
+    for d01name in ["best", "top5_max", "top5_mean", "top5_min"]
+        d01 = design01_matrix_from_R_list(res, d01name)
+        d = design_matrix_from_design01_matrix(pe, d01)
+        pvs = parameter_values_from_design_matrix(pe, d)
+        print(d01name, ": ", pvs)
+    end
+    perm = sortperm(res["sa_mean_1st_order_sens_indices"], rev=true)
+    println("Sensitivity analysis, decreasing main effects: ", pe.parameters[perm])
+    perm = sortperm(res["sa_mean_total_sens_indices"], rev=true)
+    println("Sensitivity analysis, decreasing total effects: ", pe.parameters[perm])
+end
+
+function run_based_on_design_matrix_in_file_while_saving_results_to_csvfile(
+        runfunc,
+        problem, pe::ParameterExperiment, outfilepath;
+        designfile = "new_runs.json", d01name = "best", num_repeats = 5,
+        fixed_params = {:max_evals_per_dim => 1e7,
+                        :utilitiesFunc => log_utilities}
+)
+    if !isfile(outfilepath)
+        write_csv_header_to_file(pe, outfilepath)
+    end
+
+    res = read_json_design_list_from_file(designfile)
     d01 = design01_matrix_from_R_list(res, d01name)
     d = design_matrix_from_design01_matrix(pe, d01)
     pvs = parameter_values_from_design_matrix(pe, d)
-    print(d01name, ": ", pvs)
-  end
-  perm = sortperm(res["sa_mean_1st_order_sens_indices"], rev=true)
-  println("Sensitivity analysis, decreasing main effects: ", pe.parameters[perm])
-  perm = sortperm(res["sa_mean_total_sens_indices"], rev=true)
-  println("Sensitivity analysis, decreasing total effects: ", pe.parameters[perm])
-end
 
-function run_based_on_design_matrix_in_file_while_saving_results_to_csvfile(runfunc,
-  problem, pe::ParameterExperiment, outfilepath;
-  designfile = "new_runs.json", d01name = "best", num_repeats = 5,
-  fixed_params = {:max_evals_per_dim => 1e7,
-    :utilitiesFunc => log_utilities})
+    for i in 1:length(pvs)
+        param_dict = pvs[i]
+        # Add other arguments.
+        param_dict = chain(param_dict, fixed_params)
+        print("params: "); show(param_dict); println("")
 
-  if !isfile(outfilepath)
-    write_csv_header_to_file(pe, outfilepath)
-  end
+        # Set up for saving results
+        fbs = zeros(num_repeats)
+        nfs = zeros(num_repeats)
+        ets = zeros(num_repeats)
+        num_within_ftol = 0
 
-  res = read_json_design_list_from_file(designfile)
-  d01 = design01_matrix_from_R_list(res, d01name)
-  d = design_matrix_from_design01_matrix(pe, d01)
-  pvs = parameter_values_from_design_matrix(pe, d)
+        # Now run it while timing.
+        for k in 1:num_repeats
+            tic()
+            xb, fbs[k], nfs[k], r, a = runfunc(problem; collect(param_dict)...)
+            ets[k] = toq()
+            if r == "Within ftol"
+                num_within_ftol += 1
+            end
+        end
 
-  for i in 1:length(pvs)
-    param_dict = pvs[i]
-    # Add other arguments.
-    param_dict = chain(param_dict, fixed_params)
-    print("params: "); show(param_dict); println("")
-
-    # Set up for saving results
-    fbs = zeros(num_repeats)
-    nfs = zeros(num_repeats)
-    ets = zeros(num_repeats)
-    num_within_ftol = 0
-
-    # Now run it while timing.
-    for k in 1:num_repeats
-      tic()
-      xb, fbs[k], nfs[k], r, a = runfunc(problem; collect(param_dict)...)
-      ets[k] = toq()
-      if r == "Within ftol"
-        num_within_ftol += 1
-      end
+        # Save info to the csv file
+        fh = open(outfilepath, "a+")
+        print(fh, join(map( (dv) -> "$(dv)", d01[i,:]), ","))
+        for i in 1:numparams(pe)
+            pv = param_dict[symbol(pe.parameters[i])]
+            print(fh, ",$(pv)")
+        end
+        mf = median(fbs)
+        fmagnitude = BlackBoxOptim.magnitude_class(mf)[2]
+        println(fh, ",", median(fbs), ",", fmagnitude, ",", median(nfs), ",", median(ets), ",", num_within_ftol/num_repeats)
+        close(fh)
     end
-
-    # Save info to the csv file
-    fh = open(outfilepath, "a+")
-    print(fh, join(map( (dv) -> "$(dv)", d01[i,:]), ","))
-    for i in 1:numparams(pe)
-      pv = param_dict[symbol(pe.parameters[i])]
-      print(fh, ",$(pv)")
-    end
-    mf = median(fbs)
-    fmagnitude = BlackBoxOptim.magnitude_class(mf)[2]
-    println(fh, ",", median(fbs), ",", fmagnitude, ",", median(nfs), ",", median(ets), ",", num_within_ftol/num_repeats)
-    close(fh)
-  end
-
 end
 
 function run_with_parameters_from_json_file(pe::ParameterExperiment, designfile, searchfunc, problem;
-  outfile = "exp.csv", num_repeats = 1, path_to_R_dir = "../../R")
+    outfile = "exp.csv", num_repeats = 1, path_to_R_dir = "../../R")
 
-  if !isfile(outfile)
-    write_csv_header_to_file(pe, outfile)
-  end
+    if !isfile(outfile)
+        write_csv_header_to_file(pe, outfile)
+    end
 
-  run_based_on_design_matrix_in_file_while_saving_results_to_csvfile(searchfunc,
-    problem, pe, outfile; num_repeats = num_repeats, designfile = designfile)
-
+    run_based_on_design_matrix_in_file_while_saving_results_to_csvfile(searchfunc,
+        problem, pe, outfile; num_repeats = num_repeats, designfile = designfile)
 end
 
-function explore_parameters(pe::ParameterExperiment, searchfunc, problem;
-  experiment_prefix = "exp", num_repeats = 10,
-  path_to_R_dir = "../../R")
+function explore_parameters(
+        pe::ParameterExperiment, searchfunc, problem;
+        experiment_prefix = "exp", num_repeats = 10,
+        path_to_R_dir = "../../R"
+)
+    nps = numparams(pe)
+    experiment_name = join([experiment_prefix, name(problem), numdims(problem),
+            nps, "params"], "_")
 
-  nps = numparams(pe)
-  experiment_name = join([experiment_prefix, name(problem), numdims(problem),
-    nps, "params"], "_")
+    outfile = join([experiment_name, ".csv"])
+    designfile = join(["new_runs_for_", experiment_name, ".csv"])
 
-  outfile = join([experiment_name, ".csv"])
-  designfile = join(["new_runs_for_", experiment_name, ".csv"])
+    write_csv_header_to_file(pe, outfile)
 
-  write_csv_header_to_file(pe, outfile)
+    index_fitness = 2*nps+1
+    index_magnitude = 2*nps+2
+    index_fevals = 2*nps+3
+    index_time = 2*nps+4
+    index_success_rate = 2*nps+5
 
-  index_fitness = 2*nps+1
-  index_magnitude = 2*nps+2
-  index_fevals = 2*nps+3
-  index_time = 2*nps+4
-  index_success_rate = 2*nps+5
-
-  # First run nps+1 times with a random LHS sample of points. Before we have
-  # that number of points we cannot run the GP regressions.
-  run(`/usr/bin/Rscript $(path_to_R_dir)/parameter_experiment.R $(nps) $(nps+1) $(index_fitness) $(nps) $(outfile) $(designfile)`)
-  run_based_on_design_matrix_in_file_while_saving_results_to_csvfile(searchfunc,
-    problem, pe, outfile; num_repeats = num_repeats, designfile = designfile)
-
-  # Now run new points, each selected by ALC and optimizing fitness magnitude,
-  # until we have gathered 30 points in total.
-  for i in 1:(30-nps-1)
-    run(`/usr/bin/Rscript $(path_to_R_dir)/parameter_experiment.R $(nps) 1 $(index_magnitude) $(nps) $(outfile) $(designfile) not alc`)
+    # First run nps+1 times with a random LHS sample of points. Before we have
+    # that number of points we cannot run the GP regressions.
+    run(`/usr/bin/Rscript $(path_to_R_dir)/parameter_experiment.R $(nps) $(nps+1) $(index_fitness) $(nps) $(outfile) $(designfile)`)
     run_based_on_design_matrix_in_file_while_saving_results_to_csvfile(searchfunc,
-      problem, pe, outfile; num_repeats = num_repeats, designfile = designfile)
-  end
+            problem, pe, outfile; num_repeats = num_repeats, designfile = designfile)
 
-  # Now run 20 new points that minimize fitness and select by alc.
-  for i in 1:20
-    run(`/usr/bin/Rscript $(path_to_R_dir)/parameter_experiment.R $(nps) 1 $(index_fitness) $(nps) $(outfile) $(designfile) not alc`)
-    run_based_on_design_matrix_in_file_while_saving_results_to_csvfile(searchfunc,
-      problem, pe, outfile; num_repeats = num_repeats, designfile = designfile)
-  end
+    # Now run new points, each selected by ALC and optimizing fitness magnitude,
+    # until we have gathered 30 points in total.
+    for i in 1:(30-nps-1)
+        run(`/usr/bin/Rscript $(path_to_R_dir)/parameter_experiment.R $(nps) 1 $(index_magnitude) $(nps) $(outfile) $(designfile) not alc`)
+        run_based_on_design_matrix_in_file_while_saving_results_to_csvfile(searchfunc,
+                problem, pe, outfile; num_repeats = num_repeats, designfile = designfile)
+    end
 
-  # Now run 10 new points that minimize fitness magnitude and select greedily to minimize execution time.
-  for i in 1:10
-    run(`/usr/bin/Rscript $(path_to_R_dir)/parameter_experiment.R $(nps) 1 $(index_magnitude) $(nps) $(outfile) $(designfile) not min`)
-    run_based_on_design_matrix_in_file_while_saving_results_to_csvfile(searchfunc,
-      problem, pe, outfile; num_repeats = num_repeats, designfile = designfile)
-  end
+    # Now run 20 new points that minimize fitness and select by alc.
+    for i in 1:20
+        run(`/usr/bin/Rscript $(path_to_R_dir)/parameter_experiment.R $(nps) 1 $(index_fitness) $(nps) $(outfile) $(designfile) not alc`)
+        run_based_on_design_matrix_in_file_while_saving_results_to_csvfile(searchfunc,
+                problem, pe, outfile; num_repeats = num_repeats, designfile = designfile)
+    end
 
-  # Now run 10 new points that minimize fitness magnitude and select greedily to
-  # minimize and be quick.
-  for i in 1:10
-    run(`/usr/bin/Rscript $(path_to_R_dir)/parameter_experiment.R $(nps) 1 $(index_magnitude) $(nps) $(outfile) $(designfile) not min`)
-    run_based_on_design_matrix_in_file_while_saving_results_to_csvfile(searchfunc,
-      problem, pe, outfile; num_repeats = num_repeats, designfile = designfile)
-  end
+    # Now run 10 new points that minimize fitness magnitude and select greedily to minimize execution time.
+    for i in 1:10
+        run(`/usr/bin/Rscript $(path_to_R_dir)/parameter_experiment.R $(nps) 1 $(index_magnitude) $(nps) $(outfile) $(designfile) not min`)
+        run_based_on_design_matrix_in_file_while_saving_results_to_csvfile(searchfunc,
+                problem, pe, outfile; num_repeats = num_repeats, designfile = designfile)
+    end
 
-  # Now run 10 new points that maximize success rate and select greedily to
-  # minimize and be quick. I missed the negative sign on the first runs so skip
-  # those runs.
-  for i in 1:10
-    run(`/usr/bin/Rscript $(path_to_R_dir)/parameter_experiment.R $(nps) 1 -$(index_success_rate) $(nps) $(outfile) $(designfile) not minquick`)
-    run_based_on_design_matrix_in_file_while_saving_results_to_csvfile(searchfunc,
-      problem, pe, outfile; num_repeats = num_repeats, designfile = designfile)
-  end
+    # Now run 10 new points that minimize fitness magnitude and select greedily to
+    # minimize and be quick.
+    for i in 1:10
+        run(`/usr/bin/Rscript $(path_to_R_dir)/parameter_experiment.R $(nps) 1 $(index_magnitude) $(nps) $(outfile) $(designfile) not min`)
+        run_based_on_design_matrix_in_file_while_saving_results_to_csvfile(searchfunc,
+                problem, pe, outfile; num_repeats = num_repeats, designfile = designfile)
+    end
 
+    # Now run 10 new points that maximize success rate and select greedily to
+    # minimize and be quick. I missed the negative sign on the first runs so skip
+    # those runs.
+    for i in 1:10
+        run(`/usr/bin/Rscript $(path_to_R_dir)/parameter_experiment.R $(nps) 1 -$(index_success_rate) $(nps) $(outfile) $(designfile) not minquick`)
+        run_based_on_design_matrix_in_file_while_saving_results_to_csvfile(searchfunc,
+                problem, pe, outfile; num_repeats = num_repeats, designfile = designfile)
+    end
 end

--- a/src/experiments/parameter_experiment.jl
+++ b/src/experiments/parameter_experiment.jl
@@ -1,6 +1,6 @@
 using JSON
 
-type ParameterExperiment
+struct ParameterExperiment
     parameters::Vector{String}               # Parameter names
     mappers::Vector{Function}                     # One function per param mapping a design value to a param value
     design_ranges::Vector{Tuple{Float64, Float64}}# Design range per parameter

--- a/src/experiments/parameter_tuning_bonesa.jl
+++ b/src/experiments/parameter_tuning_bonesa.jl
@@ -1,7 +1,9 @@
-# A BonesaTuner has state for optimizing a certain algorithm on a set of
-# parameters described by a ParameterSet. The parameter vectors that are tuned
-# only take values in [0.0, 1.0] and it is up to the ParameterSet to translate
-# that to meaningful ranges.
+"""
+A `BonesaTuner` has state for optimizing a certain algorithm on a set of
+parameters described by a ParameterSet. The parameter vectors that are tuned
+only take values in [0.0, 1.0] and it is up to the ParameterSet to translate
+that to meaningful ranges.
+"""
 type BonesaTuner
   numvectors::Int                     # Current num of param vectors in archive
   parameter_vectors::Matrix{Float64}  # Archive of param vectors, each column is one vector

--- a/src/experiments/parameter_tuning_bonesa.jl
+++ b/src/experiments/parameter_tuning_bonesa.jl
@@ -4,7 +4,7 @@ parameters described by a ParameterSet. The parameter vectors that are tuned
 only take values in [0.0, 1.0] and it is up to the ParameterSet to translate
 that to meaningful ranges.
 """
-type BonesaTuner
+struct BonesaTuner
     numvectors::Int                     # Current num of param vectors in archive
     parameter_vectors::Matrix{Float64}  # Archive of param vectors, each column is one vector
     utilities::Matrix{Float64}          # Each column has Nu * Np utility values for one and the same parameter vector

--- a/src/experiments/parameter_tuning_bonesa.jl
+++ b/src/experiments/parameter_tuning_bonesa.jl
@@ -5,10 +5,10 @@ only take values in [0.0, 1.0] and it is up to the ParameterSet to translate
 that to meaningful ranges.
 """
 type BonesaTuner
-  numvectors::Int                     # Current num of param vectors in archive
-  parameter_vectors::Matrix{Float64}  # Archive of param vectors, each column is one vector
-  utilities::Matrix{Float64}          # Each column has Nu * Np utility values for one and the same parameter vector
-  num_utility_values
+    numvectors::Int                     # Current num of param vectors in archive
+    parameter_vectors::Matrix{Float64}  # Archive of param vectors, each column is one vector
+    utilities::Matrix{Float64}          # Each column has Nu * Np utility values for one and the same parameter vector
+    num_utility_values
 end
 
 # The predicted utility of a parameter vector x on problem is a weigthed, kernel
@@ -17,113 +17,109 @@ function predicted_utility(ba::BonesaArchive, x, problem)
 end
 
 function time_is_up(bt::BonesaTuner)
-  time() - bt.start_time >= bt.max_time_seconds
+    time() - bt.start_time >= bt.max_time_seconds
 end
 
 # Start tuning parameters given a maximum time budget in hours.
 function tune_parameters(bt::BonesaTuner, max_hours = 1.0)
-  # Set up for measuring time left.
-  bt.start_time = time()
-  bt.max_time_seconds = max_hours * 60.0 * 60.0
+    # Set up for measuring time left.
+    bt.start_time = time()
+    bt.max_time_seconds = max_hours * 60.0 * 60.0
 
-  # Create a random set of vectors and then evaluate them on the problem set.
-  create_random_parameter_vectors(bt, bt.M)
-  bt.utilities = zeros(num_utilities(bt) * num_problems(bt.problem_set), bt.M)
-  for i in 1:num_param_vectors(bt)
-    if time_is_up(bt)
-      # Cut the size of the archive since we did not have time to eval them all... :(
-      bt.parameter_vectors = bt.parameter_vectors[:,1:(i-1)]
-      bt.utilities = bt.utilities[:,1:(i-1)]
-      break
+    # Create a random set of vectors and then evaluate them on the problem set.
+    create_random_parameter_vectors(bt, bt.M)
+    bt.utilities = zeros(num_utilities(bt) * num_problems(bt.problem_set), bt.M)
+    for i in 1:num_param_vectors(bt)
+        if time_is_up(bt)
+            # Cut the size of the archive since we did not have time to eval them all... :(
+            bt.parameter_vectors = bt.parameter_vectors[:,1:(i-1)]
+            bt.utilities = bt.utilities[:,1:(i-1)]
+            break
+        end
+        bt.utilities[:, i] = evaluate_param_vector(bt, bt.parameter_vectors[:,i])
     end
-    bt.utilities[:, i] = evaluate_param_vector(bt, bt.parameter_vectors[:,i])
-  end
 
-  # Iteratively add to archive as we learn more about which param vectors are good.
-  while( !time_is_up(bt) )
+    # Iteratively add to archive as we learn more about which param vectors are good.
+    while( !time_is_up(bt) )
+        # Update constants and temp calcs needed to calc pareto strenght below
+    end
 
-    # Update constants and temp calcs needed to calc pareto strenght below
-
-  end
-
-  # Select the terminal set (pareto front) of the param vectors.
-
+    # Select the terminal set (pareto front) of the param vectors.
 end
 
 # Calc predicted utilities, variance and support as well as pareto dominance
 # and strengths for all param vectors in the archive.
 function calc_temp_values_for_archive(bt::BonesaTuner)
-  # Update magic constant c based on size of archive
-  bt.c = calc_approximate_magic_constant_c(size_of_archive(bt), numdims(bt))
+    # Update magic constant c based on size of archive
+    bt.c = calc_approximate_magic_constant_c(size_of_archive(bt), numdims(bt))
 
-  # Calc the good vectors (saved as (boolean) indicator values)
-  mean_actual_utilities = mean(bt.utilities, 2) # Mean per row => mean for each utility value
+    # Calc the good vectors (saved as (boolean) indicator values)
+    mean_actual_utilities = mean(bt.utilities, 2) # Mean per row => mean for each utility value
 end
 
 function support_of_vector(bt::BonesaTuner, pvector)
-
 end
 
 # For now we use random sampling but use lhs here instead, long-term.
 function create_random_parameter_vectors(bt::BonesaTuner, num_vectors)
-  bt.parameter_vectors = rand(num_params(bt), num_vectors)
+    bt.parameter_vectors = rand(num_params(bt), num_vectors)
 end
 
 function num_utility_values(bt::BonesaTuner)
-  if bt.num_utility_values == false
-    # Evaluate a param vector once to know how many utility values are returned.
-    res = evaluate_param_vector_on_problem(bt, bt.problem_set[1], rand(num_params(bt)))
-    bt.num_utility_values = length(res) + 1 # Add one for time
-  else
-    bt.num_utility_values
-  end
+    if bt.num_utility_values == false
+        # Evaluate a param vector once to know how many utility values are returned.
+        res = evaluate_param_vector_on_problem(bt, bt.problem_set[1], rand(num_params(bt)))
+        bt.num_utility_values = length(res) + 1 # Add one for time
+    else
+        bt.num_utility_values
+    end
 end
 
 function evaluate_param_vector(bt, pvector)
-  parameters = map_to_parameter_values(bt.parameter_set, pvector)
-  nu = num_utility_values(bt)
-  np = num_problems(bt.problem_set)
-  utilities = zeros(np*nu)
+    parameters = map_to_parameter_values(bt.parameter_set, pvector)
+    nu = num_utility_values(bt)
+    np = num_problems(bt.problem_set)
+    utilities = zeros(np*nu)
 
-  for i in 1:np
-    p = bt.problem_set[i]
-    start = 1 + (i-1) * nu
-    tic()
-    utilities[ustart:(ustart+nu-2)] = evaluate_param_vector_on_problem(bt, p, parameters)
-    utilities[ustart+nu-1] = toq()
-  end
+    for i in 1:np
+        p = bt.problem_set[i]
+        start = 1 + (i-1) * nu
+        tic()
+        utilities[ustart:(ustart+nu-2)] = evaluate_param_vector_on_problem(bt, p, parameters)
+        utilities[ustart+nu-1] = toq()
+    end
 
-  utilities
+    return utilities
 end
 
 # Find an approximation to the BONESA magic constant c. It is the value
 # that makes sum(w) == 50, where w is exp(c * normalized_distance(x, y)) for
 # m uniformly, randomly sampled on the l-dimensional hypercube.
 function calc_approximate_magic_constant_c(m, l, num_repeats = 5, tolerance = 1e-3)
-  # Do a number of random approximations and then average
-  mean([find_approximate_c_given_random_sample_of_points(m, l, tolerance) for i in 1:num_repeats])
+    # Do a number of random approximations and then average
+    mean([find_approximate_c_given_random_sample_of_points(m, l, tolerance) for i in 1:num_repeats])
 end
 
 function find_approximate_c_given_random_sample_of_points(m, l, tolerance = 1e-3)
-  # Randomly sample m l-dimensional points
-  points = rand(l, m)
+    # Randomly sample m l-dimensional points
+    points = rand(l, m)
 
-  # To calc the distances we need the std dev per dimension
-  std_devs = std(points, 2)
+    # To calc the distances we need the std dev per dimension
+    std_devs = std(points, 2)
 
-  # Now calc the distances between points. We only sample them if m is large.
-  distances = zeros(Float64, m, m)
-  for i in 1:m
-    x = points[:,i]
-    for j in i:m
-      y = points[:,j]
-      distances[i, j] = distances[i, j] = std_distance(x, y, std_devs)
+    # Now calc the distances between points. We only sample them if m is large.
+    distances = zeros(Float64, m, m)
+    for i in 1:m
+        x = points[:,i]
+        for j in i:m
+            y = points[:,j]
+            distances[i, j] = distances[i, j] = std_distance(x, y, std_devs)
+        end
     end
-  end
 
-  # Find a value of c by using bisection so that we are close to 50.0
-  f = (c) -> average_sum_of_distances_for_c(c, distances) - 50.0
-  bisection(f, -100.0, 100.0, tolerance)
+    # Find a value of c by using bisection so that we are close to 50.0
+    f = (c) -> average_sum_of_distances_for_c(c, distances) - 50.0
+    bisection(f, -100.0, 100.0, tolerance)
 end
 
 # Find a value v that makes abs(f(v)) <= tolerance where a and b are guesses
@@ -131,47 +127,47 @@ end
 # (or positive) value of the function by stepping down (or up) => will not
 # work for any function but throws an ArgumentError after many iterations of trying.
 function bisection(f, a, b = 2*a, tolerance = 1e-5, max_iterations = 1e4)
-  if f(a) > 0 && f(b) > 0
-    a = step_value_until_changes_sign(f, a, -1.0, max_iterations, max_iterations)
-  elseif f(a) < 0 && f(b) < 0
-    b = step_value_until_changes_sign(f, b, 1.0, max_iterations, max_iterations)
-  end
+    if f(a) > 0 && f(b) > 0
+        a = step_value_until_changes_sign(f, a, -1.0, max_iterations, max_iterations)
+    elseif f(a) < 0 && f(b) < 0
+        b = step_value_until_changes_sign(f, b, 1.0, max_iterations, max_iterations)
+    end
 
-  p = (a + b)/2
-  error = abs(f(p))
-  iterations = 0
-  while iterations < max_iterations && error > tolerance
-    iterations += 1
-    (f(a)*f(p) < 0) ? (b = p) : (a = p)
     p = (a + b)/2
     error = abs(f(p))
-  end
-  if iterations >= max_iterations
-    throw(ArgumentError("Could not find a good approximation after $(iterations) iterations."))
-  else
-    return p
-  end
+    iterations = 0
+    while iterations < max_iterations && error > tolerance
+        iterations += 1
+        (f(a)*f(p) < 0) ? (b = p) : (a = p)
+        p = (a + b)/2
+        error = abs(f(p))
+    end
+    if iterations >= max_iterations
+        throw(ArgumentError("Could not find a good approximation after $(iterations) iterations."))
+    else
+        return p
+    end
 end
 
 function step_value_until_changes_sign(func, value::Float64, step_size::Float64 = 1.0, max_iterations = 1e3)
-  wanted_sign = -1 * sign(func(value))
-  iterations = 0
-  while iterations < max_iterations && sign(func(value)) != wanted_sign
-    iterations += 1
-    value = value + step_size
-    step_size *= 2
-  end
-  if iterations >= max_iterations
-    throw(ArgumentError("Could not invert the sign after $(iterations) iterations."))
-  else
-    return value
-  end
+    wanted_sign = -1 * sign(func(value))
+    iterations = 0
+    while iterations < max_iterations && sign(func(value)) != wanted_sign
+        iterations += 1
+        value = value + step_size
+        step_size *= 2
+    end
+    if iterations >= max_iterations
+        throw(ArgumentError("Could not invert the sign after $(iterations) iterations."))
+    else
+        return value
+    end
 end
 
 function average_sum_of_distances_for_c(c, distances)
-  mean( exp(c * collect(triu(distances))) )
+    mean( exp(c * collect(triu(distances))) )
 end
 
 function std_distance(x, y, std_devs)
-  sqrt(1/l * sum(((x .- y) ./ std_devs).^2))
+    sqrt(1/l * sum(((x .- y) ./ std_devs).^2))
 end

--- a/src/fit_individual.jl
+++ b/src/fit_individual.jl
@@ -27,7 +27,7 @@ Candidate can be either a member of the population (`index` > 0) or
 a standalone solution (`index` == -1).
 Can carry additional information, like the `tag` or the genetic operator applied (`extra`).
 """
-type Candidate{F} <: FitIndividual{F}
+mutable struct Candidate{F} <: FitIndividual{F}
     params::Individual
     index::Int          # index of individual in the population, -1 if unassigned
     fitness::F          # fitness

--- a/src/fit_individual.jl
+++ b/src/fit_individual.jl
@@ -53,7 +53,7 @@ tag(cand::Candidate) = cand.tag
 
 Base.copy(c::Candidate) = Candidate(copy(c.params), c.index, c.fitness, c.extra, c.tag)
 
-function Base.copy!{F}(c::Candidate{F}, o::Candidate{F})
+function Base.copy!(c::Candidate{F}, o::Candidate{F}) where F
     copy!(c.params, o.params)
     c.index = o.index
     c.fitness = o.fitness # FIXME if vector?

--- a/src/fit_individual.jl
+++ b/src/fit_individual.jl
@@ -4,7 +4,7 @@
 
   `F` is the original problem's fitness type
 """
-@compat abstract type FitIndividual{F} end
+abstract type FitIndividual{F} end
 
 fitness_type{F}(indi::FitIndividual{F}) = F
 

--- a/src/fit_individual.jl
+++ b/src/fit_individual.jl
@@ -35,17 +35,16 @@ mutable struct Candidate{F} <: FitIndividual{F}
     extra::Any          # extra information
     tag::Int            # additional information set by the genetic operator
 
-    Candidate(params::Individual, index::Int = -1,
-             fitness::F = NaN,
-             extra::Any = Void,
-             tag::Int = 0) =
+    Candidate{F}(params::Individual, index::Int = -1,
+                 fitness::F = NaN,
+                 extra::Any = nothing,
+                 tag::Int = 0) where {F} =
         new(params, index, fitness, extra, tag)
 
-    (::Type{Candidate}){F}(
-            params::Individual, index::Int = -1,
-            fitness::F = NaN,
-            extra::Any = Void,
-            tag::Int = 0) =
+    Candidate(params::Individual, index::Int = -1,
+              fitness::F = NaN,
+              extra::Any = nothing,
+              tag::Int = 0) where {F} =
         new{F}(params, index, fitness, extra, tag)
 end
 

--- a/src/fit_individual.jl
+++ b/src/fit_individual.jl
@@ -1,31 +1,31 @@
 """
-    A point in the problem's search space with the
-    corresponding fitness value.
+A point in the problem's search space with the
+corresponding fitness value.
 
-  `F` is the original problem's fitness type
+`F` is the original problem's fitness type
 """
 abstract type FitIndividual{F} end
 
 fitness_type{F}(indi::FitIndividual{F}) = F
 
 """
-    Get the problem parameters (a point in the search space) of the individual.
+Get the problem parameters (a point in the search space) of the individual.
 """
 params(indi::FitIndividual) = indi.params
 
 """
     fitness(indi::FitIndividual)
 
-    Gets the fitness of the individual.
+Gets the fitness of the individual.
 """
 fitness(indi::FitIndividual) = indi.fitness
 
 """
-  Candidate solution to the problem.
+Candidate solution to the problem.
 
-  Candidate can be either a member of the population (`index` > 0) or
-  a standalone solution (`index` == -1).
-  Can carry additional information, like the `tag` or the genetic operator applied (`extra`).
+Candidate can be either a member of the population (`index` > 0) or
+a standalone solution (`index` == -1).
+Can carry additional information, like the `tag` or the genetic operator applied (`extra`).
 """
 type Candidate{F} <: FitIndividual{F}
     params::Individual

--- a/src/fitness.jl
+++ b/src/fitness.jl
@@ -17,15 +17,14 @@ abstract type FitnessScheme{F} end
 
 Get the type of fitness values for fitness scheme `fs`.
 """
-fitness_type{F}(::Type{FitnessScheme{F}}) = F
-fitness_type{F}(::FitnessScheme{F}) = F
-fitness_type{FS<:FitnessScheme}(::Type{FS}) = fitness_type(supertype(FS))
-fitness_eltype{F<:Number}(::Type{FitnessScheme{F}}) = F
-fitness_eltype{F<:Number}(::FitnessScheme{F}) = F
-#fitness_type{FS<:FitnessScheme}(::FS) = fitness_type(FS)
+fitness_type(::Type{FitnessScheme{F}}) where F = F
+fitness_type(::FitnessScheme{F}) where F = F
+fitness_type(::Type{FS}) where {FS<:FitnessScheme} = fitness_type(supertype(FS))
+fitness_eltype(::Type{FitnessScheme{F}}) where {F<:Number} = F
+fitness_eltype(::FitnessScheme{F}) where {F<:Number} = F
 
 # trivial convert() between calculated and archived fitness
-Base.convert{F}(::Type{F}, fit::F, fit_scheme::FitnessScheme{F}) = fit
+Base.convert(::Type{F}, fit::F, fit_scheme::FitnessScheme{F}) where F = fit
 
 # ordering induced by the fitness scheme
 # FIXME enable once v0.5 issue #14919 is fixed
@@ -50,16 +49,16 @@ end
 const MinimizingFitnessScheme = ScalarFitnessScheme{true}()
 const MaximizingFitnessScheme = ScalarFitnessScheme{false}()
 
-is_minimizing{MIN}(::ScalarFitnessScheme{MIN}) = MIN
-nafitness{F<:Number}(::Type{F}) = convert(F, NaN)
+is_minimizing(::ScalarFitnessScheme{MIN}) where {MIN} = MIN
+nafitness(::Type{F}) where {F<:Number} = convert(F, NaN)
 @inline nafitness(fs::FitnessScheme) = nafitness(fitness_type(fs))
-isnafitness{F<:Number}(f::F, ::RatioFitnessScheme{F}) = isnan(f)
-numobjectives{F<:Number}(::RatioFitnessScheme{F}) = 1
+isnafitness(f::F, ::RatioFitnessScheme{F}) where {F<:Number} = isnan(f)
+numobjectives(::RatioFitnessScheme{F}) where {F<:Number} = 1
 
 """
 Aggregation is just the identity function for scalar fitness.
 """
-aggregate{F<:Number}(fitness::F, ::RatioFitnessScheme{F}) = fitness
+aggregate(fitness::F, ::RatioFitnessScheme{F}) where {F<:Number} = fitness
 
 is_better(f1::Float64, f2::Float64, scheme::ScalarFitnessScheme{true}) = f1 < f2
 is_better(f1::Float64, f2::Float64, scheme::ScalarFitnessScheme{false}) = f1 > f2
@@ -104,4 +103,4 @@ struct HatCompare{FS<:FitnessScheme}
     HatCompare(fs::FS) where {FS<:FitnessScheme} = new{FS}(fs)
 end
 
-(hc::HatCompare){F}(x::F, y::F) = hat_compare(x, y, hc.fs)
+(hc::HatCompare)(x::F, y::F) where {F} = hat_compare(x, y, hc.fs)

--- a/src/fitness.jl
+++ b/src/fitness.jl
@@ -1,21 +1,21 @@
 """
-  `FitnessScheme` defines how fitness vectors/values are
-  compared, presented and aggregated.
-  `Fitness` represents the score of one and the same individual
-  on one or a set of evaluations. A scheme is a specific
-  way to consider the scores in a coherent way.
-  Type parameter `F` specifies the type of fitness values.
+`FitnessScheme` defines how fitness vectors/values are
+compared, presented and aggregated.
+`Fitness` represents the score of one and the same individual
+on one or a set of evaluations. A scheme is a specific
+way to consider the scores in a coherent way.
+Type parameter `F` specifies the type of fitness values.
 
-  `FitnessScheme` could also be used as a function that defines the fitness
-  ordering, i.e. `fs(x, y) == true` iff fitness `x` is better than `y`.
+`FitnessScheme` could also be used as a function that defines the fitness
+ordering, i.e. `fs(x, y) == true` iff fitness `x` is better than `y`.
 """
 abstract type FitnessScheme{F} end
 
 """
-  `fitness_type(fs::FitnessScheme)`
-  `fitness_type(fs_type::Type{FitnessScheme})`
+    fitness_type(fs::FitnessScheme)
+    fitness_type(fs_type::Type{FitnessScheme})
 
-  Get the type of fitness values for fitness scheme `fs`.
+Get the type of fitness values for fitness scheme `fs`.
 """
 fitness_type{F}(::Type{FitnessScheme{F}}) = F
 fitness_type{F}(::FitnessScheme{F}) = F
@@ -32,17 +32,17 @@ Base.convert{F}(::Type{F}, fit::F, fit_scheme::FitnessScheme{F}) = fit
 # (fs::FitnessScheme{F}){F}(x::F, y::F) = is_better(x, y, fs)
 
 """
-  In `RatioFitnessScheme` the fitness values can be ranked on a ratio scale so
-  pairwise comparisons are not required.
-  The default scale used is the aggregate of the fitness components.
+In `RatioFitnessScheme` the fitness values can be ranked on a ratio scale so
+pairwise comparisons are not required.
+The default scale used is the aggregate of the fitness components.
 """
 # FIXME
 abstract type RatioFitnessScheme{F} <: FitnessScheme{F} end
 
 """
-  `Float64`-valued scalar fitness scheme.
-  The boolean type parameter `MIN` specifies if smaller fitness values
-  are better (`true`) or worse (`false`).
+`Float64`-valued scalar fitness scheme.
+The boolean type parameter `MIN` specifies if smaller fitness values
+are better (`true`) or worse (`false`).
 """
 immutable ScalarFitnessScheme{MIN} <: RatioFitnessScheme{Float64}
 end
@@ -56,13 +56,17 @@ nafitness{F<:Number}(::Type{F}) = convert(F, NaN)
 isnafitness{F<:Number}(f::F, ::RatioFitnessScheme{F}) = isnan(f)
 numobjectives{F<:Number}(::RatioFitnessScheme{F}) = 1
 
-""" Aggregation is just the identity function for scalar fitness. """
+"""
+Aggregation is just the identity function for scalar fitness.
+"""
 aggregate{F<:Number}(fitness::F, ::RatioFitnessScheme{F}) = fitness
 
 is_better(f1::Float64, f2::Float64, scheme::ScalarFitnessScheme{true}) = f1 < f2
 is_better(f1::Float64, f2::Float64, scheme::ScalarFitnessScheme{false}) = f1 > f2
 
-""" Complex-valued fitness. """
+"""
+Complex-valued fitness.
+"""
 # FIXME what is isbetter() for ComplexFitnessScheme
 immutable ComplexFitnessScheme <: FitnessScheme{Complex128}
 end
@@ -74,11 +78,12 @@ best_fitness(fs::FitnessScheme) = -worst_fitness(fs)
 hat_compare(a1::Number, a2::Number) = (a1 < a2) ? -1 : ((a1 > a2) ? 1 : (isnan(a1) ? (isnan(a2) ? 0 : 1) : (isnan(a2) ? -1 : 0)))
 
 """
-  Check whether `f1` or `f2` fitness is better.
+Check whether `f1` or `f2` fitness is better.
 
-  Returns `-1` if `f1` is better than `f2`,
-          `1` if `f2` is better than `f1` and
-          `0` if they are equal.
+Returns
+  * `-1` if `f1` is better than `f2`
+  * `1` if `f2` is better than `f1`
+  * `0` if `f1` and `f2` are equal.
 """
 function hat_compare(f1, f2, s::RatioFitnessScheme)
   if is_minimizing(s)

--- a/src/fitness.jl
+++ b/src/fitness.jl
@@ -101,7 +101,7 @@ same_fitness(f1, f2, scheme::FitnessScheme) = hat_compare(f1, f2, scheme) == 0
 struct HatCompare{FS<:FitnessScheme}
     fs::FS
 
-    (::Type{HatCompare}){FS<:FitnessScheme}(fs::FS) = new{FS}(fs)
+    HatCompare(fs::FS) where {FS<:FitnessScheme} = new{FS}(fs)
 end
 
 (hc::HatCompare){F}(x::F, y::F) = hat_compare(x, y, hc.fs)

--- a/src/fitness.jl
+++ b/src/fitness.jl
@@ -44,7 +44,7 @@ abstract type RatioFitnessScheme{F} <: FitnessScheme{F} end
 The boolean type parameter `MIN` specifies if smaller fitness values
 are better (`true`) or worse (`false`).
 """
-immutable ScalarFitnessScheme{MIN} <: RatioFitnessScheme{Float64}
+struct ScalarFitnessScheme{MIN} <: RatioFitnessScheme{Float64}
 end
 
 const MinimizingFitnessScheme = ScalarFitnessScheme{true}()
@@ -68,7 +68,7 @@ is_better(f1::Float64, f2::Float64, scheme::ScalarFitnessScheme{false}) = f1 > f
 Complex-valued fitness.
 """
 # FIXME what is isbetter() for ComplexFitnessScheme
-immutable ComplexFitnessScheme <: FitnessScheme{Complex128}
+struct ComplexFitnessScheme <: FitnessScheme{Complex128}
 end
 
 # FIXME do we need it? it might be confused with problem's fitness bounds
@@ -98,7 +98,7 @@ is_better(f1, f2, scheme::FitnessScheme) = hat_compare(f1, f2, scheme) == -1
 is_worse(f1, f2, scheme::FitnessScheme) = hat_compare(f1, f2, scheme) == 1
 same_fitness(f1, f2, scheme::FitnessScheme) = hat_compare(f1, f2, scheme) == 0
 
-immutable HatCompare{FS<:FitnessScheme}
+struct HatCompare{FS<:FitnessScheme}
     fs::FS
 
     (::Type{HatCompare}){FS<:FitnessScheme}(fs::FS) = new{FS}(fs)

--- a/src/fitness.jl
+++ b/src/fitness.jl
@@ -9,7 +9,7 @@
   `FitnessScheme` could also be used as a function that defines the fitness
   ordering, i.e. `fs(x, y) == true` iff fitness `x` is better than `y`.
 """
-@compat abstract type FitnessScheme{F} end
+abstract type FitnessScheme{F} end
 
 """
   `fitness_type(fs::FitnessScheme)`
@@ -37,7 +37,7 @@ Base.convert{F}(::Type{F}, fit::F, fit_scheme::FitnessScheme{F}) = fit
   The default scale used is the aggregate of the fitness components.
 """
 # FIXME
-@compat abstract type RatioFitnessScheme{F} <: FitnessScheme{F} end
+abstract type RatioFitnessScheme{F} <: FitnessScheme{F} end
 
 """
   `Float64`-valued scalar fitness scheme.

--- a/src/fitness.jl
+++ b/src/fitness.jl
@@ -75,7 +75,8 @@ end
 worst_fitness(fs::FitnessScheme) = is_minimizing(fs) ? Inf : (-Inf)
 best_fitness(fs::FitnessScheme) = -worst_fitness(fs)
 
-hat_compare(a1::Number, a2::Number) = (a1 < a2) ? -1 : ((a1 > a2) ? 1 : (isnan(a1) ? (isnan(a2) ? 0 : 1) : (isnan(a2) ? -1 : 0)))
+hat_compare(a1::Number, a2::Number) =
+    (a1 < a2) ? -1 : ((a1 > a2) ? 1 : (isnan(a1) ? (isnan(a2) ? 0 : 1) : (isnan(a2) ? -1 : 0)))
 
 """
 Check whether `f1` or `f2` fitness is better.
@@ -86,11 +87,11 @@ Returns
   * `0` if `f1` and `f2` are equal.
 """
 function hat_compare(f1, f2, s::RatioFitnessScheme)
-  if is_minimizing(s)
-    hat_compare(aggregate(f1, s), aggregate(f2, s))
-  else
-    hat_compare(aggregate(f2, s), aggregate(f1, s))
-  end
+    if is_minimizing(s)
+        hat_compare(aggregate(f1, s), aggregate(f2, s))
+    else
+        hat_compare(aggregate(f2, s), aggregate(f1, s))
+    end
 end
 
 is_better(f1, f2, scheme::FitnessScheme) = hat_compare(f1, f2, scheme) == -1

--- a/src/fitness/epsilon_box_dominance.jl
+++ b/src/fitness/epsilon_box_dominance.jl
@@ -1,11 +1,11 @@
 # Returns two booleans where the first indicates e-box dominance and the 2nd indicates
 # epsilon progress
 function epsilon_box_dominates_and_epsilon_progress(u, v, epsilon)
-  uindex = floor(u ./ epsilon)
-  vindex = floor(v ./ epsilon)
-  inner_epsilon_box_dominates_and_epsilon_progress(
-    u, uindex, (epsilon .* uindex),
-    v, vindex, (epsilon .* vindex))
+    uindex = floor(u ./ epsilon)
+    vindex = floor(v ./ epsilon)
+    inner_epsilon_box_dominates_and_epsilon_progress(
+        u, uindex, (epsilon .* uindex),
+        v, vindex, (epsilon .* vindex))
 end
 
 # FIXME
@@ -17,16 +17,15 @@ epsilon_box_progress(u, v, epsilon) = epsilon_box_dominates_and_epsilon_progress
 # This is to speed up processing when there is a whole archive of solutions to compare
 # a new solution to.
 function inner_epsilon_box_dominates_and_epsilon_progress(
-  u, uindex, uindextimesepsilon,
-  v, vindex, vindextimesepsilon)
+    u, uindex, uindextimesepsilon,
+    v, vindex, vindextimesepsilon)
 
-  if pareto_dominates_fast(uindex, vindex)
-    return (true, true)
-  elseif all(uindex .== vindex)
-    smaller_distance = norm(u .- uindextimesepsilon) < norm(v .- vindextimesepsilon)
-    return (smaller_distance, false)
-  else
-    return (false, false)
-  end
-
+    if pareto_dominates_fast(uindex, vindex)
+        return (true, true)
+    elseif all(uindex .== vindex)
+        smaller_distance = norm(u .- uindextimesepsilon) < norm(v .- vindextimesepsilon)
+        return (smaller_distance, false)
+    else
+        return (false, false)
+    end
 end

--- a/src/fitness/epsilon_pareto_dominance.jl
+++ b/src/fitness/epsilon_pareto_dominance.jl
@@ -1,8 +1,6 @@
 function epsilon_dominates_clear(u, v, epsilon)
-  veps = v .+ epsilon
-  all(u .<= veps) && any(u .< veps)
+    veps = v .+ epsilon
+    all(u .<= veps) && any(u .< veps)
 end
 
-function epsilon_dominates_fast(u, v, epsilon)
-  pareto_dominates_fast(u, v .+ epsilon)
-end
+epsilon_dominates_fast(u, v, epsilon) = pareto_dominates_fast(u, v .+ epsilon)

--- a/src/fitness/fitness_types.jl
+++ b/src/fitness/fitness_types.jl
@@ -22,11 +22,11 @@ simulations(f::NewFitness) = characteristics(f)
 characteristics(f::NewFitness) = fitnessvalues(f)
 evaluator(f::NewFitness) = nothing
 
-type SingleNumberFitness{T <: Real} <: SingleObjectiveFitness
+struct SingleNumberFitness{T <: Real} <: SingleObjectiveFitness
     fvalue::T
 end
 
-type VectorFitness{T <: Real} <: MultiObjectiveFitness
+struct VectorFitness{T <: Real} <: MultiObjectiveFitness
     fvalues::Vector{T}
 end
 

--- a/src/fitness/fitness_types.jl
+++ b/src/fitness/fitness_types.jl
@@ -30,8 +30,8 @@ struct VectorFitness{T <: Real} <: MultiObjectiveFitness
     fvalues::Vector{T}
 end
 
-makefitness{T <: Real}(fvalue::T) = SingleNumberFitness(fvalue)
-makefitness{T <: Real}(fvalues::Vector{T}) = VectorFitness(fvalues)
+makefitness(fvalue::T) where {T <: Real} = SingleNumberFitness(fvalue)
+makefitness(fvalues::Vector{T}) where {T <: Real} = VectorFitness(fvalues)
 
-fitnessvalues{T <: Real}(f::VectorFitness{T}) = f.fvalues
-fitnessvalues{T <: Real}(f::SingleNumberFitness{T}) = [f.fvalue]
+fitnessvalues(f::VectorFitness{T}) where {T <: Real} = f.fvalues
+fitnessvalues(f::SingleNumberFitness{T}) where {T <: Real} = [f.fvalue]

--- a/src/fitness/fitness_types.jl
+++ b/src/fitness/fitness_types.jl
@@ -23,11 +23,11 @@ characteristics(f::NewFitness) = fitnessvalues(f)
 evaluator(f::NewFitness) = nothing
 
 type SingleNumberFitness{T <: Real} <: SingleObjectiveFitness
-  fvalue::T
+    fvalue::T
 end
 
 type VectorFitness{T <: Real} <: MultiObjectiveFitness
-  fvalues::Vector{T}
+    fvalues::Vector{T}
 end
 
 makefitness{T <: Real}(fvalue::T) = SingleNumberFitness(fvalue)

--- a/src/fitness/fitness_types.jl
+++ b/src/fitness/fitness_types.jl
@@ -1,8 +1,8 @@
-@compat abstract type NewFitness end
+abstract type NewFitness end
 
-@compat abstract type SingleObjectiveFitness <: NewFitness end
+abstract type SingleObjectiveFitness <: NewFitness end
 
-@compat abstract type MultiObjectiveFitness <: NewFitness end
+abstract type MultiObjectiveFitness <: NewFitness end
 
 # Some evaluators go through several stages of fitness evaluation:
 #   1. a candidate is simulated -> *simulation(s)*

--- a/src/fitness/pareto_dominance.jl
+++ b/src/fitness/pareto_dominance.jl
@@ -1,7 +1,7 @@
-pareto_dominates_clear{T <: Real}(u::Vector{T}, v::Vector{T}) =
+pareto_dominates_clear(u::Vector{T}, v::Vector{T}) where {T <: Real} =
     all(u .<= v) && any(u .< v)
 
-function pareto_dominates_fast{T <: Real}(u::Vector{T}, v::Vector{T})
+function pareto_dominates_fast(u::Vector{T}, v::Vector{T}) where {T <: Real}
     one_smaller = false
     @inbounds for i in eachindex(u)
         if u[i] > v[i]
@@ -13,10 +13,10 @@ function pareto_dominates_fast{T <: Real}(u::Vector{T}, v::Vector{T})
     return one_smaller
 end
 
-pareto_dominates{T <: Real}(v1::Vector{T}, v2::Vector{T}) =
+pareto_dominates(v1::Vector{T}, v2::Vector{T}) where {T <: Real} =
     pareto_dominates_fast(v1, v2)
 
-function pareto_dominates_hat{T <: Real}(u::Vector{T}, v::Vector{T})
+function pareto_dominates_hat(u::Vector{T}, v::Vector{T}) where {T <: Real}
     one_larger = one_smaller = false
     @inbounds for i in eachindex(u)
         if u[i] > v[i]
@@ -32,7 +32,7 @@ function pareto_dominates_hat{T <: Real}(u::Vector{T}, v::Vector{T})
     end
 end
 
-pareto_dominates{T <: Real}(v1::Vector{T}, v2::Vector{T}) =
+pareto_dominates(v1::Vector{T}, v2::Vector{T}) where {T <: Real} =
     pareto_dominates_fast(v1, v2)
 
 # FIXME

--- a/src/fitness/pareto_dominance.jl
+++ b/src/fitness/pareto_dominance.jl
@@ -1,36 +1,40 @@
-pareto_dominates_clear{T <: Real}(u::Vector{T}, v::Vector{T}) = all(u .<= v) && any(u .< v)
+pareto_dominates_clear{T <: Real}(u::Vector{T}, v::Vector{T}) =
+    all(u .<= v) && any(u .< v)
 
 function pareto_dominates_fast{T <: Real}(u::Vector{T}, v::Vector{T})
-  one_smaller = false
-  @inbounds for i in eachindex(u)
-    if u[i] > v[i]
-      return false
-    elseif u[i] < v[i]
-      one_smaller = true
+    one_smaller = false
+    @inbounds for i in eachindex(u)
+        if u[i] > v[i]
+            return false
+        elseif u[i] < v[i]
+            one_smaller = true
+        end
     end
-  end
-  return one_smaller
+    return one_smaller
 end
 
-pareto_dominates{T <: Real}(v1::Vector{T}, v2::Vector{T}) = pareto_dominates_fast(v1, v2)
+pareto_dominates{T <: Real}(v1::Vector{T}, v2::Vector{T}) =
+    pareto_dominates_fast(v1, v2)
 
 function pareto_dominates_hat{T <: Real}(u::Vector{T}, v::Vector{T})
-  one_larger = one_smaller = false
-  @inbounds for i in eachindex(u)
-    if u[i] > v[i]
-      one_larger = true
-    elseif u[i] < v[i]
-      one_smaller = true
+    one_larger = one_smaller = false
+    @inbounds for i in eachindex(u)
+        if u[i] > v[i]
+            one_larger = true
+        elseif u[i] < v[i]
+            one_smaller = true
+        end
     end
-  end
-  if one_larger
-    return (one_smaller ? 0 : 1)
-  else
-    return (one_smaller ? -1 : 0)
-  end
+    if one_larger
+        return (one_smaller ? 0 : 1)
+    else
+        return (one_smaller ? -1 : 0)
+    end
 end
 
-pareto_dominates{T <: Real}(v1::Vector{T}, v2::Vector{T}) = pareto_dominates_fast(v1, v2)
+pareto_dominates{T <: Real}(v1::Vector{T}, v2::Vector{T}) =
+    pareto_dominates_fast(v1, v2)
 
 # FIXME
-pareto_dominates(f1::NewFitness, f2::NewFitness) = pareto_dominates(fitnessvalues(f1), fitnessvalues(f2))
+pareto_dominates(f1::NewFitness, f2::NewFitness) =
+    pareto_dominates(fitnessvalues(f1), fitnessvalues(f2))

--- a/src/fitness/pareto_dominance.jl
+++ b/src/fitness/pareto_dominance.jl
@@ -2,33 +2,33 @@ pareto_dominates_clear(u::Vector{T}, v::Vector{T}) where {T <: Real} =
     all(u .<= v) && any(u .< v)
 
 function pareto_dominates_fast(u::Vector{T}, v::Vector{T}) where {T <: Real}
-    one_smaller = false
+    anylt = false
     @inbounds for i in eachindex(u)
         if u[i] > v[i]
             return false
         elseif u[i] < v[i]
-            one_smaller = true
+            anylt = true
         end
     end
-    return one_smaller
+    return anylt
 end
 
 pareto_dominates(v1::Vector{T}, v2::Vector{T}) where {T <: Real} =
     pareto_dominates_fast(v1, v2)
 
 function pareto_dominates_hat(u::Vector{T}, v::Vector{T}) where {T <: Real}
-    one_larger = one_smaller = false
+    anygt = anylt = false
     @inbounds for i in eachindex(u)
         if u[i] > v[i]
-            one_larger = true
+            anygt = true
         elseif u[i] < v[i]
-            one_smaller = true
+            anylt = true
         end
     end
-    if one_larger
-        return (one_smaller ? 0 : 1)
+    if anygt
+        return anylt ? 0 : 1
     else
-        return (one_smaller ? -1 : 0)
+        return anylt ? -1 : 0
     end
 end
 

--- a/src/frequency_adaptation.jl
+++ b/src/frequency_adaptation.jl
@@ -10,7 +10,7 @@ but generalized so that it can support more than the adaptation of only
 the coordinates in a Coordinate Descent scheme. The things that are being
 adapted are identified by integers in 1:n, with n being the main parameter.
 """
-type FrequencyAdapter
+mutable struct FrequencyAdapter
     n::Int                # number of methods to select from
     eta::Float64          # 0..1, running average decay rate
     c::Float64            # positive, sensitivity to progress changes

--- a/src/frequency_adaptation.jl
+++ b/src/frequency_adaptation.jl
@@ -11,31 +11,31 @@ the coordinates in a Coordinate Descent scheme. The things that are being
 adapted are identified by integers in 1:n, with n being the main parameter.
 """
 type FrequencyAdapter
-  n::Int                # number of methods to select from
-  eta::Float64          # 0..1, running average decay rate
-  c::Float64            # positive, sensitivity to progress changes
-  pmin::Float64         # minimal method probability
-  pmax::Float64         # maximal method probability
+    n::Int                # number of methods to select from
+    eta::Float64          # 0..1, running average decay rate
+    c::Float64            # positive, sensitivity to progress changes
+    pmin::Float64         # minimal method probability
+    pmax::Float64         # maximal method probability
 
-  p::Vector{Float64}    # Current method weights
-  psum::Float64         # Sum of p[i]
-  a::Vector{Float64}    # Number of pending method applications
-  deltahat::Float64     # Running average of the progress values.
+    p::Vector{Float64}    # Current method weights
+    psum::Float64         # Sum of p[i]
+    a::Vector{Float64}    # Number of pending method applications
+    deltahat::Float64     # Running average of the progress values.
 
-  block::Vector{Int}    # current queue of methods to apply
-  block_pos::Int		# current position in the queue
+    block::Vector{Int}    # current queue of methods to apply
+    block_pos::Int		# current position in the queue
 
-  numupdates::Int     # Number of times we have been updated.
-  min_updates::Int    # Number of updates until we start adapting frequencies.
+    numupdates::Int     # Number of times we have been updated.
+    min_updates::Int    # Number of updates until we start adapting frequencies.
 
-  FrequencyAdapter(n; c = 0.2, eta = 1/n, pmin = 0.05, pmax = 20.0) = begin
-    new(n, eta, c, pmin, pmax,
-      fill(1/n, n), 1.0,
-      zeros(Float64, n),
-      0.0,
-      shuffle!(collect(1:n)), 1,
-      0, n)
-  end
+    function FrequencyAdapter(n; c = 0.2, eta = 1/n, pmin = 0.05, pmax = 20.0)
+        new(n, eta, c, pmin, pmax,
+            fill(1/n, n), 1.0,
+            zeros(Float64, n),
+            0.0,
+            shuffle!(collect(1:n)), 1,
+            0, n)
+    end
 end
 
 frequencies(fa::FrequencyAdapter) = weights(fa.p)
@@ -53,48 +53,48 @@ The methods are randomly shuffled each time the block is regenerated, since we n
 to know their effectiveness at every period of the optimization process.
 """
 function Base.next(fa::FrequencyAdapter)
-  if fa.block_pos > length(fa.block)
-    fill_block!(fa)
-  end
-  #println("Taking $(fa.block_pos) from block = ", fa.block)
-  fa.block_pos += 1
-  return fa.block[fa.block_pos-1]
+    if fa.block_pos > length(fa.block)
+        fill_block!(fa)
+    end
+    #println("Taking $(fa.block_pos) from block = ", fa.block)
+    fa.block_pos += 1
+    return fa.block[fa.block_pos-1]
 end
 
 """
 Fill the block of methods to apply.
 """
 function fill_block!(fa::FrequencyAdapter)
-  #print("Creating new block, psum = $(fa.psum), a = ", fa.a, ", p = ", fa.p)
-  empty!(fa.block)
-  # fill the block according to the fa.p and fa.a
-  last_pos = 0 # position in the block
-  for i in 1:fa.n
-    fa.a[i] += (fa.n * fa.p[i] / fa.psum)
-    if fa.a[i] >= 1.0
-      # block should have at least one i-th method
-      num_ai = floor(Int, fa.a[i])
-      @assert num_ai > 0
-      fa.a[i] -= num_ai # adjust the remainder
-      new_pos = last_pos+num_ai
-      resize!(fa.block, new_pos)
-      fa.block[(last_pos+1):(new_pos)] = i
-      last_pos = new_pos
+    #print("Creating new block, psum = $(fa.psum), a = ", fa.a, ", p = ", fa.p)
+    empty!(fa.block)
+    # fill the block according to the fa.p and fa.a
+    last_pos = 0 # position in the block
+    for i in 1:fa.n
+        fa.a[i] += (fa.n * fa.p[i] / fa.psum)
+        if fa.a[i] >= 1.0
+            # block should have at least one i-th method
+            num_ai = floor(Int, fa.a[i])
+            @assert num_ai > 0
+            fa.a[i] -= num_ai # adjust the remainder
+            new_pos = last_pos+num_ai
+            resize!(fa.block, new_pos)
+            fa.block[(last_pos+1):(new_pos)] = i
+            last_pos = new_pos
+        end
     end
-  end
-  # Due to rounding errors the block is sometimes empty so we select the one
-  # with largest a value.
-  if last_pos == 0
-    #println("Empty block created. Rectifying., std(p) = ", std(fa.p))
-    #print("psum = $(fa.psum), a = ", fa.a, ", p = ", fa.p)
-    i = indmax(fa.a)
-    fa.a[i] = 0
-    resize!(fa.block, 1)
-    fa.block[1] = i
-  end
-  #println("Created new block = ", block)
-  fa.block_pos = 1
-  shuffle!(fa.block)
+    # Due to rounding errors the block is sometimes empty so we select the one
+    # with largest a value.
+    if last_pos == 0
+        #println("Empty block created. Rectifying., std(p) = ", std(fa.p))
+        #print("psum = $(fa.psum), a = ", fa.a, ", p = ", fa.p)
+        i = indmax(fa.a)
+        fa.a[i] = 0
+        resize!(fa.block, 1)
+        fa.block[1] = i
+    end
+    #println("Created new block = ", block)
+    fa.block_pos = 1
+    shuffle!(fa.block)
 end
 
 """
@@ -103,26 +103,26 @@ on the latest progress value of one method. Progress values should be larger
 the larger the progress/improvement was.
 """
 function update!(fa::FrequencyAdapter, methodIndex, progress)
-  # If we already have collected a few samples of progress rates we can update
-  # the pi. This is the common case.
-  if fa.numupdates >= fa.min_updates
-    pnew = fa.deltahat > 0 ? clamp(fa.p[methodIndex] * exp(fa.c * (progress / fa.deltahat - 1)),
-                 fa.pmin, fa.pmax) : fa.pmin
-    #print("i = ", methodIndex, ", pi = ", fa.p[methodIndex], ", pnew = ", pnew, ", psum = ", fa.psum)
-    fa.psum += (pnew - fa.p[methodIndex])
-    fa.p[methodIndex] = pnew
-    #print(", new psum = ", fa.psum, ", deltahat = ", fa.deltahat)
-    fa.deltahat = (1 - fa.eta) * fa.deltahat + fa.eta * progress
-    #println(", new deltahat = ", fa.deltahat)
-  else
-    # Until we have collected at least min_updates we just sum the progress
-    # values so we can later calculate their average.
-    fa.deltahat += progress
-  end
-  fa.numupdates += 1
-  if fa.numupdates == fa.min_updates
-    #print("Setting deltahat, was = ", fa.deltahat, " (min_updates = $(fa.min_updates))")
-    fa.deltahat = fa.deltahat / fa.min_updates
-    #println(", now = ", fa.deltahat)
-  end
+    # If we already have collected a few samples of progress rates we can update
+    # the pi. This is the common case.
+    if fa.numupdates >= fa.min_updates
+        pnew = fa.deltahat > 0 ? clamp(fa.p[methodIndex] * exp(fa.c * (progress / fa.deltahat - 1)),
+                                       fa.pmin, fa.pmax) : fa.pmin
+        #print("i = ", methodIndex, ", pi = ", fa.p[methodIndex], ", pnew = ", pnew, ", psum = ", fa.psum)
+        fa.psum += (pnew - fa.p[methodIndex])
+        fa.p[methodIndex] = pnew
+        #print(", new psum = ", fa.psum, ", deltahat = ", fa.deltahat)
+        fa.deltahat = (1 - fa.eta) * fa.deltahat + fa.eta * progress
+        #println(", new deltahat = ", fa.deltahat)
+    else
+        # Until we have collected at least min_updates we just sum the progress
+        # values so we can later calculate their average.
+        fa.deltahat += progress
+    end
+    fa.numupdates += 1
+    if fa.numupdates == fa.min_updates
+        #print("Setting deltahat, was = ", fa.deltahat, " (min_updates = $(fa.min_updates))")
+        fa.deltahat = fa.deltahat / fa.min_updates
+        #println(", now = ", fa.deltahat)
+    end
 end

--- a/src/frequency_adaptation.jl
+++ b/src/frequency_adaptation.jl
@@ -70,17 +70,20 @@ function fill_block!(fa::FrequencyAdapter)
     # fill the block according to the fa.p and fa.a
     last_pos = 0 # position in the block
     for i in 1:fa.n
-        fa.a[i] += (fa.n * fa.p[i] / fa.psum)
-        if fa.a[i] >= 1.0
+        ai = fa.a[i]
+        pi = fa.p[i]
+        ai += (fa.n * pi / fa.psum)
+        if ai >= 1.0
             # block should have at least one i-th method
-            num_ai = floor(Int, fa.a[i])
-            @assert num_ai > 0
-            fa.a[i] -= num_ai # adjust the remainder
-            new_pos = last_pos+num_ai
+            nai = floor(Int, ai)
+            @assert nai > 0
+            ai -= nai # adjust the remainder
+            new_pos = last_pos + nai
             resize!(fa.block, new_pos)
             fa.block[(last_pos+1):(new_pos)] = i
             last_pos = new_pos
         end
+        fa.a[i] = ai
     end
     # Due to rounding errors the block is sometimes empty so we select the one
     # with largest a value.

--- a/src/frequency_adaptation.jl
+++ b/src/frequency_adaptation.jl
@@ -1,14 +1,14 @@
 """
-  A `FrequencyAdapter` adapts the frequencies with which a set of
-  values/strategies/methods should be applied/tried in an optimization problem.
-  It is based on the `Adaptive Coordinate Frequencies` scheme described in:
+A `FrequencyAdapter` adapts the frequencies with which a set of
+values/strategies/methods should be applied/tried in an optimization problem.
+It is based on the `Adaptive Coordinate Frequencies` scheme described in:
 
-  T. Glasmachers and U. Dogan, "Accelerated Coordinate Descent with
-  Adaptive Coordinate Frequencies", 2013.
+T. Glasmachers and U. Dogan, "Accelerated Coordinate Descent with
+Adaptive Coordinate Frequencies", 2013.
 
-  but generalized so that it can support more than the adaptation of only
-  the coordinates in a Coordinate Descent scheme. The things that are being
-  adapted are identified by integers in 1:n, with n being the main parameter.
+but generalized so that it can support more than the adaptation of only
+the coordinates in a Coordinate Descent scheme. The things that are being
+adapted are identified by integers in 1:n, with n being the main parameter.
 """
 type FrequencyAdapter
   n::Int                # number of methods to select from
@@ -41,16 +41,16 @@ end
 frequencies(fa::FrequencyAdapter) = weights(fa.p)
 
 """
-  `next(fa::FrequencyAdapter)`
+    next(fa::FrequencyAdapter)
 
-  Give the index of the method that should be used at the next iteration.
+Give the index of the method that should be used at the next iteration.
 
-  `FrequencyAdapter` maintains a block of randomly shuffled methods.
-  The function takes the next available method in the block.
-  If the block is empty, it is repopulated.
+`FrequencyAdapter` maintains a block of randomly shuffled methods.
+The function takes the next available method in the block.
+If the block is empty, it is repopulated.
 
-  The methods are randomly shuffled each time the block is regenerated, since we need
-  to know their effectiveness at every period of the optimization process.
+The methods are randomly shuffled each time the block is regenerated, since we need
+to know their effectiveness at every period of the optimization process.
 """
 function Base.next(fa::FrequencyAdapter)
   if fa.block_pos > length(fa.block)
@@ -62,7 +62,7 @@ function Base.next(fa::FrequencyAdapter)
 end
 
 """
-  Fill the block of methods to apply.
+Fill the block of methods to apply.
 """
 function fill_block!(fa::FrequencyAdapter)
   #print("Creating new block, psum = $(fa.psum), a = ", fa.a, ", p = ", fa.p)
@@ -98,9 +98,9 @@ function fill_block!(fa::FrequencyAdapter)
 end
 
 """
-  Update the internal model of progress and success rate of each method based
-  on the latest progress value of one method. Progress values should be larger
-  the larger the progress/improvement was.
+Update the internal model of progress and success rate of each method based
+on the latest progress value of one method. Progress values should be larger
+the larger the progress/improvement was.
 """
 function update!(fa::FrequencyAdapter, methodIndex, progress)
   # If we already have collected a few samples of progress rates we can update

--- a/src/generating_set_search.jl
+++ b/src/generating_set_search.jl
@@ -61,21 +61,23 @@ mutable struct GeneratingSetSearcher{V<:Evaluator, D<:DirectionGenerator, E<:Emb
     step_size::Float64           # current step size
     x::Individual
     xfitness::Float64
-end
 
-function GeneratingSetSearcher{V<:Evaluator, D<:DirectionGenerator, E<:EmbeddingOperator}(evaluator::V, dgen::D, embed::E,
-    random_dir_order::Bool, step_size_factor::Float64, step_size_gamma::Float64, step_size_phi::Float64, step_size_max::Float64,
-    step_tol::Float64)
-    # FIXME check parameters ranges
-    n = numdims(evaluator)
-    ss = search_space(evaluator)
-    x = rand_individual(ss)
-    GeneratingSetSearcher{V, D, E}(dgen, evaluator, embed, ss, n, 0,
-        random_dir_order, step_size_factor,
-        step_size_gamma, step_size_phi,
-        step_size_max, step_tol,
-        calc_initial_step_size(ss, step_size_factor),
-        x, fitness(x, evaluator))
+    function GeneratingSetSearcher(
+            evaluator::V, dgen::D, embed::E,
+            random_dir_order::Bool, step_size_factor::Float64, step_size_gamma::Float64,
+            step_size_phi::Float64, step_size_max::Float64,
+            step_tol::Float64) where {V<:Evaluator, D<:DirectionGenerator, E<:EmbeddingOperator}
+        # FIXME check parameters ranges
+        n = numdims(evaluator)
+        ss = search_space(evaluator)
+        x = rand_individual(ss)
+        new{V, D, E}(dgen, evaluator, embed, ss, n, 0,
+            random_dir_order, step_size_factor,
+            step_size_gamma, step_size_phi,
+            step_size_max, step_tol,
+            calc_initial_step_size(ss, step_size_factor),
+            x, fitness(x, evaluator))
+    end
 end
 
 # by default use RandomBound embedder

--- a/src/generating_set_search.jl
+++ b/src/generating_set_search.jl
@@ -5,13 +5,13 @@
 #
 
 """ A supertype for all generating set searcher-like algorithms. """
-@compat abstract type DirectSearcher <: SteppingOptimizer end
+abstract type DirectSearcher <: SteppingOptimizer end
 
 """
   `DirectionGenerator` generates the search directions to use at each step of
   a GSS search.
 """
-@compat abstract type DirectionGenerator end
+abstract type DirectionGenerator end
 
 immutable ConstantDirectionGen <: DirectionGenerator
   directions::Matrix{Float64}

--- a/src/generating_set_search.jl
+++ b/src/generating_set_search.jl
@@ -4,12 +4,14 @@
 #  SIAM review 45.3 (2003): 385-482.
 #
 
-""" A supertype for all generating set searcher-like algorithms. """
+"""
+A supertype for all generating set searcher-like algorithms.
+"""
 abstract type DirectSearcher <: SteppingOptimizer end
 
 """
-  `DirectionGenerator` generates the search directions to use at each step of
-  a GSS search.
+`DirectionGenerator` generates the search directions to use at each step of
+a GSS search.
 """
 abstract type DirectionGenerator end
 
@@ -41,10 +43,10 @@ const GSSDefaultParameters = ParamsDict(
 calc_initial_step_size(ss, stepSizeFactor = 0.5) = stepSizeFactor * minimum(diameters(ss))
 
 """
-  Generating Set Search as described in Kolda2003:
-    Kolda, Tamara G., Robert Michael Lewis, and Virginia Torczon. "Optimization
-    by direct search: New perspectives on some classical and modern methods."
-    SIAM review 45.3 (2003): 385-482.
+Generating Set Search as described in Kolda2003:
+  Kolda, Tamara G., Robert Michael Lewis, and Virginia Torczon. "Optimization
+  by direct search: New perspectives on some classical and modern methods."
+  SIAM review 45.3 (2003): 385-482.
 """
 type GeneratingSetSearcher{V<:Evaluator, D<:DirectionGenerator, E<:EmbeddingOperator} <: DirectSearcher
   direction_gen::D

--- a/src/generating_set_search.jl
+++ b/src/generating_set_search.jl
@@ -15,7 +15,7 @@ a GSS search.
 """
 abstract type DirectionGenerator end
 
-immutable ConstantDirectionGen <: DirectionGenerator
+struct ConstantDirectionGen <: DirectionGenerator
     directions::Matrix{Float64}
 
     ConstantDirectionGen(directions) = new(directions)
@@ -45,7 +45,7 @@ Generating Set Search as described in Kolda2003:
   by direct search: New perspectives on some classical and modern methods."
   SIAM review 45.3 (2003): 385-482.
 """
-type GeneratingSetSearcher{V<:Evaluator, D<:DirectionGenerator, E<:EmbeddingOperator} <: DirectSearcher
+mutable struct GeneratingSetSearcher{V<:Evaluator, D<:DirectionGenerator, E<:EmbeddingOperator} <: DirectSearcher
     direction_gen::D
     evaluator::V
     embed::E

--- a/src/generating_set_search.jl
+++ b/src/generating_set_search.jl
@@ -16,28 +16,25 @@ a GSS search.
 abstract type DirectionGenerator end
 
 immutable ConstantDirectionGen <: DirectionGenerator
-  directions::Matrix{Float64}
+    directions::Matrix{Float64}
 
-  ConstantDirectionGen(directions) = begin
-    new(directions)
-  end
+    ConstantDirectionGen(directions) = new(directions)
 end
 
-function directions_for_k(cg::ConstantDirectionGen, k)
-  cg.directions # For a ConstantDirectionGen it is always the same regardless of k...
-end
+directions_for_k(cg::ConstantDirectionGen, k) =
+    cg.directions # For a ConstantDirectionGen it is always the same regardless of k...
 
 # We can easily do a compass search with GSS by generating directions
 # individually (+ and -) for each coordinate.
 compass_search_directions(n) = ConstantDirectionGen([eye(n,n) -eye(n, n)])
 
 const GSSDefaultParameters = ParamsDict(
-  :DeltaTolerance => 1e-10,       # GSS has converged if the StepSize drops below this tolerance level
-  :InitialStepSizeFactor => 0.50,        # Factor times the minimum search space diameter to give the initial StepSize
-  :RandomDirectionOrder => true,  # Randomly shuffle the order in which the directions are used for each step
-  :StepSizeGamma => 2.0,          # Factor by which step size is multiplied if improved point is found. Should be >= 1.0.
-  :StepSizePhi => 0.5,            # Factor by which step size is multiplied if NO improved point is found. Should be < 1.0.
-  :StepSizeMax => prevfloat(typemax(Float64)) # A limit on the step size can be set but is typically not => Inf.
+    :DeltaTolerance => 1e-10,       # GSS has converged if the StepSize drops below this tolerance level
+    :InitialStepSizeFactor => 0.50,        # Factor times the minimum search space diameter to give the initial StepSize
+    :RandomDirectionOrder => true,  # Randomly shuffle the order in which the directions are used for each step
+    :StepSizeGamma => 2.0,          # Factor by which step size is multiplied if improved point is found. Should be >= 1.0.
+    :StepSizePhi => 0.5,            # Factor by which step size is multiplied if NO improved point is found. Should be < 1.0.
+    :StepSizeMax => prevfloat(typemax(Float64)) # A limit on the step size can be set but is typically not => Inf.
 )
 
 calc_initial_step_size(ss, stepSizeFactor = 0.5) = stepSizeFactor * minimum(diameters(ss))
@@ -49,21 +46,21 @@ Generating Set Search as described in Kolda2003:
   SIAM review 45.3 (2003): 385-482.
 """
 type GeneratingSetSearcher{V<:Evaluator, D<:DirectionGenerator, E<:EmbeddingOperator} <: DirectSearcher
-  direction_gen::D
-  evaluator::V
-  embed::E
-  search_space::SearchSpace
-  n::Int
-  k::Int
-  random_dir_order::Bool       # shuffle the order of directions?
-  step_size_factor::Float64    # initial step size factor
-  step_size_gamma::Float64     # step size factor if improved
-  step_size_phi::Float64       # step size factor if no improvement
-  step_size_max::Float64       # maximal step size
-  step_tol::Float64            # step delta tolerance
-  step_size::Float64           # current step size
-  x::Individual
-  xfitness::Float64
+    direction_gen::D
+    evaluator::V
+    embed::E
+    search_space::SearchSpace
+    n::Int
+    k::Int
+    random_dir_order::Bool       # shuffle the order of directions?
+    step_size_factor::Float64    # initial step size factor
+    step_size_gamma::Float64     # step size factor if improved
+    step_size_phi::Float64       # step size factor if no improvement
+    step_size_max::Float64       # maximal step size
+    step_tol::Float64            # step delta tolerance
+    step_size::Float64           # current step size
+    x::Individual
+    xfitness::Float64
 end
 
 function GeneratingSetSearcher{V<:Evaluator, D<:DirectionGenerator, E<:EmbeddingOperator}(evaluator::V, dgen::D, embed::E,
@@ -83,8 +80,8 @@ end
 
 # by default use RandomBound embedder
 function GeneratingSetSearcher(problem::OptimizationProblem, parameters::Parameters)
-  params = chain(GSSDefaultParameters, parameters)
-  GeneratingSetSearcher(ProblemEvaluator(problem),
+    params = chain(GSSDefaultParameters, parameters)
+    GeneratingSetSearcher(ProblemEvaluator(problem),
                         get(params, :DirectionGenerator, compass_search_directions(numdims(problem))),
                         RandomBound(search_space(problem)),
                         params[:RandomDirectionOrder],
@@ -93,57 +90,52 @@ function GeneratingSetSearcher(problem::OptimizationProblem, parameters::Paramet
                         params[:DeltaTolerance])
 end
 
-function name(opt::GeneratingSetSearcher)
-  # We also include the name of the direction generator.
-  "GeneratingSetSearcher($(typeof(opt.direction_gen)))"
-end
+# We also include the name of the direction generator.
+name(opt::GeneratingSetSearcher) = "GeneratingSetSearcher($(typeof(opt.direction_gen)))"
 
-function has_converged(gss::GeneratingSetSearcher)
-  gss.step_size < gss.step_tol
-end
+has_converged(gss::GeneratingSetSearcher) = gss.step_size < gss.step_tol
 
 function step!(gss::GeneratingSetSearcher)
-  if has_converged(gss)
-    # Restart from a random point
-    gss.x = rand_individual(gss.search_space)
-    gss.xfitness = fitness(gss.x, gss.evaluator)
-    gss.step_size = calc_initial_step_size(gss.search_space, gss.step_size_factor)
-  end
-
-  # Get the directions for this iteration
-  gss.k += 1
-  directions = directions_for_k(gss.direction_gen, gss.k)
-
-  # Set up order vector from which we will take the directions after possibly shuffling it
-  order = collect(1:size(directions, 2))
-  if gss.random_dir_order
-    shuffle!(order)
-  end
-
-  # Check all directions to find a better point; default is that no one is found.
-  found_better = false
-  candidate = zeros(gss.n, 1)
-
-  # Loop over directions until we find an improvement (or there are no more directions to check).
-  for direction in order
-
-    candidate = gss.x + gss.step_size .* directions[:, direction]
-    apply!(gss.embed, candidate, gss.x)
-
-    if is_better(candidate, gss.xfitness, gss.evaluator)
-      found_better = true
-      break
+    if has_converged(gss)
+        # Restart from a random point
+        gss.x = rand_individual(gss.search_space)
+        gss.xfitness = fitness(gss.x, gss.evaluator)
+        gss.step_size = calc_initial_step_size(gss.search_space, gss.step_size_factor)
     end
 
-  end
+    # Get the directions for this iteration
+    gss.k += 1
+    directions = directions_for_k(gss.direction_gen, gss.k)
 
-  if found_better
-    gss.x = candidate
-    gss.xfitness = last_fitness(gss.evaluator)
-    gss.step_size *= gss.step_size_gamma
-  else
-    gss.step_size *= gss.step_size_phi
-  end
-  gss.step_size = min(gss.step_size, gss.step_size_max)
-  gss
+    # Set up order vector from which we will take the directions after possibly shuffling it
+    order = collect(1:size(directions, 2))
+    if gss.random_dir_order
+        shuffle!(order)
+    end
+
+    # Check all directions to find a better point; default is that no one is found.
+    found_better = false
+    candidate = zeros(gss.n, 1)
+
+    # Loop over directions until we find an improvement (or there are no more directions to check).
+    for direction in order
+        candidate = gss.x + gss.step_size .* directions[:, direction]
+        apply!(gss.embed, candidate, gss.x)
+
+        if is_better(candidate, gss.xfitness, gss.evaluator)
+            found_better = true
+            break
+        end
+    end
+
+    if found_better
+        gss.x = candidate
+        gss.xfitness = last_fitness(gss.evaluator)
+        gss.step_size *= gss.step_size_gamma
+    else
+        gss.step_size *= gss.step_size_phi
+    end
+    gss.step_size = min(gss.step_size, gss.step_size_max)
+
+    return gss
 end

--- a/src/genetic_operators/crossover/differential_evolution_crossover.jl
+++ b/src/genetic_operators/crossover/differential_evolution_crossover.jl
@@ -1,7 +1,7 @@
 abstract type DiffEvoCrossoverOperator{NP,NC} <: CrossoverOperator{NP,NC} end
 
 # FIXME is it possible somehow to do arithmetic operations with N?
-immutable DiffEvoRandBin{N} <: DiffEvoCrossoverOperator{N,1}
+struct DiffEvoRandBin{N} <: DiffEvoCrossoverOperator{N,1}
     cr::Float64   # probability to crossover the dimension
     f::Float64    # scale parameter
 

--- a/src/genetic_operators/crossover/differential_evolution_crossover.jl
+++ b/src/genetic_operators/crossover/differential_evolution_crossover.jl
@@ -1,4 +1,4 @@
-@compat abstract type DiffEvoCrossoverOperator{NP,NC} <: CrossoverOperator{NP,NC} end
+abstract type DiffEvoCrossoverOperator{NP,NC} <: CrossoverOperator{NP,NC} end
 
 # FIXME is it possible somehow to do arithmetic operations with N?
 immutable DiffEvoRandBin{N} <: DiffEvoCrossoverOperator{N,1}
@@ -16,8 +16,8 @@ const DEX_DefaultOptions = ParamsDict(
 
 crossover_parameters(xover::DiffEvoRandBin, pop, target_index) = xover.cr, xover.f
 
-@compat const DiffEvoRandBin1 = DiffEvoRandBin{3}
-@compat const DiffEvoRandBin2 = DiffEvoRandBin{5}
+const DiffEvoRandBin1 = DiffEvoRandBin{3}
+const DiffEvoRandBin2 = DiffEvoRandBin{5}
 
 function apply!(xover::DiffEvoCrossoverOperator{3,1}, target, target_index::Int, pop, parentIndices)
   @assert length(parentIndices) == 3

--- a/src/genetic_operators/crossover/differential_evolution_crossover.jl
+++ b/src/genetic_operators/crossover/differential_evolution_crossover.jl
@@ -2,16 +2,16 @@ abstract type DiffEvoCrossoverOperator{NP,NC} <: CrossoverOperator{NP,NC} end
 
 # FIXME is it possible somehow to do arithmetic operations with N?
 immutable DiffEvoRandBin{N} <: DiffEvoCrossoverOperator{N,1}
-  cr::Float64   # probability to crossover the dimension
-  f::Float64    # scale parameter
+    cr::Float64   # probability to crossover the dimension
+    f::Float64    # scale parameter
 
-  DiffEvoRandBin(cr::Number, f::Number) = new(cr, f)
-  DiffEvoRandBin(options::Parameters) = new(options[:DEX_cr], options[:DEX_f])
+    DiffEvoRandBin(cr::Number, f::Number) = new(cr, f)
+    DiffEvoRandBin(options::Parameters) = new(options[:DEX_cr], options[:DEX_f])
 end
 
 const DEX_DefaultOptions = ParamsDict(
-  :DEX_f => 0.6,
-  :DEX_cr => 0.7
+    :DEX_f => 0.6,
+    :DEX_cr => 0.7
 )
 
 crossover_parameters(xover::DiffEvoRandBin, pop, target_index) = xover.cr, xover.f
@@ -19,36 +19,38 @@ crossover_parameters(xover::DiffEvoRandBin, pop, target_index) = xover.cr, xover
 const DiffEvoRandBin1 = DiffEvoRandBin{3}
 const DiffEvoRandBin2 = DiffEvoRandBin{5}
 
-function apply!(xover::DiffEvoCrossoverOperator{3,1}, target, target_index::Int, pop, parentIndices)
-  @assert length(parentIndices) == 3
-  cr, f = crossover_parameters(xover, pop, target_index)
-  p1ix, p2ix, p3ix = parentIndices
-  # Always ensure at least one parameter is xovered
-  mut_ix = rand(1:length(target))
-  @inbounds for i in 1:length(target)
-    if i == mut_ix || rand() <= cr
-      target[i] = pop[i,p3ix] + f * (pop[i,p1ix] - pop[i,p2ix])
-    elseif target_index == 0
-      target[i] = pop[i,p3ix]
+function apply!(xover::DiffEvoCrossoverOperator{3,1},
+                target, target_index::Int, pop, parentIndices)
+    @assert length(parentIndices) == 3
+    cr, f = crossover_parameters(xover, pop, target_index)
+    p1ix, p2ix, p3ix = parentIndices
+    # Always ensure at least one parameter is xovered
+    mut_ix = rand(1:length(target))
+    @inbounds for i in 1:length(target)
+        if i == mut_ix || rand() <= cr
+            target[i] = pop[i,p3ix] + f * (pop[i,p1ix] - pop[i,p2ix])
+        elseif target_index == 0
+            target[i] = pop[i,p3ix]
+        end
     end
-  end
-  return target
+    return target
 end
 
-function apply!(xover::DiffEvoCrossoverOperator{5,1}, target, target_index::Int, pop, parentIndices)
-  @assert length(parentIndices) == 5
-  cr, f = crossover_parameters(xover, pop, target_index)
-  p1ix, p2ix, p3ix, p4ix, p5ix = parentIndices
-  # Always ensure at least one parameter is xovered
-  mut_ix = rand(1:length(target))
-  @inbounds for i in 1:length(target)
-    if i == mut_ix || rand() <= cr
-      target[i] = pop[i,p3ix] +
+function apply!(xover::DiffEvoCrossoverOperator{5,1},
+                target, target_index::Int, pop, parentIndices)
+    @assert length(parentIndices) == 5
+    cr, f = crossover_parameters(xover, pop, target_index)
+    p1ix, p2ix, p3ix, p4ix, p5ix = parentIndices
+    # Always ensure at least one parameter is xovered
+    mut_ix = rand(1:length(target))
+    @inbounds for i in 1:length(target)
+        if i == mut_ix || rand() <= cr
+            target[i] = pop[i,p3ix] +
                 f * (pop[i,p1ix] - pop[i,p2ix]) +
                 f * (pop[i,p4ix] - pop[i,p5ix])
-    elseif target_index == 0
-      target[i] = pop[i,p3ix]
+        elseif target_index == 0
+            target[i] = pop[i,p3ix]
+        end
     end
-  end
-  return target
+    return target
 end

--- a/src/genetic_operators/crossover/differential_evolution_crossover.jl
+++ b/src/genetic_operators/crossover/differential_evolution_crossover.jl
@@ -5,8 +5,8 @@ struct DiffEvoRandBin{N} <: DiffEvoCrossoverOperator{N,1}
     cr::Float64   # probability to crossover the dimension
     f::Float64    # scale parameter
 
-    DiffEvoRandBin(cr::Number, f::Number) = new(cr, f)
-    DiffEvoRandBin(options::Parameters) = new(options[:DEX_cr], options[:DEX_f])
+    DiffEvoRandBin{N}(cr::Number, f::Number) where N = new{N}(cr, f)
+    DiffEvoRandBin{N}(options::Parameters) where N = new{N}(options[:DEX_cr], options[:DEX_f])
 end
 
 const DEX_DefaultOptions = ParamsDict(

--- a/src/genetic_operators/crossover/mutation_wrapper.jl
+++ b/src/genetic_operators/crossover/mutation_wrapper.jl
@@ -1,6 +1,6 @@
 """
-    Wraps the mutation operator, so that it could
-    be used as crossover operator.
+Wraps the mutation operator, so that it could
+be used as crossover operator.
 """
 immutable MutationWrapper{OP<:MutationOperator} <: CrossoverOperator{1,1}
     inner::OP

--- a/src/genetic_operators/crossover/mutation_wrapper.jl
+++ b/src/genetic_operators/crossover/mutation_wrapper.jl
@@ -5,7 +5,7 @@ be used as crossover operator.
 struct MutationWrapper{OP<:MutationOperator} <: CrossoverOperator{1,1}
     inner::OP
 
-    (::Type{MutationWrapper}){OP<:MutationOperator}(mutation::OP) =
+    MutationWrapper(mutation::OP) where {OP<:MutationOperator} =
         new{OP}(mutation)
 end
 

--- a/src/genetic_operators/crossover/mutation_wrapper.jl
+++ b/src/genetic_operators/crossover/mutation_wrapper.jl
@@ -2,7 +2,7 @@
 Wraps the mutation operator, so that it could
 be used as crossover operator.
 """
-immutable MutationWrapper{OP<:MutationOperator} <: CrossoverOperator{1,1}
+struct MutationWrapper{OP<:MutationOperator} <: CrossoverOperator{1,1}
     inner::OP
 
     (::Type{MutationWrapper}){OP<:MutationOperator}(mutation::OP) =

--- a/src/genetic_operators/crossover/mutation_wrapper.jl
+++ b/src/genetic_operators/crossover/mutation_wrapper.jl
@@ -9,7 +9,8 @@ immutable MutationWrapper{OP<:MutationOperator} <: CrossoverOperator{1,1}
         new{OP}(mutation)
 end
 
-function apply!(wrapper::MutationWrapper, target::Individual, targetIndex::Int, pop, parentIndices)
+function apply!(wrapper::MutationWrapper,
+                target::Individual, targetIndex::Int, pop, parentIndices)
     @assert length(parentIndices) == 1
     apply!(wrapper.inner, copy!(target, viewer(pop, parentIndices[1])), targetIndex)
 end

--- a/src/genetic_operators/crossover/parent_centric_crossover.jl
+++ b/src/genetic_operators/crossover/parent_centric_crossover.jl
@@ -13,15 +13,18 @@ immutable ParentCentricCrossover{NP} <: CrossoverOperator{NP,1}
         η > 0 || throw(ArgumentError("η must be non-negative"))
         new(ζ, η)
     end
-    ParentCentricCrossover(params::Parameters) = new(params[:PCX_ζ], params[:PCX_η])
+    ParentCentricCrossover(params::Parameters) =
+        new(params[:PCX_ζ], params[:PCX_η])
 end
 
 const PCX_DefaultOptions = ParamsDict(
-  :PCX_ζ => 0.1,
-  :PCX_η => 0.5
+    :PCX_ζ => 0.1,
+    :PCX_η => 0.5
 )
 
-function apply!{NP}(xover::ParentCentricCrossover{NP}, target::Individual, targetIndex::Int, pop, parentIndices)
+function apply!{NP}(xover::ParentCentricCrossover{NP},
+                    target::Individual, targetIndex::Int,
+                    pop, parentIndices)
     @assert length(parentIndices) == NP
 
     parents_centered = pop[:, parentIndices]

--- a/src/genetic_operators/crossover/parent_centric_crossover.jl
+++ b/src/genetic_operators/crossover/parent_centric_crossover.jl
@@ -8,13 +8,13 @@ struct ParentCentricCrossover{NP} <: CrossoverOperator{NP,1}
 	ζ::Float64 # sd for the orthogonal directions defined by 2nd,3rd etc parents
     η::Float64 # sd for the direction of the 1st parent
 
-    function ParentCentricCrossover(ζ::Number, η::Number)
+    function ParentCentricCrossover{NP}(ζ::Number, η::Number) where NP
         ζ > 0 || throw(ArgumentError("ζ must be positive"))
         η > 0 || throw(ArgumentError("η must be non-negative"))
-        new(ζ, η)
+        new{NP}(ζ, η)
     end
-    ParentCentricCrossover(params::Parameters) =
-        new(params[:PCX_ζ], params[:PCX_η])
+    ParentCentricCrossover{NP}(params::Parameters) where NP =
+        new{NP}(params[:PCX_ζ], params[:PCX_η])
 end
 
 const PCX_DefaultOptions = ParamsDict(

--- a/src/genetic_operators/crossover/parent_centric_crossover.jl
+++ b/src/genetic_operators/crossover/parent_centric_crossover.jl
@@ -1,8 +1,8 @@
 """
-    Parent Centric Crossover (PCX).
+Parent Centric Crossover (PCX).
 
-    See
-        Deb, K., Anand, A., and Joshi, D., "A Computationally Efficient Evolutionary Algorithm for Real-Parameter Optimization," Evolutionary Computation, vol. 10, no. 4, pp. 371-395, 2002.
+See
+    Deb, K., Anand, A., and Joshi, D., "A Computationally Efficient Evolutionary Algorithm for Real-Parameter Optimization," Evolutionary Computation, vol. 10, no. 4, pp. 371-395, 2002.
 """
 immutable ParentCentricCrossover{NP} <: CrossoverOperator{NP,1}
 	ζ::Float64 # sd for the orthogonal directions defined by 2nd,3rd etc parents

--- a/src/genetic_operators/crossover/parent_centric_crossover.jl
+++ b/src/genetic_operators/crossover/parent_centric_crossover.jl
@@ -22,9 +22,9 @@ const PCX_DefaultOptions = ParamsDict(
     :PCX_η => 0.5
 )
 
-function apply!{NP}(xover::ParentCentricCrossover{NP},
-                    target::Individual, targetIndex::Int,
-                    pop, parentIndices)
+function apply!(xover::ParentCentricCrossover{NP},
+                target::Individual, targetIndex::Int,
+                pop, parentIndices) where NP
     @assert length(parentIndices) == NP
 
     parents_centered = pop[:, parentIndices]

--- a/src/genetic_operators/crossover/parent_centric_crossover.jl
+++ b/src/genetic_operators/crossover/parent_centric_crossover.jl
@@ -4,7 +4,7 @@ Parent Centric Crossover (PCX).
 See
     Deb, K., Anand, A., and Joshi, D., "A Computationally Efficient Evolutionary Algorithm for Real-Parameter Optimization," Evolutionary Computation, vol. 10, no. 4, pp. 371-395, 2002.
 """
-immutable ParentCentricCrossover{NP} <: CrossoverOperator{NP,1}
+struct ParentCentricCrossover{NP} <: CrossoverOperator{NP,1}
 	ζ::Float64 # sd for the orthogonal directions defined by 2nd,3rd etc parents
     η::Float64 # sd for the direction of the 1st parent
 

--- a/src/genetic_operators/crossover/simplex_crossover.jl
+++ b/src/genetic_operators/crossover/simplex_crossover.jl
@@ -7,7 +7,7 @@ inflation.
 See Tsutsui, Yamamura & Higuchi "Multi-parent recombination with simplex crossover in real coded genetic algorithms", 1999,
 Proc. of the Genetic and Evolutionary Computation Conference
 """
-immutable SimplexCrossover{NP} <: CrossoverOperator{NP,1}
+struct SimplexCrossover{NP} <: CrossoverOperator{NP,1}
     ϵ::Float64      # inflation rate
 
     SimplexCrossover(ϵ::Number = Math.sqrt(NP + 1)) = new(ϵ)

--- a/src/genetic_operators/crossover/simplex_crossover.jl
+++ b/src/genetic_operators/crossover/simplex_crossover.jl
@@ -20,9 +20,9 @@ const SPX_DefaultOptions = ParamsDict(
 
 #masscenter(pop, parentIndices) = mapslices(mean, pop[:, parentIndices], 2)
 
-function apply!{NP}(xover::SimplexCrossover{NP},
-                    target::Individual, targetIndex::Int,
-                    pop, parentIndices)
+function apply!(xover::SimplexCrossover{NP},
+                target::Individual, targetIndex::Int,
+                pop, parentIndices) where NP
     @assert length(parentIndices) == NP
 
     offset = zeros(target)

--- a/src/genetic_operators/crossover/simplex_crossover.jl
+++ b/src/genetic_operators/crossover/simplex_crossover.jl
@@ -15,12 +15,14 @@ immutable SimplexCrossover{NP} <: CrossoverOperator{NP,1}
 end
 
 const SPX_DefaultOptions = ParamsDict(
-  :SPX_ϵ => 1.1 # how much to inflate
+    :SPX_ϵ => 1.1 # how much to inflate
 )
 
 #masscenter(pop, parentIndices) = mapslices(mean, pop[:, parentIndices], 2)
 
-function apply!{NP}(xover::SimplexCrossover{NP}, target::Individual, targetIndex::Int, pop, parentIndices)
+function apply!{NP}(xover::SimplexCrossover{NP},
+                    target::Individual, targetIndex::Int,
+                    pop, parentIndices)
     @assert length(parentIndices) == NP
 
     offset = zeros(target)

--- a/src/genetic_operators/crossover/simplex_crossover.jl
+++ b/src/genetic_operators/crossover/simplex_crossover.jl
@@ -10,8 +10,8 @@ Proc. of the Genetic and Evolutionary Computation Conference
 struct SimplexCrossover{NP} <: CrossoverOperator{NP,1}
     ϵ::Float64      # inflation rate
 
-    SimplexCrossover(ϵ::Number = Math.sqrt(NP + 1)) = new(ϵ)
-    SimplexCrossover(params::Parameters) = new(params[:SPX_ϵ])
+    SimplexCrossover{NP}(ϵ::Number = Math.sqrt(NP + 1)) where NP = new{NP}(ϵ)
+    SimplexCrossover{NP}(params::Parameters) where NP = new{NP}(params[:SPX_ϵ])
 end
 
 const SPX_DefaultOptions = ParamsDict(

--- a/src/genetic_operators/crossover/simplex_crossover.jl
+++ b/src/genetic_operators/crossover/simplex_crossover.jl
@@ -1,11 +1,11 @@
 """
-    Simplex Crossover (SPX).
+Simplex Crossover (SPX).
 
-    `ϵ>0` controls how the original simplex is inflated, `ϵ=1` means no
-    inflation.
+`ϵ>0` controls how the original simplex is inflated, `ϵ=1` means no
+inflation.
 
-    See Tsutsui, Yamamura & Higuchi "Multi-parent recombination with simplex crossover in real coded genetic algorithms", 1999,
-    Proc. of the Genetic and Evolutionary Computation Conference
+See Tsutsui, Yamamura & Higuchi "Multi-parent recombination with simplex crossover in real coded genetic algorithms", 1999,
+Proc. of the Genetic and Evolutionary Computation Conference
 """
 immutable SimplexCrossover{NP} <: CrossoverOperator{NP,1}
     ϵ::Float64      # inflation rate

--- a/src/genetic_operators/crossover/simulated_binary_crossover.jl
+++ b/src/genetic_operators/crossover/simulated_binary_crossover.jl
@@ -28,7 +28,9 @@ function randbeta(xover::SimulatedBinaryCrossover)
     return (u < 0.5 ? 2*u : 1/(2*(1-u)))^xover.η_exp
 end
 
-function apply!(xover::SimulatedBinaryCrossover, targets::Vector{Individual}, targetIndices::Vector{Int}, pop, parentIndices)
+function apply!(xover::SimulatedBinaryCrossover,
+                targets::Vector{Individual}, targetIndices::Vector{Int},
+                pop, parentIndices)
     @assert length(targets) == 2
     @assert length(targetIndices) == 2
     @assert length(parentIndices) == 2

--- a/src/genetic_operators/crossover/simulated_binary_crossover.jl
+++ b/src/genetic_operators/crossover/simulated_binary_crossover.jl
@@ -3,7 +3,7 @@ Simulated Binary Crossover (SBX).
 
 See Deb&Agrawal "Simulated binary crossover for continuous search space", 1994, Complex Systems
 """
-immutable SimulatedBinaryCrossover <: CrossoverOperator{2,2}
+struct SimulatedBinaryCrossover <: CrossoverOperator{2,2}
     p::Float64      # probability to modify a dimension
     η::Float64      # distribution index
     η_exp::Float64  # pre-processed index

--- a/src/genetic_operators/crossover/simulated_binary_crossover.jl
+++ b/src/genetic_operators/crossover/simulated_binary_crossover.jl
@@ -1,7 +1,7 @@
 """
-    Simulated Binary Crossover (SBX).
+Simulated Binary Crossover (SBX).
 
-    See Deb&Agrawal "Simulated binary crossover for continuous search space", 1994, Complex Systems
+See Deb&Agrawal "Simulated binary crossover for continuous search space", 1994, Complex Systems
 """
 immutable SimulatedBinaryCrossover <: CrossoverOperator{2,2}
     p::Float64      # probability to modify a dimension

--- a/src/genetic_operators/crossover/unimodal_normal_distribution_crossover.jl
+++ b/src/genetic_operators/crossover/unimodal_normal_distribution_crossover.jl
@@ -14,15 +14,18 @@ immutable UnimodalNormalDistributionCrossover{NP} <: CrossoverOperator{NP,1}
         η >= 0 || throw(ArgumentError("η must be non-negative"))
         new(ζ, η)
     end
-    UnimodalNormalDistributionCrossover(params::Parameters) = new(params[:UNDX_ζ], params[:UNDX_η])
+    UnimodalNormalDistributionCrossover(params::Parameters) =
+        new(params[:UNDX_ζ], params[:UNDX_η])
 end
 
 const UNDX_DefaultOptions = ParamsDict(
-  :UNDX_ζ => 0.5,
-  :UNDX_η => 0.1
+    :UNDX_ζ => 0.5,
+    :UNDX_η => 0.1
 )
 
-function apply!{NP}(xover::UnimodalNormalDistributionCrossover{NP}, target::Individual, targetIndex::Int, pop, parentIndices)
+function apply!{NP}(xover::UnimodalNormalDistributionCrossover{NP},
+                    target::Individual, targetIndex::Int,
+                    pop, parentIndices)
     @assert length(parentIndices) == NP
 
     parents = pop[:, parentIndices]

--- a/src/genetic_operators/crossover/unimodal_normal_distribution_crossover.jl
+++ b/src/genetic_operators/crossover/unimodal_normal_distribution_crossover.jl
@@ -5,7 +5,7 @@ See
     Kita, H., Ono, I., and Kobayashi, S., "Multi-parental Extension of the Unimodal Normal Distribution Crossover for Real-coded Genetic Algorithms," Proceedings of the 1999 Congress on Evolutionary Computation, pp. 1581-1588, 1999.
     Deb, K., Anand, A., and Joshi, D., "A Computationally Efficient Evolutionary Algorithm for Real-Parameter Optimization," Evolutionary Computation, vol. 10, no. 4, pp. 371-395, 2002.
 """
-immutable UnimodalNormalDistributionCrossover{NP} <: CrossoverOperator{NP,1}
+struct UnimodalNormalDistributionCrossover{NP} <: CrossoverOperator{NP,1}
 	ζ::Float64 # sd for parent-defined orthogonal directions
     η::Float64 # sd for the directions orthogonal to the parent-defined ones, divided by √n
 

--- a/src/genetic_operators/crossover/unimodal_normal_distribution_crossover.jl
+++ b/src/genetic_operators/crossover/unimodal_normal_distribution_crossover.jl
@@ -9,13 +9,13 @@ struct UnimodalNormalDistributionCrossover{NP} <: CrossoverOperator{NP,1}
 	ζ::Float64 # sd for parent-defined orthogonal directions
     η::Float64 # sd for the directions orthogonal to the parent-defined ones, divided by √n
 
-    function UnimodalNormalDistributionCrossover(ζ::Number, η::Number)
+    function UnimodalNormalDistributionCrossover{NP}(ζ::Number, η::Number) where NP
         ζ > 0 || throw(ArgumentError("ζ must be positive"))
         η >= 0 || throw(ArgumentError("η must be non-negative"))
-        new(ζ, η)
+        new{NP}(ζ, η)
     end
-    UnimodalNormalDistributionCrossover(params::Parameters) =
-        new(params[:UNDX_ζ], params[:UNDX_η])
+    UnimodalNormalDistributionCrossover{NP}(params::Parameters) where NP =
+        new{NP}(params[:UNDX_ζ], params[:UNDX_η])
 end
 
 const UNDX_DefaultOptions = ParamsDict(

--- a/src/genetic_operators/crossover/unimodal_normal_distribution_crossover.jl
+++ b/src/genetic_operators/crossover/unimodal_normal_distribution_crossover.jl
@@ -23,9 +23,9 @@ const UNDX_DefaultOptions = ParamsDict(
     :UNDX_η => 0.1
 )
 
-function apply!{NP}(xover::UnimodalNormalDistributionCrossover{NP},
-                    target::Individual, targetIndex::Int,
-                    pop, parentIndices)
+function apply!(xover::UnimodalNormalDistributionCrossover{NP},
+                target::Individual, targetIndex::Int,
+                pop, parentIndices) where NP
     @assert length(parentIndices) == NP
 
     parents = pop[:, parentIndices]

--- a/src/genetic_operators/crossover/unimodal_normal_distribution_crossover.jl
+++ b/src/genetic_operators/crossover/unimodal_normal_distribution_crossover.jl
@@ -1,9 +1,9 @@
 """
-    Unimodal Normal Distribution Crossover (UNDX).
+Unimodal Normal Distribution Crossover (UNDX).
 
-    See
-        Kita, H., Ono, I., and Kobayashi, S., "Multi-parental Extension of the Unimodal Normal Distribution Crossover for Real-coded Genetic Algorithms," Proceedings of the 1999 Congress on Evolutionary Computation, pp. 1581-1588, 1999.
-        Deb, K., Anand, A., and Joshi, D., "A Computationally Efficient Evolutionary Algorithm for Real-Parameter Optimization," Evolutionary Computation, vol. 10, no. 4, pp. 371-395, 2002.
+See
+    Kita, H., Ono, I., and Kobayashi, S., "Multi-parental Extension of the Unimodal Normal Distribution Crossover for Real-coded Genetic Algorithms," Proceedings of the 1999 Congress on Evolutionary Computation, pp. 1581-1588, 1999.
+    Deb, K., Anand, A., and Joshi, D., "A Computationally Efficient Evolutionary Algorithm for Real-Parameter Optimization," Evolutionary Computation, vol. 10, no. 4, pp. 371-395, 2002.
 """
 immutable UnimodalNormalDistributionCrossover{NP} <: CrossoverOperator{NP,1}
 	ζ::Float64 # sd for parent-defined orthogonal directions

--- a/src/genetic_operators/embedding/random_bound.jl
+++ b/src/genetic_operators/embedding/random_bound.jl
@@ -6,7 +6,7 @@ to get the new valid value if target's parameter is out-of-bounds.
 struct RandomBound{S<:SearchSpace} <: EmbeddingOperator
     searchSpace::S
 
-    (::Type{RandomBound}){S<:SearchSpace}(searchSpace::S) = new{S}(searchSpace)
+    RandomBound(searchSpace::S) where {S<:SearchSpace} = new{S}(searchSpace)
 end
 
 # outer ctors

--- a/src/genetic_operators/embedding/random_bound.jl
+++ b/src/genetic_operators/embedding/random_bound.jl
@@ -15,27 +15,29 @@ RandomBound(dimBounds::Vector{ParamBounds}) = RandomBound(RangePerDimSearchSpace
 search_space(rb::RandomBound) = rb.searchSpace
 
 function apply!(eo::RandomBound, target::AbstractIndividual, ref::AbstractIndividual)
-  length(target) == length(ref) == numdims(eo.searchSpace) || throw(ArgumentError("Dimensions of problem/individuals do not match"))
-  ssmins = mins(eo.searchSpace)
-  ssmaxs = maxs(eo.searchSpace)
+    length(target) == length(ref) == numdims(eo.searchSpace) ||
+        throw(ArgumentError("Dimensions of problem/individuals do not match"))
+    ssmins = mins(eo.searchSpace)
+    ssmaxs = maxs(eo.searchSpace)
 
-  @inbounds for i in 1:length(target)
-    l, u = ssmins[i], ssmaxs[i]
+    @inbounds for i in 1:length(target)
+        l, u = ssmins[i], ssmaxs[i]
 
-    if target[i] < l
-      target[i] = l + rand() * (ref[i] - l)
-    elseif target[i] > u
-      target[i] = u + rand() * (ref[i] - u)
+        if target[i] < l
+            target[i] = l + rand() * (ref[i] - l)
+        elseif target[i] > u
+            target[i] = u + rand() * (ref[i] - u)
+        end
+        @assert l <= target[i] <= u "target[$i]=$(target[i]) is out of [$l, $u]"
     end
-    @assert l <= target[i] <= u "target[$i]=$(target[i]) is out of [$l, $u]"
-  end
-  return target
+    return target
 end
 
 apply!(eo::RandomBound, target::AbstractIndividual, pop, refIndex::Int) =
     apply!(eo, target, viewer(pop, refIndex))
 
-function apply!(eo::RandomBound, target::AbstractIndividual, pop, parentIndices::AbstractVector{Int})
-  @assert length(parentIndices) == 1
-  apply!(eo, target, pop, parentIndices[1])
+function apply!(eo::RandomBound, target::AbstractIndividual,
+                pop, parentIndices::AbstractVector{Int})
+    @assert length(parentIndices) == 1
+    apply!(eo, target, pop, parentIndices[1])
 end

--- a/src/genetic_operators/embedding/random_bound.jl
+++ b/src/genetic_operators/embedding/random_bound.jl
@@ -3,7 +3,7 @@ Embedding operator that randomly samples
 between parent's value and the nearest parameter boundary
 to get the new valid value if target's parameter is out-of-bounds.
 """
-immutable RandomBound{S<:SearchSpace} <: EmbeddingOperator
+struct RandomBound{S<:SearchSpace} <: EmbeddingOperator
     searchSpace::S
 
     (::Type{RandomBound}){S<:SearchSpace}(searchSpace::S) = new{S}(searchSpace)

--- a/src/genetic_operators/embedding/random_bound.jl
+++ b/src/genetic_operators/embedding/random_bound.jl
@@ -1,7 +1,7 @@
 """
-  Embedding operator that randomly samples
-  between parent's value and the nearest parameter boundary
-  to get the new valid value if target's parameter is out-of-bounds.
+Embedding operator that randomly samples
+between parent's value and the nearest parameter boundary
+to get the new valid value if target's parameter is out-of-bounds.
 """
 immutable RandomBound{S<:SearchSpace} <: EmbeddingOperator
     searchSpace::S

--- a/src/genetic_operators/genetic_operator.jl
+++ b/src/genetic_operators/genetic_operator.jl
@@ -38,7 +38,7 @@ Select `numSamples` random candidates from the `population`.
 """
 function select(::IndividualsSelector, population, numSamples::Int) end
 
-apply(o::MutationOperator, parents::Vector{Vector{<:Real}}) =
+apply(o::MutationOperator, parents::AbstractVector{<:AbstractVector{<:Real}}) =
     map(p -> apply(o, p), parents)
 
 numchildren(o::GeneticOperator) = 1

--- a/src/genetic_operators/genetic_operator.jl
+++ b/src/genetic_operators/genetic_operator.jl
@@ -1,35 +1,35 @@
 """
   Abstract genetic operator that transforms individuals in the population.
 """
-@compat abstract type GeneticOperator end
+abstract type GeneticOperator end
 
 """
   Modifies (mutates) one individual.
 
   The concrete implementations must provide `apply!()` method.
 """
-@compat abstract type MutationOperator <: GeneticOperator end
+abstract type MutationOperator <: GeneticOperator end
 
 """
   Modifies `NC` "children" by transferring some information from `NP` "parents".
 
   The concrete implementations must provide `apply!()` method.
 """
-@compat abstract type CrossoverOperator{NP,NC} <: GeneticOperator end
+abstract type CrossoverOperator{NP,NC} <: GeneticOperator end
 
 """
   Embeds(projects) the individual into the search space.
 
   The concrete implementations must provide `apply!()` method.
 """
-@compat abstract type EmbeddingOperator <: GeneticOperator end
+abstract type EmbeddingOperator <: GeneticOperator end
 
 """
   Selects the individuals from the population.
 
   The concrete implementations must provide `select()` method.
 """
-@compat abstract type IndividualsSelector end
+abstract type IndividualsSelector end
 
 """
   `select(selector<:IndividualsSelector, population, numSamples::Int)`
@@ -91,7 +91,7 @@ function trace_state(io::IO, op::GeneticOperator, mode::Symbol) end
   A mixture of genetic operators,
   use `next()` to choose the next operator from the mixture.
 """
-@compat abstract type GeneticOperatorsMixture <: GeneticOperator end
+abstract type GeneticOperatorsMixture <: GeneticOperator end
 
 include("operators_mixture.jl")
 

--- a/src/genetic_operators/genetic_operator.jl
+++ b/src/genetic_operators/genetic_operator.jl
@@ -1,40 +1,40 @@
 """
-  Abstract genetic operator that transforms individuals in the population.
+Abstract genetic operator that transforms individuals in the population.
 """
 abstract type GeneticOperator end
 
 """
-  Modifies (mutates) one individual.
+Modifies (mutates) one individual.
 
-  The concrete implementations must provide `apply!()` method.
+The concrete implementations must provide `apply!()` method.
 """
 abstract type MutationOperator <: GeneticOperator end
 
 """
-  Modifies `NC` "children" by transferring some information from `NP` "parents".
+Modifies `NC` "children" by transferring some information from `NP` "parents".
 
-  The concrete implementations must provide `apply!()` method.
+The concrete implementations must provide `apply!()` method.
 """
 abstract type CrossoverOperator{NP,NC} <: GeneticOperator end
 
 """
-  Embeds(projects) the individual into the search space.
+Embeds(projects) the individual into the search space.
 
-  The concrete implementations must provide `apply!()` method.
+The concrete implementations must provide `apply!()` method.
 """
 abstract type EmbeddingOperator <: GeneticOperator end
 
 """
-  Selects the individuals from the population.
+Selects the individuals from the population.
 
-  The concrete implementations must provide `select()` method.
+The concrete implementations must provide `select()` method.
 """
 abstract type IndividualsSelector end
 
 """
-  `select(selector<:IndividualsSelector, population, numSamples::Int)`
+    select(selector<:IndividualsSelector, population, numSamples::Int)
 
-  Select `numSamples` random candidates from the `population`.
+Select `numSamples` random candidates from the `population`.
 """
 function select(::IndividualsSelector, population, numSamples::Int) end
 
@@ -59,37 +59,37 @@ function apply!{NP,I<:AbstractIndividual}(xover::CrossoverOperator{NP,1}, target
 end
 
 """
-  `MutationOperator` that does nothing.
+`MutationOperator` that does nothing.
 """
 immutable NoMutation <: MutationOperator end
 apply!(mo::NoMutation, target, target_index) = target
 
 """
-  Placeholder for no-effect genetic operations.
+Placeholder for no-effect genetic operations.
 """
 const NO_GEN_OP = NoMutation()
 
 """
-  Adjust the internal parameters of the genetic operator `op` taking into account
-  the fitness change.
+Adjust the internal parameters of the genetic operator `op` taking into account
+the fitness change.
 
-  The default implementation does nothing.
+The default implementation does nothing.
 """
 function adjust!{F}(op::GeneticOperator, tag::Int, indi_index::Int, new_fitness::F, old_fitness::F, is_improved::Bool) end
 
 """
-  `trace_state(io, op::GeneticOperator, mode::Symbol)`
+    trace_state(io, op::GeneticOperator, mode::Symbol)
 
-  Trace the state of the operator.
-  Called by `trace_progress()` during `OptRunController` run by some of the genetic optimizers.
+Trace the state of the operator.
+Called by `trace_progress()` during `OptRunController` run by some of the genetic optimizers.
 
-  Override the method to trace the state of your genetic operator.
+Override the method to trace the state of your genetic operator.
 """
 function trace_state(io::IO, op::GeneticOperator, mode::Symbol) end
 
 """
-  A mixture of genetic operators,
-  use `next()` to choose the next operator from the mixture.
+A mixture of genetic operators,
+use `next()` to choose the next operator from the mixture.
 """
 abstract type GeneticOperatorsMixture <: GeneticOperator end
 

--- a/src/genetic_operators/genetic_operator.jl
+++ b/src/genetic_operators/genetic_operator.jl
@@ -38,7 +38,8 @@ Select `numSamples` random candidates from the `population`.
 """
 function select(::IndividualsSelector, population, numSamples::Int) end
 
-apply{T <: Real}(o::MutationOperator, parents::Vector{Vector{T}}) = map(p -> apply(o, p), parents)
+apply{T <: Real}(o::MutationOperator, parents::Vector{Vector{T}}) =
+    map(p -> apply(o, p), parents)
 
 numchildren(o::GeneticOperator) = 1
 numparents(o::MutationOperator) = 1 # But it will apply to each parent separately if given more than one...
@@ -50,8 +51,11 @@ numparents(o::EmbeddingOperator) = 1
 numchildren(o::EmbeddingOperator) = 1
 
 # wrapper for multi-children variant of apply!() for single-child xover operators
-function apply!{NP,I<:AbstractIndividual}(xover::CrossoverOperator{NP,1}, targets::AbstractVector{I}, target_indices::AbstractVector{Int}, pop, parentIndices)
-    length(targets) == length(target_indices) || throw(ArgumentError("The number of target doesn't match the number of their indices"))
+function apply!{NP,I<:AbstractIndividual}(xover::CrossoverOperator{NP,1},
+               targets::AbstractVector{I}, target_indices::AbstractVector{Int},
+               pop, parentIndices)
+    length(targets) == length(target_indices) ||
+        throw(ArgumentError("The number of target doesn't match the number of their indices"))
     for i in eachindex(target_indices)
         apply!(xover, targets[i], target_indices[i], pop, parentIndices)
     end
@@ -75,7 +79,8 @@ the fitness change.
 
 The default implementation does nothing.
 """
-function adjust!{F}(op::GeneticOperator, tag::Int, indi_index::Int, new_fitness::F, old_fitness::F, is_improved::Bool) end
+function adjust!{F}(op::GeneticOperator, tag::Int, indi_index::Int,
+                    new_fitness::F, old_fitness::F, is_improved::Bool) end
 
 """
     trace_state(io, op::GeneticOperator, mode::Symbol)

--- a/src/genetic_operators/genetic_operator.jl
+++ b/src/genetic_operators/genetic_operator.jl
@@ -65,7 +65,7 @@ end
 """
 `MutationOperator` that does nothing.
 """
-immutable NoMutation <: MutationOperator end
+struct NoMutation <: MutationOperator end
 apply!(mo::NoMutation, target, target_index) = target
 
 """

--- a/src/genetic_operators/genetic_operator.jl
+++ b/src/genetic_operators/genetic_operator.jl
@@ -38,22 +38,22 @@ Select `numSamples` random candidates from the `population`.
 """
 function select(::IndividualsSelector, population, numSamples::Int) end
 
-apply{T <: Real}(o::MutationOperator, parents::Vector{Vector{T}}) =
+apply(o::MutationOperator, parents::Vector{Vector{<:Real}}) =
     map(p -> apply(o, p), parents)
 
 numchildren(o::GeneticOperator) = 1
 numparents(o::MutationOperator) = 1 # But it will apply to each parent separately if given more than one...
 
-numparents{NP,NC}(o::CrossoverOperator{NP,NC}) = NP::Int
-numchildren{NP,NC}(o::CrossoverOperator{NP,NC}) = NC::Int
+numparents(o::CrossoverOperator{NP,NC}) where {NP,NC} = NP::Int
+numchildren(o::CrossoverOperator{NP,NC}) where {NP,NC} = NC::Int
 
 numparents(o::EmbeddingOperator) = 1
 numchildren(o::EmbeddingOperator) = 1
 
 # wrapper for multi-children variant of apply!() for single-child xover operators
-function apply!{NP,I<:AbstractIndividual}(xover::CrossoverOperator{NP,1},
-               targets::AbstractVector{I}, target_indices::AbstractVector{Int},
-               pop, parentIndices)
+function apply!(xover::CrossoverOperator{NP, 1},
+                targets::AbstractVector{<:AbstractIndividual}, target_indices::AbstractVector{Int},
+                pop, parentIndices) where NP
     length(targets) == length(target_indices) ||
         throw(ArgumentError("The number of target doesn't match the number of their indices"))
     for i in eachindex(target_indices)
@@ -79,8 +79,8 @@ the fitness change.
 
 The default implementation does nothing.
 """
-function adjust!{F}(op::GeneticOperator, tag::Int, indi_index::Int,
-                    new_fitness::F, old_fitness::F, is_improved::Bool) end
+function adjust!(op::GeneticOperator, tag::Int, indi_index::Int,
+                 new_fitness::F, old_fitness::F, is_improved::Bool) where F end
 
 """
     trace_state(io, op::GeneticOperator, mode::Symbol)

--- a/src/genetic_operators/mutation/mutation_clock.jl
+++ b/src/genetic_operators/mutation/mutation_clock.jl
@@ -17,7 +17,7 @@ end
 """
 Uniform mutation of a parameter vector.
 """
-immutable UniformMutation{SS<:SearchSpace} <: GibbsMutationOperator
+struct UniformMutation{SS<:SearchSpace} <: GibbsMutationOperator
     ss::SS
 
     (::Type{UniformMutation}){SS<:SearchSpace}(ss::SS) = new{SS}(ss)
@@ -36,7 +36,7 @@ mutation. This is based on the paper:
     Deb and Deb (2012), "Analyzing Mutation Schemes for Real-Parameter Genetic Algorithms"
 but we use a Poisson distribution.
 """
-type MutationClock{S<:GibbsMutationOperator} <: MutationOperator
+mutable struct MutationClock{S<:GibbsMutationOperator} <: MutationOperator
     inner::S
     rate::Float64           # Probability to mutate a dimension
     nextVarToMutate::Int    # dimension index - 1

--- a/src/genetic_operators/mutation/mutation_clock.jl
+++ b/src/genetic_operators/mutation/mutation_clock.jl
@@ -1,8 +1,8 @@
 num_vars_to_next_mutation_point(probMutation) = ceil( Int, (-log(rand())) / probMutation)
 
 """
-    Provides `apply()` operator that mutates one specified dimension of a parameter
-    vector.
+Provides `apply()` operator that mutates one specified dimension of a parameter
+vector.
 """
 abstract type GibbsMutationOperator <: MutationOperator end
 
@@ -15,7 +15,7 @@ function apply!{T<:Real}(m::GibbsMutationOperator, params::AbstractVector{T}, ta
 end
 
 """
-    Uniform mutation of a parameter vector.
+Uniform mutation of a parameter vector.
 """
 immutable UniformMutation{SS<:SearchSpace} <: GibbsMutationOperator
     ss::SS
@@ -29,13 +29,12 @@ search_space(m::UniformMutation) = m.ss
     return (mins(m.ss)[dim] + rand() * deltas(m.ss)[dim])
 
 """
-  Mutation clock operator is a more efficient way to mutate vectors than to generate
-  a random value per variable in the vectors. It instead generates the number of variables
-  to skip until the next mutation. Then it uses a sub-mutation operator to do the actual
-  mutation. This is based on the paper:
-
+Mutation clock operator is a more efficient way to mutate vectors than to generate
+a random value per variable in the vectors. It instead generates the number of variables
+to skip until the next mutation. Then it uses a sub-mutation operator to do the actual
+mutation. This is based on the paper:
     Deb and Deb (2012), "Analyzing Mutation Schemes for Real-Parameter Genetic Algorithms"
-  but we use a Poisson distribution.
+but we use a Poisson distribution.
 """
 type MutationClock{S<:GibbsMutationOperator} <: MutationOperator
     inner::S

--- a/src/genetic_operators/mutation/mutation_clock.jl
+++ b/src/genetic_operators/mutation/mutation_clock.jl
@@ -20,7 +20,7 @@ Uniform mutation of a parameter vector.
 struct UniformMutation{SS<:SearchSpace} <: GibbsMutationOperator
     ss::SS
 
-    (::Type{UniformMutation}){SS<:SearchSpace}(ss::SS) = new{SS}(ss)
+    UniformMutation(ss::SS) where {SS<:SearchSpace} = new{SS}(ss)
 end
 
 search_space(m::UniformMutation) = m.ss
@@ -41,7 +41,7 @@ mutable struct MutationClock{S<:GibbsMutationOperator} <: MutationOperator
     rate::Float64           # Probability to mutate a dimension
     nextVarToMutate::Int    # dimension index - 1
 
-    (::Type{MutationClock}){S<:GibbsMutationOperator}(inner::S, rate::Float64 = 0.05) =
+    MutationClock(inner::S, rate::Float64 = 0.05) where {S<:GibbsMutationOperator} =
         new{S}(inner, rate, 1 + num_vars_to_next_mutation_point(rate))
 end
 

--- a/src/genetic_operators/mutation/mutation_clock.jl
+++ b/src/genetic_operators/mutation/mutation_clock.jl
@@ -4,7 +4,7 @@ num_vars_to_next_mutation_point(probMutation) = ceil( Int, (-log(rand())) / prob
     Provides `apply()` operator that mutates one specified dimension of a parameter
     vector.
 """
-@compat abstract type GibbsMutationOperator <: MutationOperator end
+abstract type GibbsMutationOperator <: MutationOperator end
 
 # apply operator to each dimension
 function apply!{T<:Real}(m::GibbsMutationOperator, params::AbstractVector{T}, target_index::Int)

--- a/src/genetic_operators/mutation/mutation_clock.jl
+++ b/src/genetic_operators/mutation/mutation_clock.jl
@@ -7,7 +7,7 @@ vector.
 abstract type GibbsMutationOperator <: MutationOperator end
 
 # apply operator to each dimension
-function apply!{T<:Real}(m::GibbsMutationOperator, params::AbstractVector{T}, target_index::Int)
+function apply!(m::GibbsMutationOperator, params::AbstractVector{<:Real}, target_index::Int)
     @inbounds @simd for i in eachindex(params)
         params[i] = apply(m, params[i], i, target_index)
     end
@@ -45,7 +45,7 @@ mutable struct MutationClock{S<:GibbsMutationOperator} <: MutationOperator
         new{S}(inner, rate, 1 + num_vars_to_next_mutation_point(rate))
 end
 
-function apply!{T<:Real}(mc::MutationClock, v::AbstractVector{T}, target_index::Int)
+function apply!(mc::MutationClock, v::AbstractVector{<:Real}, target_index::Int)
     n = length(v)
     i = mc.nextVarToMutate
     @inbounds while i <= n

--- a/src/genetic_operators/mutation/polynomial_mutation.jl
+++ b/src/genetic_operators/mutation/polynomial_mutation.jl
@@ -2,7 +2,7 @@
 Polynomial mutation as presented in the paper:
     Deb and Deb (2012), "Analyzing Mutation Schemes for Real-Parameter Genetic Algorithms"
 """
-immutable PolynomialMutation{SS<:SearchSpace} <: GibbsMutationOperator
+struct PolynomialMutation{SS<:SearchSpace} <: GibbsMutationOperator
     ss::SS
     η::Float64
 

--- a/src/genetic_operators/mutation/polynomial_mutation.jl
+++ b/src/genetic_operators/mutation/polynomial_mutation.jl
@@ -1,5 +1,5 @@
 """
-  Polynomial mutation as presented in the paper:
+Polynomial mutation as presented in the paper:
     Deb and Deb (2012), "Analyzing Mutation Schemes for Real-Parameter Genetic Algorithms"
 """
 immutable PolynomialMutation{SS<:SearchSpace} <: GibbsMutationOperator
@@ -11,7 +11,7 @@ immutable PolynomialMutation{SS<:SearchSpace} <: GibbsMutationOperator
 end
 
 """
-   Default parameters for `PolynomialMutation`.
+Default parameters for `PolynomialMutation`.
 """
 const PM_DefaultOptions = ParamsDict(
   :PM_η => 50.0,

--- a/src/genetic_operators/mutation/polynomial_mutation.jl
+++ b/src/genetic_operators/mutation/polynomial_mutation.jl
@@ -7,14 +7,15 @@ immutable PolynomialMutation{SS<:SearchSpace} <: GibbsMutationOperator
     η::Float64
 
     (::Type{PolynomialMutation}){SS<:SearchSpace}(ss::SS, η = 50.0) = new{SS}(ss, η)
-    (::Type{PolynomialMutation}){SS<:SearchSpace}(ss::SS, options::Parameters) = new{SS}(ss, options[:PM_η])
+    (::Type{PolynomialMutation}){SS<:SearchSpace}(ss::SS, options::Parameters) =
+        new{SS}(ss, options[:PM_η])
 end
 
 """
 Default parameters for `PolynomialMutation`.
 """
 const PM_DefaultOptions = ParamsDict(
-  :PM_η => 50.0,
+    :PM_η => 50.0,
 )
 
 function apply(m::PolynomialMutation, v::Number, dim::Int, target_index::Int)

--- a/src/genetic_operators/mutation/polynomial_mutation.jl
+++ b/src/genetic_operators/mutation/polynomial_mutation.jl
@@ -6,8 +6,8 @@ struct PolynomialMutation{SS<:SearchSpace} <: GibbsMutationOperator
     ss::SS
     η::Float64
 
-    (::Type{PolynomialMutation}){SS<:SearchSpace}(ss::SS, η = 50.0) = new{SS}(ss, η)
-    (::Type{PolynomialMutation}){SS<:SearchSpace}(ss::SS, options::Parameters) =
+    PolynomialMutation(ss::SS, η = 50.0) where {SS<:SearchSpace} = new{SS}(ss, η)
+    PolynomialMutation(ss::SS, options::Parameters) where {SS<:SearchSpace} =
         new{SS}(ss, options[:PM_η])
 end
 

--- a/src/genetic_operators/operator_pipeline.jl
+++ b/src/genetic_operators/operator_pipeline.jl
@@ -1,7 +1,7 @@
 """
 Several genetic operators chained together.
 """
-type OperatorPipeline <: GeneticOperator
+struct OperatorPipeline <: GeneticOperator
     ops::Vector{GeneticOperator}
 
     function OperatorPipeline(operators...)

--- a/src/genetic_operators/operator_pipeline.jl
+++ b/src/genetic_operators/operator_pipeline.jl
@@ -10,7 +10,7 @@ struct OperatorPipeline <: GeneticOperator
     end
 end
 
-function apply{T <: Real}(p::OperatorPipeline, parents::Vector{Vector{T}})
+function apply(p::OperatorPipeline, parents::Vector{Vector{<:Real}})
     for i in 1:length(p.ops)
         parents = apply(p.ops[i], parents)
     end

--- a/src/genetic_operators/operator_pipeline.jl
+++ b/src/genetic_operators/operator_pipeline.jl
@@ -1,5 +1,6 @@
-# Several genetic operators can be chained together.
-
+"""
+Several genetic operators chained together.
+"""
 type OperatorPipeline <: GeneticOperator
   ops::Vector{GeneticOperator}
   OperatorPipeline(operators...) = begin

--- a/src/genetic_operators/operator_pipeline.jl
+++ b/src/genetic_operators/operator_pipeline.jl
@@ -2,20 +2,19 @@
 Several genetic operators chained together.
 """
 type OperatorPipeline <: GeneticOperator
-  ops::Vector{GeneticOperator}
-  OperatorPipeline(operators...) = begin
-    if !ensure_nargs_match(operators)
-      throw("The number of ")
+    ops::Vector{GeneticOperator}
+
+    function OperatorPipeline(operators...)
+        ensure_nargs_match(operators) || throw("The number of ")
+        new(operators)
     end
-    new(operators)
-  end
 end
 
 function apply{T <: Real}(p::OperatorPipeline, parents::Vector{Vector{T}})
-  for i in 1:length(p.ops)
-    parents = apply(p.ops[i], parents)
-  end
-  parents
+    for i in 1:length(p.ops)
+        parents = apply(p.ops[i], parents)
+    end
+    return parents
 end
 
 match(o1::GeneticOperator, o2::GeneticOperator) = numchildren(o1) == numparents(o2)
@@ -23,10 +22,8 @@ match(o1::GeneticOperator, o2::GeneticOperator) = numchildren(o1) == numparents(
 match(o1::GeneticOperator, o2::MutationOperator) = true
 
 function ensure_nargs_match(operators)
-  for i in 1:(length(operators)-1)
-    if !match(operators[i], operators[i+1])
-      return false
+    for i in 1:(length(operators)-1)
+        match(operators[i], operators[i+1]) || return false
     end
-  end
-  true
+    return true
 end

--- a/src/genetic_operators/operator_pipeline.jl
+++ b/src/genetic_operators/operator_pipeline.jl
@@ -10,7 +10,7 @@ struct OperatorPipeline <: GeneticOperator
     end
 end
 
-function apply(p::OperatorPipeline, parents::Vector{Vector{<:Real}})
+function apply(p::OperatorPipeline, parents::AbstractVector{<:AbstractVector{<:Real}})
     for i in 1:length(p.ops)
         parents = apply(p.ops[i], parents)
     end

--- a/src/genetic_operators/operators_mixture.jl
+++ b/src/genetic_operators/operators_mixture.jl
@@ -18,14 +18,15 @@ end
 """
 Default implementation of `apply!()` for operators mixture.
 """
-function apply!{T<:Real}(opmix::GeneticOperatorsMixture, v::Vector{T}, target_index::Int)
-  op, tag = next(opmix)
-  apply!(op, v, target_index)
+function apply!{T<:Real}(opmix::GeneticOperatorsMixture,
+                         v::Vector{T}, target_index::Int)
+    op, tag = next(opmix)
+    apply!(op, v, target_index)
 end
 
 function Base.next(opmix::FixedGeneticOperatorsMixture)
-  i = sample(1:length(opmix.operators), opmix.weights)
-  return opmix.operators[i], i
+    i = sample(1:length(opmix.operators), opmix.weights)
+    return opmix.operators[i], i
 end
 
 """
@@ -35,29 +36,29 @@ type FAGeneticOperatorsMixture <: GeneticOperatorsMixture
     operators::Vector{GeneticOperator} # available operators
     fa::FrequencyAdapter               # adapter of operator frequencies
 
-    function FAGeneticOperatorsMixture{GO<:GeneticOperator}(
+    FAGeneticOperatorsMixture{GO<:GeneticOperator}(
         operators::AbstractVector{GO};
         c = 1E-2, eta = 1E-2, pmin = 0.01, pmax = 1.0
-    )
-      new(GeneticOperator[op for op in operators],
-          FrequencyAdapter(length(operators); c = c, eta = eta, pmin = pmin, pmax = pmax))
-    end
+    ) = new(GeneticOperator[op for op in operators],
+            FrequencyAdapter(length(operators);
+                             c = c, eta = eta, pmin = pmin, pmax = pmax))
 end
 
 frequencies(opmix::FAGeneticOperatorsMixture) = frequencies(opmix.fa)
 
 function Base.next(opmix::FAGeneticOperatorsMixture)
-  i = next(opmix.fa)
-  return opmix.operators[i], i
+    i = next(opmix.fa)
+    return opmix.operators[i], i
 end
 
-function adjust!{F}(opmix::FAGeneticOperatorsMixture, op_index::Int, candi_index::Int, new_fitness::F, old_fitness::F, is_improved::Bool)
-  # KLUDGE we don't know the fitness scheme, but if there is no improvement in fitness,
-  # new_fitness==old_fitness, so it's ok to take the abs()
-  update!(opmix.fa, op_index, is_improved ? abs(new_fitness-old_fitness) : 0.0)
+function adjust!{F}(opmix::FAGeneticOperatorsMixture, op_index::Int, candi_index::Int,
+                    new_fitness::F, old_fitness::F, is_improved::Bool)
+    # KLUDGE we don't know the fitness scheme, but if there is no improvement in fitness,
+    # new_fitness==old_fitness, so it's ok to take the abs()
+    update!(opmix.fa, op_index, is_improved ? abs(new_fitness-old_fitness) : 0.0)
 
-  # also adjust the actual operator
-  adjust!(opmix.operators[op_index], 0, candi_index, new_fitness, old_fitness, is_improved)
+    # also adjust the actual operator
+    adjust!(opmix.operators[op_index], 0, candi_index, new_fitness, old_fitness, is_improved)
 end
 
 function trace_state(io::IO, fa::FAGeneticOperatorsMixture, mode::Symbol)

--- a/src/genetic_operators/operators_mixture.jl
+++ b/src/genetic_operators/operators_mixture.jl
@@ -19,8 +19,8 @@ end
 """
 Default implementation of `apply!()` for operators mixture.
 """
-function apply!{T<:Real}(opmix::GeneticOperatorsMixture,
-                         v::Vector{T}, target_index::Int)
+function apply!(opmix::GeneticOperatorsMixture,
+                v::Vector{<:Real}, target_index::Int)
     op, tag = next(opmix)
     apply!(op, v, target_index)
 end
@@ -52,8 +52,8 @@ function Base.next(opmix::FAGeneticOperatorsMixture)
     return opmix.operators[i], i
 end
 
-function adjust!{F}(opmix::FAGeneticOperatorsMixture, op_index::Int, candi_index::Int,
-                    new_fitness::F, old_fitness::F, is_improved::Bool)
+function adjust!(opmix::FAGeneticOperatorsMixture, op_index::Int, candi_index::Int,
+                 new_fitness::F, old_fitness::F, is_improved::Bool) where F
     # KLUDGE we don't know the fitness scheme, but if there is no improvement in fitness,
     # new_fitness==old_fitness, so it's ok to take the abs()
     update!(opmix.fa, op_index, is_improved ? abs(new_fitness-old_fitness) : 0.0)

--- a/src/genetic_operators/operators_mixture.jl
+++ b/src/genetic_operators/operators_mixture.jl
@@ -2,7 +2,7 @@
 Randomly selects the genetic operator from the vector
 according to its weight and applies it.
 """
-type FixedGeneticOperatorsMixture <: GeneticOperatorsMixture
+struct FixedGeneticOperatorsMixture <: GeneticOperatorsMixture
     operators::Vector{GeneticOperator} # available operations
     weights::Weights{Float64, Float64, Vector{Float64}}  # fixed weights
 
@@ -32,7 +32,7 @@ end
 """
 Frequency-adapting genetic operators mixture.
 """
-type FAGeneticOperatorsMixture <: GeneticOperatorsMixture
+struct FAGeneticOperatorsMixture <: GeneticOperatorsMixture
     operators::Vector{GeneticOperator} # available operators
     fa::FrequencyAdapter               # adapter of operator frequencies
 

--- a/src/genetic_operators/operators_mixture.jl
+++ b/src/genetic_operators/operators_mixture.jl
@@ -20,7 +20,7 @@ end
 Default implementation of `apply!()` for operators mixture.
 """
 function apply!(opmix::GeneticOperatorsMixture,
-                v::Vector{<:Real}, target_index::Int)
+                v::AbstractVector{<:Real}, target_index::Int)
     op, tag = next(opmix)
     apply!(op, v, target_index)
 end

--- a/src/genetic_operators/operators_mixture.jl
+++ b/src/genetic_operators/operators_mixture.jl
@@ -1,6 +1,6 @@
 """
-  Randomly selects the genetic operator from the vector
-  according to its weight and applies it.
+Randomly selects the genetic operator from the vector
+according to its weight and applies it.
 """
 type FixedGeneticOperatorsMixture <: GeneticOperatorsMixture
     operators::Vector{GeneticOperator} # available operations
@@ -16,7 +16,7 @@ type FixedGeneticOperatorsMixture <: GeneticOperatorsMixture
 end
 
 """
-  Default implementation of `apply!()` for operators mixture.
+Default implementation of `apply!()` for operators mixture.
 """
 function apply!{T<:Real}(opmix::GeneticOperatorsMixture, v::Vector{T}, target_index::Int)
   op, tag = next(opmix)
@@ -29,7 +29,7 @@ function Base.next(opmix::FixedGeneticOperatorsMixture)
 end
 
 """
-  Frequency-adapting genetic operators mixture.
+Frequency-adapting genetic operators mixture.
 """
 type FAGeneticOperatorsMixture <: GeneticOperatorsMixture
     operators::Vector{GeneticOperator} # available operators

--- a/src/genetic_operators/operators_mixture.jl
+++ b/src/genetic_operators/operators_mixture.jl
@@ -6,12 +6,13 @@ struct FixedGeneticOperatorsMixture <: GeneticOperatorsMixture
     operators::Vector{GeneticOperator} # available operations
     weights::Weights{Float64, Float64, Vector{Float64}}  # fixed weights
 
-    function FixedGeneticOperatorsMixture{GO<:GeneticOperator}(
-        operators::AbstractVector{GO},
+    function FixedGeneticOperatorsMixture(
+        operators::AbstractVector{<:GeneticOperator},
         rates::AbstractVector{Float64} = fill(1.0/length(operators), length(operators)) # defaults to uniform distribution of rates
     )
-      length(operators) == length(rates) || throw(DimensionMismatch("Number of mutators does not match the number of their rates"))
-      new(GeneticOperator[op for op in operators], weights(rates))
+        length(operators) == length(rates) ||
+            throw(DimensionMismatch("Number of mutators does not match the number of their rates"))
+        new(GeneticOperator[op for op in operators], weights(rates))
     end
 end
 
@@ -36,8 +37,8 @@ struct FAGeneticOperatorsMixture <: GeneticOperatorsMixture
     operators::Vector{GeneticOperator} # available operators
     fa::FrequencyAdapter               # adapter of operator frequencies
 
-    FAGeneticOperatorsMixture{GO<:GeneticOperator}(
-        operators::AbstractVector{GO};
+    FAGeneticOperatorsMixture(
+        operators::AbstractVector{<:GeneticOperator};
         c = 1E-2, eta = 1E-2, pmin = 0.01, pmax = 1.0
     ) = new(GeneticOperator[op for op in operators],
             FrequencyAdapter(length(operators);

--- a/src/genetic_operators/selector/radius_limited.jl
+++ b/src/genetic_operators/selector/radius_limited.jl
@@ -13,7 +13,7 @@ The original paper is:
     and B. Worzel, pp. 109-124. Boston, MA: Kluwer Academic Publishers.
     http://faculty.hampshire.edu/lspector/pubs/trivial-geography-toappear.pdf
 """
-immutable RadiusLimitedSelector <: IndividualsSelector
+mutable struct RadiusLimitedSelector <: IndividualsSelector
     radius::Int
 end
 

--- a/src/genetic_operators/selector/radius_limited.jl
+++ b/src/genetic_operators/selector/radius_limited.jl
@@ -25,5 +25,5 @@ function select(sel::RadiusLimitedSelector, population, numSamples::Int)
     deme_start = rand(1:psize)
     ixs = rand_indexes(deme_start:(deme_start+radius-1), numSamples)
     # Ensure they are not out of bounds by wrapping over at the end.
-    map!(ix -> mod1(ix, psize), ixs, ixs)
+    ixs .= mod1.(ixs, psize)
 end

--- a/src/genetic_operators/selector/radius_limited.jl
+++ b/src/genetic_operators/selector/radius_limited.jl
@@ -1,13 +1,13 @@
 """
-  `IndividualsSelector` that implements a "trivial geography" similar to Spector and Kline (2006)
-  by first sampling an individual randomly and then selecting additional
-  individuals for the same tournament within a certain deme of limited size (`radius`)
-  for the sub-sequent individuals in the population.
+`IndividualsSelector` that implements a "trivial geography" similar to Spector and Kline (2006)
+by first sampling an individual randomly and then selecting additional
+individuals for the same tournament within a certain deme of limited size (`radius`)
+for the sub-sequent individuals in the population.
 
-  The version we implement here is from:
+The version we implement here is from:
     I. Harvey, "The Microbial Genetic Algorithm", in Advances in Artificial Life
     Darwin Meets von Neumann, Springer, 2011.
-  The original paper is:
+The original paper is:
     Spector, L., and J. Klein. 2005. Trivial Geography in Genetic Programming.
     In Genetic Programming Theory and Practice III, edited by T. Yu, R.L. Riolo,
     and B. Worzel, pp. 109-124. Boston, MA: Kluwer Academic Publishers.

--- a/src/genetic_operators/selector/simple.jl
+++ b/src/genetic_operators/selector/simple.jl
@@ -3,7 +3,7 @@ Simple random `IndividualsSelector`.
 
 The probabilties of all candidates are equal.
 """
-immutable SimpleSelector <: IndividualsSelector
+struct SimpleSelector <: IndividualsSelector
 end
 
 select(::SimpleSelector, population, numSamples::Int) =

--- a/src/genetic_operators/selector/simple.jl
+++ b/src/genetic_operators/selector/simple.jl
@@ -1,7 +1,7 @@
 """
-  Simple random `IndividualsSelector`.
+Simple random `IndividualsSelector`.
 
-  The probabilties of all candidates are equal.
+The probabilties of all candidates are equal.
 """
 immutable SimpleSelector <: IndividualsSelector
 end

--- a/src/genetic_operators/selector/tournament.jl
+++ b/src/genetic_operators/selector/tournament.jl
@@ -1,5 +1,5 @@
 """
-  Tournament selector.
+Tournament selector.
 """
 type TournamentSelector{H} <: IndividualsSelector
     hat_comp::H     # fitness comparison tri-valued operator
@@ -26,9 +26,9 @@ function select(sel::TournamentSelector, population, n_tours::Int)
 end
 
 """
-    Simulate tournament among specified `candidates`.
+Simulate tournament among specified `candidates`.
 
-    Returns the index of the winner.
+Returns the index of the winner.
 """
 function tournament(sel::TournamentSelector, population, candidates)
     if isempty(candidates)

--- a/src/genetic_operators/selector/tournament.jl
+++ b/src/genetic_operators/selector/tournament.jl
@@ -31,9 +31,7 @@ Simulate tournament among specified `candidates`.
 Returns the index of the winner.
 """
 function tournament(sel::TournamentSelector, population, candidates)
-    if isempty(candidates)
-        return 0
-    end
+    isempty(candidates) && return 0
     @inbounds begin
         winner_ix = candidates[1]
         best_fitness = fitness(population, winner_ix)

--- a/src/genetic_operators/selector/tournament.jl
+++ b/src/genetic_operators/selector/tournament.jl
@@ -4,11 +4,11 @@ Tournament selector.
 mutable struct TournamentSelector{H} <: IndividualsSelector
     hat_comp::H     # fitness comparison tri-valued operator
     size::Int       # tournament size
+end
 
-    function (::Type{TournamentSelector}){FS}(fs::FS, size::Int=2)
-        h = HatCompare(fs)
-        new{typeof(h)}(h, size)
-    end
+function TournamentSelector(fs::FitnessScheme, size::Int=2)
+    h = HatCompare(fs)
+    TournamentSelector{typeof(h)}(h, size)
 end
 
 # selection using `n_tours` tournaments

--- a/src/genetic_operators/selector/tournament.jl
+++ b/src/genetic_operators/selector/tournament.jl
@@ -1,7 +1,7 @@
 """
 Tournament selector.
 """
-type TournamentSelector{H} <: IndividualsSelector
+mutable struct TournamentSelector{H} <: IndividualsSelector
     hat_comp::H     # fitness comparison tri-valued operator
     size::Int       # tournament size
 

--- a/src/natural_evolution_strategies.jl
+++ b/src/natural_evolution_strategies.jl
@@ -313,8 +313,8 @@ end
 Calculate the `n`-dimensional fitness shaping utilities vector using the "log" method.
 """
 function fitness_shaping_utilities_log(n::Int)
-    u = [max(0.0, log(n / 2 + 1.0) - log(i)) for i in 1:n]
-    return u/sum(u) - 1/n
+    u = max.(0.0, log(n / 2 + 1.0) - log.(1:n))
+    return u./sum(u) - 1/n
 end
 
 """
@@ -326,7 +326,7 @@ using the "steps" method.
 function fitness_shaping_utilities_linear(n::Int)
     # Second half has zero utility.
     treshold = floor(Int, n/2)
-    second_half = zeros(n - treshold)
+    second_half = fill(0.0, n - treshold)
 
     # While first half's utility decreases in linear steps
     step_size = 1 / treshold
@@ -334,5 +334,5 @@ function fitness_shaping_utilities_linear(n::Int)
 
     # But the utilities should sum to 0, so we normalize and return
     u = vcat(first_half, second_half)
-    return u/sum(u) - 1/n
+    return u./sum(u) - 1/n
 end

--- a/src/natural_evolution_strategies.jl
+++ b/src/natural_evolution_strategies.jl
@@ -3,7 +3,7 @@ abstract type NaturalEvolutionStrategyOpt <: PopulationOptimizer end
 """
 Separable Natural Evolution Strategy (sNES) optimizer.
 """
-type SeparableNESOpt{F,E<:EmbeddingOperator} <: NaturalEvolutionStrategyOpt
+mutable struct SeparableNESOpt{F,E<:EmbeddingOperator} <: NaturalEvolutionStrategyOpt
     embed::E                        # operator embedding into the search space
     lambda::Int                     # number of samples to take per iteration
     mu::Vector{Float64}             # center of the population
@@ -212,7 +212,7 @@ end
 
 Nice but scales badly with increasing dimensions.
 """
-type XNESOpt{F,E<:EmbeddingOperator} <: ExponentialNaturalEvolutionStrategyOpt
+mutable struct XNESOpt{F,E<:EmbeddingOperator} <: ExponentialNaturalEvolutionStrategyOpt
     embed::E                        # operator embedding into the search space
     lambda::Int                     # number of samples to take per iteration
     sortedUtilities::Vector{Float64}# the fitness shaping utility vector

--- a/src/natural_evolution_strategies.jl
+++ b/src/natural_evolution_strategies.jl
@@ -1,4 +1,4 @@
-@compat abstract type NaturalEvolutionStrategyOpt <: PopulationOptimizer end
+abstract type NaturalEvolutionStrategyOpt <: PopulationOptimizer end
 
 """
   Separable Natural Evolution Strategy (sNES) optimizer.
@@ -141,7 +141,7 @@ end
   ```
 where `B` is an exponential of some symmetric matrix `lnB`, `tr(lnB)==0.0`
 """
-@compat abstract type ExponentialNaturalEvolutionStrategyOpt <: NaturalEvolutionStrategyOpt end
+abstract type ExponentialNaturalEvolutionStrategyOpt <: NaturalEvolutionStrategyOpt end
 
 function update_candidates!(exnes::ExponentialNaturalEvolutionStrategyOpt, Z::Matrix)
   B = expm(exnes.ln_B)

--- a/src/natural_evolution_strategies.jl
+++ b/src/natural_evolution_strategies.jl
@@ -4,48 +4,50 @@ abstract type NaturalEvolutionStrategyOpt <: PopulationOptimizer end
 Separable Natural Evolution Strategy (sNES) optimizer.
 """
 type SeparableNESOpt{F,E<:EmbeddingOperator} <: NaturalEvolutionStrategyOpt
-  embed::E                        # operator embedding into the search space
-  lambda::Int                     # number of samples to take per iteration
-  mu::Vector{Float64}             # center of the population
-  sigma::Vector{Float64}          # average std deviation for sampling in position
-  distr::Distribution             # distribution to sample the step sizes from
-  mu_learnrate::Float64
-  sigma_learnrate::Float64
-  max_sigma::Float64
+    embed::E                        # operator embedding into the search space
+    lambda::Int                     # number of samples to take per iteration
+    mu::Vector{Float64}             # center of the population
+    sigma::Vector{Float64}          # average std deviation for sampling in position
+    distr::Distribution             # distribution to sample the step sizes from
+    mu_learnrate::Float64
+    sigma_learnrate::Float64
+    max_sigma::Float64
 
-  last_s::Matrix{Float64}         # `s` values sampled in the last call to `ask()`
-  candidates::Vector{Candidate{F}}# the last sampled values, now being evaluated
-  sortedUtilities::Vector{Float64}# the fitness shaping utility vector
-  tmp_Utilities::Vector{Float64}   # the fitness shaping utility vector sorted by current population fitness
+    last_s::Matrix{Float64}         # `s` values sampled in the last call to `ask()`
+    candidates::Vector{Candidate{F}}# the last sampled values, now being evaluated
+    sortedUtilities::Vector{Float64}# the fitness shaping utility vector
+    tmp_Utilities::Vector{Float64}   # the fitness shaping utility vector sorted by current population fitness
 
-  function SeparableNESOpt(embed::E;
-    lambda::Int = 0,
-    mu_learnrate::Float64 = 1.0,
-    sigma_learnrate::Float64 = 0.0,
-    ini_x = nothing, max_sigma::Float64 = 1.0E+10)
-    d = numdims(search_space(embed))
+    function SeparableNESOpt(
+            embed::E;
+            lambda::Int = 0,
+            mu_learnrate::Float64 = 1.0,
+            sigma_learnrate::Float64 = 0.0,
+            ini_x = nothing, max_sigma::Float64 = 1.0E+10
+    )
+        d = numdims(search_space(embed))
 
-    if lambda == 0
-      lambda = 4 + ceil(Int, log(3*d)) # default lambda
-    end
-    if sigma_learnrate == 0.0
-      sigma_learnrate = calc_sigma_learnrate_for_snes(d) # default sigma learn rate
-    end
-    if ini_x === nothing
-      ini_x = rand_individual(search_space(embed))
-    else
-      ini_x = copy(ini_x::Individual)
-    end
+        if lambda == 0
+            lambda = 4 + ceil(Int, log(3*d)) # default lambda
+        end
+        if sigma_learnrate == 0.0
+            sigma_learnrate = calc_sigma_learnrate_for_snes(d) # default sigma learn rate
+        end
+        if ini_x === nothing
+            ini_x = rand_individual(search_space(embed))
+        else
+            ini_x = copy(ini_x::Individual)
+        end
 
-    new(embed, lambda,
-      ini_x, ones(d),
-      Normal(0, 1),
-      mu_learnrate, sigma_learnrate, max_sigma,
-      zeros(d, lambda),
-      Candidate{F}[Candidate{F}(Individual(d), i) for i in 1:lambda],
-      # Most modern NES papers use log rather than linear fitness shaping.
-      fitness_shaping_utilities_log(lambda),
-      Vector{Float64}(lambda))
+        new(embed, lambda,
+            ini_x, ones(d),
+            Normal(0, 1),
+            mu_learnrate, sigma_learnrate, max_sigma,
+            zeros(d, lambda),
+            Candidate{F}[Candidate{F}(Individual(d), i) for i in 1:lambda],
+            # Most modern NES papers use log rather than linear fitness shaping.
+            fitness_shaping_utilities_log(lambda),
+            Vector{Float64}(lambda))
   end
 end
 
@@ -53,62 +55,62 @@ population(o::NaturalEvolutionStrategyOpt) = o.candidates
 numdims(o::NaturalEvolutionStrategyOpt) = numdims(search_space(o.embed))
 
 const NES_DefaultOptions = ParamsDict(
-  :lambda => 0,              # If 0 it will be set based on the number of dimensions
-  :ini_x => nothing,         # starting point, "nothing" generates random point in a search space
-  :mu_learnrate => 1.0,
-  :sigma_learnrate => 0.0,   # If 0.0 it will be set based on the number of dimensions
-  :max_sigma => 1.0E+10       # Maximal sigma
+    :lambda => 0,              # If 0 it will be set based on the number of dimensions
+    :ini_x => nothing,         # starting point, "nothing" generates random point in a search space
+    :mu_learnrate => 1.0,
+    :sigma_learnrate => 0.0,   # If 0.0 it will be set based on the number of dimensions
+    :max_sigma => 1.0E+10      # Maximal sigma
 )
 
 function separable_nes(problem::OptimizationProblem, parameters)
-  params = chain(NES_DefaultOptions, parameters)
-  embed = RandomBound(search_space(problem))
-  SeparableNESOpt{fitness_type(problem), typeof(embed)}(embed,
-    lambda = params[:lambda],
-    mu_learnrate = params[:mu_learnrate],
-    sigma_learnrate = params[:sigma_learnrate],
-    ini_x = params[:ini_x],
-    max_sigma = params[:max_sigma])
+    params = chain(NES_DefaultOptions, parameters)
+    embed = RandomBound(search_space(problem))
+    SeparableNESOpt{fitness_type(problem), typeof(embed)}(embed,
+        lambda = params[:lambda],
+        mu_learnrate = params[:mu_learnrate],
+        sigma_learnrate = params[:sigma_learnrate],
+        ini_x = params[:ini_x],
+        max_sigma = params[:max_sigma])
 end
 
 calc_sigma_learnrate_for_snes(d) = (3 + log(d)) / (5 * sqrt(d))
 calc_sigma_learnrate_for_nes(d) = (9 + 3 * log(d)) / (5 * d * sqrt(d))
 
 function ask(snes::SeparableNESOpt)
-  # Sample from N(0, 1)
-  randn!(snes.last_s)
+    # Sample from N(0, 1)
+    randn!(snes.last_s)
 
-  for i in eachindex(snes.candidates)
-    candi = snes.candidates[i]
-    candi.index = i # reset ordering
-    @inbounds for j in 1:length(candi.params)
-      candi.params[j] = snes.mu[j] + snes.sigma[j] * snes.last_s[j, i]
+    for i in eachindex(snes.candidates)
+        candi = snes.candidates[i]
+        candi.index = i # reset ordering
+        @inbounds for j in 1:length(candi.params)
+            candi.params[j] = snes.mu[j] + snes.sigma[j] * snes.last_s[j, i]
+        end
+        apply!(snes.embed, candi.params, snes.mu)
+        candi.fitness = NaN # FIXME: use nafitness()
     end
-    apply!(snes.embed, candi.params, snes.mu)
-    candi.fitness = NaN # FIXME: use nafitness()
-  end
 
-  return snes.candidates
+    return snes.candidates
 end
 
 function tell!{F}(snes::SeparableNESOpt{F}, rankedCandidates::Vector{Candidate{F}})
-  u = assign_weights!(snes.tmp_Utilities, rankedCandidates, snes.sortedUtilities)
+    u = assign_weights!(snes.tmp_Utilities, rankedCandidates, snes.sortedUtilities)
 
-  # Calc gradient
-  gradient_mu = snes.last_s * u
-  gradient_sigma = (snes.last_s.^2 - 1) * u
+    # Calc gradient
+    gradient_mu = snes.last_s * u
+    gradient_sigma = (snes.last_s.^2 - 1) * u
 
-  # Update the mean and sigma vectors based on the gradient
-  old_mu = copy(snes.mu)
-  snes.mu += snes.mu_learnrate * (snes.sigma .* gradient_mu)
-  @inbounds for i in eachindex(snes.sigma)
-      snes.sigma[i] = clamp(snes.sigma[i] * exp(0.5 * snes.sigma_learnrate * gradient_sigma[i]),
-                            0.0, snes.max_sigma)
-  end
-  apply!(snes.embed, snes.mu, old_mu)
+    # Update the mean and sigma vectors based on the gradient
+    old_mu = copy(snes.mu)
+    snes.mu += snes.mu_learnrate * (snes.sigma .* gradient_mu)
+    @inbounds for i in eachindex(snes.sigma)
+        snes.sigma[i] = clamp(snes.sigma[i] * exp(0.5 * snes.sigma_learnrate * gradient_sigma[i]),
+                              0.0, snes.max_sigma)
+    end
+    apply!(snes.embed, snes.mu, old_mu)
 
-  # There is no notion of how many was better in NES so return 0
-  return 0
+    # There is no notion of how many was better in NES so return 0
+    return 0
 end
 
 """
@@ -120,12 +122,14 @@ the corresponding weights.
 
 Returns candidate weights sorted by the individual's index in the population.
 """
-function assign_weights!{F}(weights::Vector{Float64}, rankedCandidates::Vector{Candidate{F}}, sortedWeights::Vector{Float64})
-  @assert length(weights) == length(sortedWeights) && length(rankedCandidates) == length(weights)
-  for i in eachindex(rankedCandidates)
-    weights[rankedCandidates[i].index] = sortedWeights[i]
-  end
-  return weights
+function assign_weights!{F}(weights::Vector{Float64},
+                            rankedCandidates::Vector{Candidate{F}},
+                            sortedWeights::Vector{Float64})
+    @assert length(weights) == length(sortedWeights) && length(rankedCandidates) == length(weights)
+    for i in eachindex(rankedCandidates)
+        weights[rankedCandidates[i].index] = sortedWeights[i]
+    end
+    return weights
 end
 
 #  Traces the current `sNES` optimization state.
@@ -144,51 +148,51 @@ where `B` is an exponential of some symmetric matrix `lnB`, `tr(lnB)==0.0`
 abstract type ExponentialNaturalEvolutionStrategyOpt <: NaturalEvolutionStrategyOpt end
 
 function update_candidates!(exnes::ExponentialNaturalEvolutionStrategyOpt, Z::Matrix)
-  B = expm(exnes.ln_B)
-  sBZ = A_mul_B!(exnes.tmp_sBZ, B, Z)
-  scale!(sBZ, exnes.sigma)
-  for i in eachindex(exnes.candidates)
-    candi = exnes.candidates[i]
-    candi.index = i # reset ordering
-    @inbounds for j in 1:length(candi.params)
-      candi.params[j] = exnes.x[j] + sBZ[j, i]
+    B = expm(exnes.ln_B)
+    sBZ = A_mul_B!(exnes.tmp_sBZ, B, Z)
+    scale!(sBZ, exnes.sigma)
+    for i in eachindex(exnes.candidates)
+        candi = exnes.candidates[i]
+        candi.index = i # reset ordering
+        @inbounds for j in 1:length(candi.params)
+            candi.params[j] = exnes.x[j] + sBZ[j, i]
+        end
+        apply!(exnes.embed, candi.params, exnes.x)
+        candi.fitness = NaN # FIXME: use nafitness()
     end
-    apply!(exnes.embed, candi.params, exnes.x)
-    candi.fitness = NaN # FIXME: use nafitness()
-  end
 
-  return exnes.candidates
+    return exnes.candidates
 end
 
 function update_parameters!(exnes::ExponentialNaturalEvolutionStrategyOpt, u::Vector)
-  # TODO use syrk(Z,dA) to speed-up multiplication
-  Zu = scale!(exnes.tmp_Zu, exnes.Z, u)
-  ln_dB = A_mul_Bt!(exnes.tmp_lndB, Zu, exnes.Z)
-  sumU = sum(u)
-  dSigma = 0.0
-  @inbounds for i in 1:size(ln_dB, 1)
-    ln_dB[i, i] -= sumU
-    dSigma += ln_dB[i, i]
-  end
-  dSigma /= size(ln_dB, 1)
-  @inbounds for i in 1:size(ln_dB, 1)
-    ln_dB[i, i] -= dSigma
-  end
-  scale!(ln_dB, 0.5 * exnes.B_learnrate)
+    # TODO use syrk(Z,dA) to speed-up multiplication
+    Zu = scale!(exnes.tmp_Zu, exnes.Z, u)
+    ln_dB = A_mul_Bt!(exnes.tmp_lndB, Zu, exnes.Z)
+    sumU = sum(u)
+    dSigma = 0.0
+    @inbounds for i in 1:size(ln_dB, 1)
+        ln_dB[i, i] -= sumU
+        dSigma += ln_dB[i, i]
+    end
+    dSigma /= size(ln_dB, 1)
+    @inbounds for i in 1:size(ln_dB, 1)
+        ln_dB[i, i] -= dSigma
+    end
+    scale!(ln_dB, 0.5 * exnes.B_learnrate)
 
-  prev_x = copy!(exnes.tmp_x, exnes.x)
-  dx = A_mul_B!(exnes.tmp_dx, exnes.tmp_sBZ, u)
-  scale!(dx, exnes.x_learnrate)
-  exnes.x += dx
-  apply!(exnes.embed, exnes.x, prev_x)
+    prev_x = copy!(exnes.tmp_x, exnes.x)
+    dx = A_mul_B!(exnes.tmp_dx, exnes.tmp_sBZ, u)
+    scale!(dx, exnes.x_learnrate)
+    exnes.x += dx
+    apply!(exnes.embed, exnes.x, prev_x)
 
-  exnes.ln_B += ln_dB
+    exnes.ln_B += ln_dB
 
-  new_sigma = exnes.sigma * exp(0.5 * exnes.sigma_learnrate * dSigma)
-  if isfinite(new_sigma) && new_sigma > 0
-    exnes.sigma = min(new_sigma, exnes.max_sigma)
-  end
-  exnes
+    new_sigma = exnes.sigma * exp(0.5 * exnes.sigma_learnrate * dSigma)
+    if isfinite(new_sigma) && new_sigma > 0
+        exnes.sigma = min(new_sigma, exnes.max_sigma)
+    end
+    return exnes
 end
 
 " Identity for generic search space "
@@ -198,9 +202,9 @@ ini_xnes_B(ss::SearchSpace) = eye(numdims(ss), numdims(ss))
 Calculates the initial ``log B`` matrix for `xNES` based on the deltas of each dimension.
 """
 function ini_xnes_B(ss::RangePerDimSearchSpace)
-  diag = map(log, deltas(ss))
-  diag -= mean(diag)
-  return full(Diagonal(diag))
+    diag = map(log, deltas(ss))
+    diag -= mean(diag)
+    return full(Diagonal(diag))
 end
 
 """
@@ -209,73 +213,73 @@ end
 Nice but scales badly with increasing dimensions.
 """
 type XNESOpt{F,E<:EmbeddingOperator} <: ExponentialNaturalEvolutionStrategyOpt
-  embed::E                        # operator embedding into the search space
-  lambda::Int                     # number of samples to take per iteration
-  sortedUtilities::Vector{Float64}# the fitness shaping utility vector
-  tmp_Utilities::Vector{Float64}   # the fitness shaping utility vector sorted by current population fitness
-  x_learnrate::Float64
-  sigma_learnrate::Float64
-  B_learnrate::Float64
-  max_sigma::Float64
+    embed::E                        # operator embedding into the search space
+    lambda::Int                     # number of samples to take per iteration
+    sortedUtilities::Vector{Float64}# the fitness shaping utility vector
+    tmp_Utilities::Vector{Float64}   # the fitness shaping utility vector sorted by current population fitness
+    x_learnrate::Float64
+    sigma_learnrate::Float64
+    B_learnrate::Float64
+    max_sigma::Float64
 
-  # TODO use Symmetric{Float64} to improve exponent etc calculation
-  ln_B::Matrix{Float64}           # `log` of "covariation" matrix
-  sigma::Float64                  # step size
-  x::Individual                   # center of the population (aka most likely value, `mu` etc)
-  Z::Matrix{Float64}              # current `N(0,I)` samples
-  candidates::Vector{Candidate{F}}# the last sampled values, now being evaluated
+    # TODO use Symmetric{Float64} to improve exponent etc calculation
+    ln_B::Matrix{Float64}           # `log` of "covariation" matrix
+    sigma::Float64                  # step size
+    x::Individual                   # center of the population (aka most likely value, `mu` etc)
+    Z::Matrix{Float64}              # current `N(0,I)` samples
+    candidates::Vector{Candidate{F}}# the last sampled values, now being evaluated
 
-  # temporary variables to minimize GC overhead
-  tmp_x::Individual
-  tmp_dz::Individual
-  tmp_dx::Individual
-  tmp_lndB::Matrix{Float64}
-  tmp_Zu::Matrix{Float64}
-  tmp_sBZ::Matrix{Float64}
+    # temporary variables to minimize GC overhead
+    tmp_x::Individual
+    tmp_dz::Individual
+    tmp_dx::Individual
+    tmp_lndB::Matrix{Float64}
+    tmp_Zu::Matrix{Float64}
+    tmp_sBZ::Matrix{Float64}
 
-  function XNESOpt(embed::E; lambda::Int = 0, mu_learnrate::Float64 = 1.0,
+    function XNESOpt(embed::E; lambda::Int = 0, mu_learnrate::Float64 = 1.0,
                    sigma_learnrate = 0.0, B_learnrate::Float64 = 0.0,
                    ini_x = nothing, ini_sigma::Float64 = 1.0, ini_lnB = nothing,
                    max_sigma::Float64 = 1.0E+10)
-    d = numdims(search_space(embed))
-    if lambda == 0
-      lambda = 4 + 3*floor(Int, log(d))
-    end
-    if sigma_learnrate == 0.0
-      sigma_learnrate = 0.5 * min(1.0 / d, 0.25) # 0.6 * (3+log(d))/(d*sqrt(d)) in other literature
-    end
-    if B_learnrate == 0.0
-      B_learnrate = 0.6 * (3+log(d))/(d*sqrt(d)) # 0.5 * min(1.0 / d, 0.25)
-    end
-    if ini_x === nothing
-      ini_x = rand_individual(search_space(embed))
-    else
-      ini_x = copy(ini_x::Individual)
-      apply!(embed, ini_x, rand_individual(search_space(embed)))
-    end
+        d = numdims(search_space(embed))
+        if lambda == 0
+            lambda = 4 + 3*floor(Int, log(d))
+        end
+        if sigma_learnrate == 0.0
+            sigma_learnrate = 0.5 * min(1.0 / d, 0.25) # 0.6 * (3+log(d))/(d*sqrt(d)) in other literature
+        end
+        if B_learnrate == 0.0
+            B_learnrate = 0.6 * (3+log(d))/(d*sqrt(d)) # 0.5 * min(1.0 / d, 0.25)
+        end
+        if ini_x === nothing
+            ini_x = rand_individual(search_space(embed))
+        else
+            ini_x = copy(ini_x::Individual)
+            apply!(embed, ini_x, rand_individual(search_space(embed)))
+        end
 
-    new(embed, lambda, fitness_shaping_utilities_log(lambda), Vector{Float64}(lambda),
-      mu_learnrate, sigma_learnrate, B_learnrate, max_sigma,
-      ini_lnB === nothing ? ini_xnes_B(search_space(embed)) : ini_lnB, ini_sigma, ini_x, zeros(d, lambda),
-      Candidate{F}[Candidate{F}(Individual(d), i) for i in 1:lambda],
-      # temporaries
-      zeros(d), zeros(d), zeros(d),
-      zeros(d, d),
-      zeros(d, lambda), zeros(d, lambda)
-    )
-  end
+        new(embed, lambda, fitness_shaping_utilities_log(lambda), Vector{Float64}(lambda),
+            mu_learnrate, sigma_learnrate, B_learnrate, max_sigma,
+            ini_lnB === nothing ? ini_xnes_B(search_space(embed)) : ini_lnB, ini_sigma, ini_x, zeros(d, lambda),
+            Candidate{F}[Candidate{F}(Individual(d), i) for i in 1:lambda],
+            # temporaries
+            zeros(d), zeros(d), zeros(d),
+            zeros(d, d),
+            zeros(d, lambda), zeros(d, lambda)
+        )
+    end
 end
 
 const XNES_DefaultOptions = chain(NES_DefaultOptions, ParamsDict(
-  :B_learnrate => 0.0,   # If 0.0 it will be set based on the number of dimensions
-  :ini_sigma => 1.0,     # Initial sigma (step size)
-  :ini_lnB => nothing    # Initial log(B)
+    :B_learnrate => 0.0,   # If 0.0 it will be set based on the number of dimensions
+    :ini_sigma => 1.0,     # Initial sigma (step size)
+    :ini_lnB => nothing    # Initial log(B)
 ))
 
 function xnes(problem::OptimizationProblem, parameters)
-  params = chain(XNES_DefaultOptions, parameters)
-  embed = RandomBound(search_space(problem))
-  XNESOpt{fitness_type(problem), typeof(embed)}(embed; lambda = params[:lambda],
+    params = chain(XNES_DefaultOptions, parameters)
+    embed = RandomBound(search_space(problem))
+    XNESOpt{fitness_type(problem), typeof(embed)}(embed; lambda = params[:lambda],
                                                 mu_learnrate = params[:mu_learnrate],
                                                 sigma_learnrate = params[:sigma_learnrate],
                                                 B_learnrate = params[:B_learnrate],
@@ -286,15 +290,15 @@ function xnes(problem::OptimizationProblem, parameters)
 end
 
 function ask(xnes::XNESOpt)
-  randn!(xnes.Z)
-  update_candidates!(xnes, xnes.Z)
+    randn!(xnes.Z)
+    update_candidates!(xnes, xnes.Z)
 end
 
 function tell!{F}(xnes::XNESOpt{F}, rankedCandidates::Vector{Candidate{F}})
-  u = assign_weights!(xnes.tmp_Utilities, rankedCandidates, xnes.sortedUtilities)
+    u = assign_weights!(xnes.tmp_Utilities, rankedCandidates, xnes.sortedUtilities)
 
-  update_parameters!(xnes, u)
-  return 0
+    update_parameters!(xnes, u)
+    return 0
 end
 
 function trace_state(io::IO, xnes::XNESOpt, mode::Symbol)
@@ -308,8 +312,8 @@ end
 Calculate the `n`-dimensional fitness shaping utilities vector using the "log" method.
 """
 function fitness_shaping_utilities_log(n::Int)
-  u = [max(0.0, log(n / 2 + 1.0) - log(i)) for i in 1:n]
-  u/sum(u) - 1/n
+    u = [max(0.0, log(n / 2 + 1.0) - log(i)) for i in 1:n]
+    return u/sum(u) - 1/n
 end
 
 """
@@ -319,15 +323,15 @@ Calculate the `n`-dimensional fitness shaping utilities vector
 using the "steps" method.
 """
 function fitness_shaping_utilities_linear(n::Int)
-  # Second half has zero utility.
-  treshold = floor(Int, n/2)
-  second_half = zeros(n - treshold)
+    # Second half has zero utility.
+    treshold = floor(Int, n/2)
+    second_half = zeros(n - treshold)
 
-  # While first half's utility decreases in linear steps
-  step_size = 1 / treshold
-  first_half = linspace(1.0, step_size, treshold)
+    # While first half's utility decreases in linear steps
+    step_size = 1 / treshold
+    first_half = linspace(1.0, step_size, treshold)
 
-  # But the utilities should sum to 0, so we normalize and return
-  u = vcat(first_half, second_half)
-  u/sum(u) - 1/n
+    # But the utilities should sum to 0, so we normalize and return
+    u = vcat(first_half, second_half)
+    return u/sum(u) - 1/n
 end

--- a/src/natural_evolution_strategies.jl
+++ b/src/natural_evolution_strategies.jl
@@ -93,7 +93,7 @@ function ask(snes::SeparableNESOpt)
     return snes.candidates
 end
 
-function tell!(snes::SeparableNESOpt{F}, rankedCandidates::Vector{Candidate{F}}) where F
+function tell!(snes::SeparableNESOpt{F}, rankedCandidates::AbstractVector{<:Candidate{F}}) where F
     u = assign_weights!(snes.tmp_Utilities, rankedCandidates, snes.sortedUtilities)
 
     # Calc gradient
@@ -123,7 +123,7 @@ the corresponding weights.
 Returns candidate weights sorted by the individual's index in the population.
 """
 function assign_weights!(weights::Vector{Float64},
-                         rankedCandidates::Vector{<:Candidate},
+                         rankedCandidates::AbstractVector{<:Candidate},
                          sortedWeights::Vector{Float64})
     @assert length(weights) == length(sortedWeights) && length(rankedCandidates) == length(weights)
     for i in eachindex(rankedCandidates)
@@ -164,7 +164,7 @@ function update_candidates!(exnes::ExponentialNaturalEvolutionStrategyOpt, Z::Ma
     return exnes.candidates
 end
 
-function update_parameters!(exnes::ExponentialNaturalEvolutionStrategyOpt, u::Vector)
+function update_parameters!(exnes::ExponentialNaturalEvolutionStrategyOpt, u::AbstractVector)
     # TODO use syrk(Z,dA) to speed-up multiplication
     Zu = scale!(exnes.tmp_Zu, exnes.Z, u)
     ln_dB = A_mul_Bt!(exnes.tmp_lndB, Zu, exnes.Z)

--- a/src/natural_evolution_strategies.jl
+++ b/src/natural_evolution_strategies.jl
@@ -93,7 +93,7 @@ function ask(snes::SeparableNESOpt)
     return snes.candidates
 end
 
-function tell!{F}(snes::SeparableNESOpt{F}, rankedCandidates::Vector{Candidate{F}})
+function tell!(snes::SeparableNESOpt{F}, rankedCandidates::Vector{Candidate{F}}) where F
     u = assign_weights!(snes.tmp_Utilities, rankedCandidates, snes.sortedUtilities)
 
     # Calc gradient
@@ -122,9 +122,9 @@ the corresponding weights.
 
 Returns candidate weights sorted by the individual's index in the population.
 """
-function assign_weights!{F}(weights::Vector{Float64},
-                            rankedCandidates::Vector{Candidate{F}},
-                            sortedWeights::Vector{Float64})
+function assign_weights!(weights::Vector{Float64},
+                         rankedCandidates::Vector{<:Candidate},
+                         sortedWeights::Vector{Float64})
     @assert length(weights) == length(sortedWeights) && length(rankedCandidates) == length(weights)
     for i in eachindex(rankedCandidates)
         weights[rankedCandidates[i].index] = sortedWeights[i]
@@ -295,7 +295,7 @@ function ask(xnes::XNESOpt)
     update_candidates!(xnes, xnes.Z)
 end
 
-function tell!{F}(xnes::XNESOpt{F}, rankedCandidates::Vector{Candidate{F}})
+function tell!(xnes::XNESOpt{F}, rankedCandidates::Vector{Candidate{F}}) where F
     u = assign_weights!(xnes.tmp_Utilities, rankedCandidates, xnes.sortedUtilities)
 
     update_parameters!(xnes, u)

--- a/src/natural_evolution_strategies.jl
+++ b/src/natural_evolution_strategies.jl
@@ -1,7 +1,7 @@
 abstract type NaturalEvolutionStrategyOpt <: PopulationOptimizer end
 
 """
-  Separable Natural Evolution Strategy (sNES) optimizer.
+Separable Natural Evolution Strategy (sNES) optimizer.
 """
 type SeparableNESOpt{F,E<:EmbeddingOperator} <: NaturalEvolutionStrategyOpt
   embed::E                        # operator embedding into the search space
@@ -112,13 +112,13 @@ function tell!{F}(snes::SeparableNESOpt{F}, rankedCandidates::Vector{Candidate{F
 end
 
 """
-  `assign_weights!(weights, rankedCandidates, sortedWeights)`
+    assign_weights!(weights, rankedCandidates, sortedWeights)
 
-  Assigns the candidate `weights` according to the candidate index.
-  `rankedCandidates` are ranked by their fitness, `sortedWeights` are
-  the corresponding weights.
+Assigns the candidate `weights` according to the candidate index.
+`rankedCandidates` are ranked by their fitness, `sortedWeights` are
+the corresponding weights.
 
-  Returns candidate weights sorted by the individual's index in the population.
+Returns candidate weights sorted by the individual's index in the population.
 """
 function assign_weights!{F}(weights::Vector{Float64}, rankedCandidates::Vector{Candidate{F}}, sortedWeights::Vector{Float64})
   @assert length(weights) == length(sortedWeights) && length(rankedCandidates) == length(weights)
@@ -135,10 +135,10 @@ function trace_state(io::IO, snes::SeparableNESOpt, mode::Symbol)
 end
 
 """
-  Abstract type for a family of NES methods that represent population as
-  ```
-   x = μ + σ B⋅Z,
-  ```
+Abstract type for a family of NES methods that represent population as
+```
+x = μ + σ B⋅Z,
+```
 where `B` is an exponential of some symmetric matrix `lnB`, `tr(lnB)==0.0`
 """
 abstract type ExponentialNaturalEvolutionStrategyOpt <: NaturalEvolutionStrategyOpt end
@@ -195,7 +195,7 @@ end
 ini_xnes_B(ss::SearchSpace) = eye(numdims(ss), numdims(ss))
 
 """
-  Calculates the initial ``log B`` matrix for `xNES` based on the deltas of each dimension.
+Calculates the initial ``log B`` matrix for `xNES` based on the deltas of each dimension.
 """
 function ini_xnes_B(ss::RangePerDimSearchSpace)
   diag = map(log, deltas(ss))
@@ -204,9 +204,9 @@ function ini_xnes_B(ss::RangePerDimSearchSpace)
 end
 
 """
-  `xNES` method.
+`xNES` method.
 
-  Nice but scales badly with increasing dimensions.
+Nice but scales badly with increasing dimensions.
 """
 type XNESOpt{F,E<:EmbeddingOperator} <: ExponentialNaturalEvolutionStrategyOpt
   embed::E                        # operator embedding into the search space
@@ -303,9 +303,9 @@ function trace_state(io::IO, xnes::XNESOpt, mode::Symbol)
 end
 
 """
-  `fitness_shaping_utilities_log(n)`
+    fitness_shaping_utilities_log(n)
 
-  Calculate the `n`-dimensional fitness shaping utilities vector using the "log" method.
+Calculate the `n`-dimensional fitness shaping utilities vector using the "log" method.
 """
 function fitness_shaping_utilities_log(n::Int)
   u = [max(0.0, log(n / 2 + 1.0) - log(i)) for i in 1:n]
@@ -313,10 +313,10 @@ function fitness_shaping_utilities_log(n::Int)
 end
 
 """
-  `fitness_shaping_utilities_linear(n)`
+    fitness_shaping_utilities_linear(n)
 
-  Calculate the `n`-dimensional fitness shaping utilities vector
-  using the "steps" method.
+Calculate the `n`-dimensional fitness shaping utilities vector
+using the "steps" method.
 """
 function fitness_shaping_utilities_linear(n::Int)
   # Second half has zero utility.

--- a/src/ntuple_fitness.jl
+++ b/src/ntuple_fitness.jl
@@ -29,7 +29,7 @@ Pareto dominance for `N`-tuple (`N`≧1) fitnesses.
 Might be used for comparisons (or not, depending on the setup).
 Always used when printing fitness vectors though.
 """
-immutable ParetoFitnessScheme{N,F<:Number,MIN,AGG} <: TupleFitnessScheme{N,F,NTuple{N,F},MIN,AGG}
+struct ParetoFitnessScheme{N,F<:Number,MIN,AGG} <: TupleFitnessScheme{N,F,NTuple{N,F},MIN,AGG}
     aggregator::AGG    # fitness aggregation function
 
     (::Type{ParetoFitnessScheme{N,F}}){N,F<:Number,AGG}(; is_minimizing::Bool=true, aggregator::AGG=sum) =
@@ -76,7 +76,7 @@ hat_compare{N,F}(f1::NTuple{N,F}, f2::NTuple{N,F}, fs::ParetoFitnessScheme{N,F,f
 Might be used for comparisons (or not, depending on the setup).
 Always used when printing fitness vectors though.
 """
-immutable EpsDominanceFitnessScheme{N,F<:Number,MIN,AGG} <: FitnessScheme{NTuple{N,F}}
+struct EpsDominanceFitnessScheme{N,F<:Number,MIN,AGG} <: FitnessScheme{NTuple{N,F}}
     ϵ::F              # ɛ-domination threshold
     aggregator::AGG    # fitness aggregation function
 
@@ -158,7 +158,7 @@ end
 
 Used together with `EpsBoxDominanceFitnessScheme`.
 """
-immutable IndexedTupleFitness{N,F}
+struct IndexedTupleFitness{N,F}
     orig::NTuple{N,F}       # original fitness
     agg::F                  # aggregated fitness
     index::NTuple{N,Int}    # ϵ-index vector
@@ -243,7 +243,7 @@ It operates with fitnesses of type `IndexedTupleFitness`.
 Might be used for comparisons (or not, depending on the setup).
 Always used when printing fitness vectors though.
 """
-immutable EpsBoxDominanceFitnessScheme{N,F<:Number,MIN,AGG} <: TupleFitnessScheme{N,F,IndexedTupleFitness{N,F},MIN,AGG}
+struct EpsBoxDominanceFitnessScheme{N,F<:Number,MIN,AGG} <: TupleFitnessScheme{N,F,IndexedTupleFitness{N,F},MIN,AGG}
     ϵ::Vector{F}        # per-objective ɛ-domination thresholds
     aggregator::AGG     # fitness aggregation function
 

--- a/src/ntuple_fitness.jl
+++ b/src/ntuple_fitness.jl
@@ -262,20 +262,16 @@ isnafitness(f::IndexedTupleFitness{N,F},
             fit_scheme::EpsBoxDominanceFitnessScheme{N,F}) where {N,F<:Number} =
     isnafitness(f.orig, fit_scheme)
 
-Base.convert(::Type{EpsBoxDominanceFitnessScheme},
-             fs::ParetoFitnessScheme{N,F}, ϵ::F=one(F)) where {N,F} =
+EpsBoxDominanceFitnessScheme(fs::ParetoFitnessScheme{N,F}, ϵ::F=one(F)) where {N,F} =
     EpsBoxDominanceFitnessScheme{N,F}(ϵ, is_minimizing=is_minimizing(fs), aggregator=fs.aggregator)
 
-Base.convert(::Type{EpsBoxDominanceFitnessScheme},
-             fs::ParetoFitnessScheme{N,F}, ϵ::Vector{F}) where {N,F} =
+EpsBoxDominanceFitnessScheme(fs::ParetoFitnessScheme{N,F}, ϵ::Vector{F}) where {N,F} =
     EpsBoxDominanceFitnessScheme{N,F}(ϵ, is_minimizing=is_minimizing(fs), aggregator=fs.aggregator)
 
-Base.convert(::Type{EpsBoxDominanceFitnessScheme},
-             fs::EpsDominanceFitnessScheme{N,F},
-             ϵ::Union{F,Vector{F}}=fs.ϵ) where {N,F} =
+EpsBoxDominanceFitnessScheme(fs::EpsDominanceFitnessScheme{N,F}, ϵ::Union{F,Vector{F}}=fs.ϵ) where {N,F} =
     EpsBoxDominanceFitnessScheme{N,F}(ϵ, is_minimizing=is_minimizing(fs), aggregator=fs.aggregator)
 
-Base.convert(::Type{ParetoFitnessScheme}, fs::EpsBoxDominanceFitnessScheme{N,F}) where {N,F} =
+ParetoFitnessScheme(fs::EpsBoxDominanceFitnessScheme{N,F}) where {N,F} =
   ParetoFitnessScheme{N,F}(is_minimizing=is_minimizing(fs), aggregator=fs.aggregator)
 
 Base.convert(::Type{IndexedTupleFitness{N,F}}, fitness::NTuple{N,F},

--- a/src/ntuple_fitness.jl
+++ b/src/ntuple_fitness.jl
@@ -32,11 +32,11 @@ Always used when printing fitness vectors though.
 struct ParetoFitnessScheme{N,F<:Number,MIN,AGG} <: TupleFitnessScheme{N,F,NTuple{N,F},MIN,AGG}
     aggregator::AGG    # fitness aggregation function
 
-    (::Type{ParetoFitnessScheme{N,F}}){N,F<:Number,AGG}(; is_minimizing::Bool=true, aggregator::AGG=sum) =
+    ParetoFitnessScheme{N,F}(; is_minimizing::Bool=true, aggregator::AGG=sum) where {N, F<:Number, AGG} =
         new{N,F,is_minimizing,AGG}(aggregator)
 
-    (::Type{ParetoFitnessScheme{N}}){N,F<:Number,AGG}(; fitness_type::Type{F} = Float64,
-                                is_minimizing::Bool=true, aggregator::AGG=sum) =
+    ParetoFitnessScheme{N}(; fitness_type::Type{F} = Float64,
+                            is_minimizing::Bool=true, aggregator::AGG=sum) where {N, F<:Number, AGG} =
         new{N,fitness_type,is_minimizing,AGG}(aggregator)
 end
 
@@ -80,16 +80,16 @@ struct EpsDominanceFitnessScheme{N,F<:Number,MIN,AGG} <: FitnessScheme{NTuple{N,
     ϵ::F              # ɛ-domination threshold
     aggregator::AGG    # fitness aggregation function
 
-    function (::Type{EpsDominanceFitnessScheme{N,F}}){N,F<:Number,AGG}(
-                                ϵ::F; is_minimizing::Bool=true, aggregator::AGG=sum)
+    function EpsDominanceFitnessScheme{N,F}(
+            ϵ::F; is_minimizing::Bool=true, aggregator::AGG=sum) where {N, F<:Number, AGG}
         ϵ>0.0 || throw(ArgumentError("ϵ must be positive"))
         new{N,F,is_minimizing,AGG}(ϵ, aggregator)
     end
-
-    (::Type{EpsDominanceFitnessScheme{N}}){N,F<:Number,AGG}(ϵ::F; fitness_type::Type{F} = Float64,
-                               is_minimizing::Bool=true, aggregator::AGG=sum) =
-        EpsDominanceFitnessScheme{N,fitness_type}(ϵ; is_minimizing=is_minimizing, aggegator=aggregator)
 end
+
+EpsDominanceFitnessScheme{N}(ϵ::F; fitness_type::Type{F} = Float64,
+        is_minimizing::Bool=true, aggregator::AGG=sum) where {N, F<:Number, AGG} =
+    EpsDominanceFitnessScheme{N,fitness_type}(ϵ; is_minimizing=is_minimizing, aggegator=aggregator)
 
 # comparison for minimizing ϵ-dominance scheme
 function hat_compare_ϵ{N,F}(u::NTuple{N,F}, v::NTuple{N,F}, ϵ::F, expected::Int=0)
@@ -164,13 +164,14 @@ struct IndexedTupleFitness{N,F}
     index::NTuple{N,Int}    # ϵ-index vector
     dist::F                 # distance between ϵ-index vector and the original fitness
 
-    function (::Type{IndexedTupleFitness}){N,F,MIN}(u::NTuple{N,F}, agg::F, ϵ::Vector{F}, is_minimizing::Type{Val{MIN}})
+    function IndexedTupleFitness(u::NTuple{N,F}, agg::F, ϵ::Vector{F}, is_minimizing::Type{Val{MIN}}) where {N, F, MIN}
         ix, dist = ϵ_index(u, ϵ, is_minimizing)
         return new{N,F}(u, agg, ix, dist)
     end
-    (::Type{IndexedTupleFitness}){N,F,MIN}(u::NTuple{N,F}, agg::F, ϵ::F, is_minimizing::Type{Val{MIN}}) =
-        IndexedTupleFitness(u, agg, fill(ϵ, N), is_minimizing)
 end
+
+IndexedTupleFitness(u::NTuple{N,F}, agg::F, ϵ::F, is_minimizing::Type{Val{MIN}}) where {N, F, MIN} =
+    IndexedTupleFitness(u, agg, fill(ϵ, N), is_minimizing)
 
 Base.convert{N,F}(::Type{NTuple{N,F}}, fitness::IndexedTupleFitness{N,F}) = fitness.orig
 
@@ -247,12 +248,12 @@ struct EpsBoxDominanceFitnessScheme{N,F<:Number,MIN,AGG} <: TupleFitnessScheme{N
     ϵ::Vector{F}        # per-objective ɛ-domination thresholds
     aggregator::AGG     # fitness aggregation function
 
-    (::Type{EpsBoxDominanceFitnessScheme{N,F}}){N,F<:Number,AGG}(ϵ::Union{F,Vector{F}};
-                               is_minimizing::Bool=true, aggregator::AGG=sum) =
+    EpsBoxDominanceFitnessScheme{N,F}(ϵ::Union{F,Vector{F}};
+            is_minimizing::Bool=true, aggregator::AGG=sum) where {N,F<:Number,AGG} =
         new{N,F,is_minimizing,AGG}(check_epsbox_ϵ(ϵ, N), aggregator)
 
-    (::Type{EpsBoxDominanceFitnessScheme{N}}){N,F<:Number,AGG}(ϵ::Union{F,Vector{F}};
-                               is_minimizing::Bool=true, aggregator::AGG=sum) =
+    EpsBoxDominanceFitnessScheme{N}(ϵ::Union{F,Vector{F}};
+            is_minimizing::Bool=true, aggregator::AGG=sum) where {N,F<:Number,AGG} =
         new{N,F,is_minimizing,AGG}(check_epsbox_ϵ(ϵ, N), aggregator)
 end
 

--- a/src/ntuple_fitness.jl
+++ b/src/ntuple_fitness.jl
@@ -230,7 +230,7 @@ function check_epsbox_ϵ(ϵ::Number, n::Int)
     return fill(ϵ, n)
 end
 
-function check_epsbox_ϵ(ϵ::Vector{<:Number}, n::Int)
+function check_epsbox_ϵ(ϵ::AbstractVector{<:Number}, n::Int)
     length(ϵ)==n || throw(ArgumentError("The length of ϵ vector ($(length(ϵ))) does not match the specified fitness dimensions ($n)"))
     all(isposdef, ϵ) || throw(ArgumentError("ϵ must be positive"))
     return ϵ

--- a/src/ntuple_fitness.jl
+++ b/src/ntuple_fitness.jl
@@ -7,7 +7,7 @@
   `MIN` if objectives should be minimized or maximized
   `AGG` the type of aggregator
 """
-@compat abstract type TupleFitnessScheme{N,F<:Number,FA,MIN,AGG} <: FitnessScheme{FA} end
+abstract type TupleFitnessScheme{N,F<:Number,FA,MIN,AGG} <: FitnessScheme{FA} end
 
 @inline numobjectives{N}(::TupleFitnessScheme{N}) = N
 @inline fitness_eltype{N,F}(::TupleFitnessScheme{N,F}) = F

--- a/src/ntuple_fitness.jl
+++ b/src/ntuple_fitness.jl
@@ -1,11 +1,12 @@
 """
-  Base class for tuple-based fitness schemes.
+Base class for tuple-based fitness schemes.
 
-  `N` is the number of the objectives
-  `F` is the type of each objective
-  `FA` is the actual type of the multi-objective fitness
-  `MIN` if objectives should be minimized or maximized
-  `AGG` the type of aggregator
+Type parameters:
+  * `N` is the number of the objectives
+  * `F` is the type of each objective
+  * `FA` is the actual type of the multi-objective fitness
+  * `MIN` if objectives should be minimized or maximized
+  * `AGG` the type of aggregator
 """
 abstract type TupleFitnessScheme{N,F<:Number,FA,MIN,AGG} <: FitnessScheme{FA} end
 
@@ -22,11 +23,11 @@ aggregate{N,F}(f::NTuple{N,F}, fs::TupleFitnessScheme{N,F}) = fs.aggregator(f)
 @inline is_worse{N,F}(f1::NTuple{N,F}, f2::NTuple{N,F}, fs::TupleFitnessScheme{N,F,NTuple{N,F}}) = hat_compare(f1, f2, fs, 1) == 1
 
 """
-  Pareto dominance for `N`-tuple (`N`≧1) fitnesses.
+Pareto dominance for `N`-tuple (`N`≧1) fitnesses.
 
-  `aggregator::AGG` is a function mapping tuple fitness to a single numerical value.
-  Might be used for comparisons (or not, depending on the setup).
-  Always used when printing fitness vectors though.
+`aggregator::AGG` is a function mapping tuple fitness to a single numerical value.
+Might be used for comparisons (or not, depending on the setup).
+Always used when printing fitness vectors though.
 """
 immutable ParetoFitnessScheme{N,F<:Number,MIN,AGG} <: TupleFitnessScheme{N,F,NTuple{N,F},MIN,AGG}
     aggregator::AGG    # fitness aggregation function
@@ -69,11 +70,11 @@ hat_compare{N,F}(f1::NTuple{N,F}, f2::NTuple{N,F}, fs::ParetoFitnessScheme{N,F,f
     hat_compare_pareto(f2, f1, expected)
 
 """
-  ϵ-dominance for `N`-tuple (`N`≧1) fitnesses.
+ϵ-dominance for `N`-tuple (`N`≧1) fitnesses.
 
-  `aggregator::AGG` is a function mapping tuple fitness to a single numerical value.
-  Might be used for comparisons (or not, depending on the setup).
-  Always used when printing fitness vectors though.
+`aggregator::AGG` is a function mapping tuple fitness to a single numerical value.
+Might be used for comparisons (or not, depending on the setup).
+Always used when printing fitness vectors though.
 """
 immutable EpsDominanceFitnessScheme{N,F<:Number,MIN,AGG} <: FitnessScheme{NTuple{N,F}}
     ϵ::F              # ɛ-domination threshold
@@ -153,9 +154,9 @@ end
 end
 
 """
-    ϵ-box indexed representation of the N-tuple fitness.
+ϵ-box indexed representation of the N-tuple fitness.
 
-    Used together with `EpsBoxDominanceFitnessScheme`.
+Used together with `EpsBoxDominanceFitnessScheme`.
 """
 immutable IndexedTupleFitness{N,F}
     orig::NTuple{N,F}       # original fitness
@@ -182,11 +183,11 @@ end
 
 # comparison for minimizing ϵ-box dominance scheme
 """
-    Returns a tuple of `u` and `v` comparison:
-      * `-1`: u≺v
-      * `0`: u and v non-dominating
-      * `1`: u≻v
-    and whether `u` index fully matches `v` index.
+Returns a tuple of `u` and `v` comparison:
+  * `-1`: u≺v
+  * `0`: u and v non-dominating
+  * `1`: u≻v
+and whether `u` index fully matches `v` index.
 """
 function hat_compare_ϵ_box{N,F}(u::IndexedTupleFitness{N,F}, v::IndexedTupleFitness{N,F}, is_minimizing::Bool=true, expected::Int=0)
     comp = 0
@@ -231,13 +232,13 @@ function check_epsbox_ϵ{F<:Number}(ϵ::Vector{F}, n::Int)
 end
 
 """
-  `EpsBoxDominanceFitnessScheme` defines ϵ-box dominance for
-  `N`-tuple (`N`≧1) fitnesses.
-  It operates with fitnesses of type `IndexedTupleFitness`.
+`EpsBoxDominanceFitnessScheme` defines ϵ-box dominance for
+`N`-tuple (`N`≧1) fitnesses.
+It operates with fitnesses of type `IndexedTupleFitness`.
 
-  `aggregator::AGG` is a function mapping tuple fitness to a single numerical value.
-  Might be used for comparisons (or not, depending on the setup).
-  Always used when printing fitness vectors though.
+`aggregator::AGG` is a function mapping tuple fitness to a single numerical value.
+Might be used for comparisons (or not, depending on the setup).
+Always used when printing fitness vectors though.
 """
 immutable EpsBoxDominanceFitnessScheme{N,F<:Number,MIN,AGG} <: TupleFitnessScheme{N,F,IndexedTupleFitness{N,F},MIN,AGG}
     ϵ::Vector{F}        # per-objective ɛ-domination thresholds

--- a/src/ntuple_fitness.jl
+++ b/src/ntuple_fitness.jl
@@ -32,7 +32,7 @@ Always used when printing fitness vectors though.
 immutable ParetoFitnessScheme{N,F<:Number,MIN,AGG} <: TupleFitnessScheme{N,F,NTuple{N,F},MIN,AGG}
     aggregator::AGG    # fitness aggregation function
 
-    (::Type{ParetoFitnessScheme{N,F}}){N,F<:Number,AGG}(;is_minimizing::Bool=true, aggregator::AGG=sum) =
+    (::Type{ParetoFitnessScheme{N,F}}){N,F<:Number,AGG}(; is_minimizing::Bool=true, aggregator::AGG=sum) =
         new{N,F,is_minimizing,AGG}(aggregator)
 
     (::Type{ParetoFitnessScheme{N}}){N,F<:Number,AGG}(; fitness_type::Type{F} = Float64,
@@ -189,7 +189,10 @@ Returns a tuple of `u` and `v` comparison:
   * `1`: u≻v
 and whether `u` index fully matches `v` index.
 """
-function hat_compare_ϵ_box{N,F}(u::IndexedTupleFitness{N,F}, v::IndexedTupleFitness{N,F}, is_minimizing::Bool=true, expected::Int=0)
+function hat_compare_ϵ_box{N,F}(
+        u::IndexedTupleFitness{N,F},
+        v::IndexedTupleFitness{N,F},
+        is_minimizing::Bool=true, expected::Int=0)
     comp = 0
     @inbounds for (ui, vi) in zip(u.index, v.index)
         if ui > vi
@@ -222,13 +225,13 @@ end
 
 function check_epsbox_ϵ(ϵ::Number, n::Int)
     ϵ>0.0 || throw(ArgumentError("ϵ must be positive"))
-    fill(ϵ, n)
+    return fill(ϵ, n)
 end
 
 function check_epsbox_ϵ{F<:Number}(ϵ::Vector{F}, n::Int)
     length(ϵ)==n || throw(ArgumentError("The length of ϵ vector ($(length(ϵ))) does not match the specified fitness dimensions ($n)"))
     all(isposdef, ϵ) || throw(ArgumentError("ϵ must be positive"))
-    ϵ
+    return ϵ
 end
 
 """

--- a/src/opt_controller.jl
+++ b/src/opt_controller.jl
@@ -1,5 +1,5 @@
 """
-    Create `Evaluator` instance for a given `problem`.
+Create `Evaluator` instance for a given `problem`.
 """
 function make_evaluator(problem::OptimizationProblem, archive=nothing, params::Parameters=ParamsDict())
     workers = get(params, :Workers, Vector{Int}())
@@ -16,10 +16,10 @@ function make_evaluator(problem::OptimizationProblem, archive=nothing, params::P
 end
 
 """
-  Optimization Run Controller.
-  Manages problem optimization using the specified method.
+Optimization Run Controller.
+Manages problem optimization using the specified method.
 
-  See `OptController`.
+See `OptController`.
 """
 type OptRunController{O<:Optimizer, E<:Evaluator}
   optimizer::O   # optimization algorithm
@@ -57,7 +57,7 @@ type OptRunController{O<:Optimizer, E<:Evaluator}
 end
 
 """
-    Create `OptRunController` for a given problem using specified `optimizer`.
+Create `OptRunController` for a given problem using specified `optimizer`.
 
 #Arguments
     * `optimizer` initialized optimization method
@@ -130,9 +130,9 @@ best_fitness(ctrl::OptRunController) =  best_fitness(ctrl.evaluator.archive)
 """
     show_fitness(io, fit, [problem::OptimizationProblem])
 
-    Output fitness to the given IO stream.
-    `show_fitness()` method could be overridden for a specific problem, e.g.
-    to print the names of each objective.
+Output fitness to the given IO stream.
+`show_fitness()` method could be overridden for a specific problem, e.g.
+to print the names of each objective.
 """
 show_fitness(io::IO, fit::Number) = @printf(io, "%.9f", fit)
 
@@ -160,8 +160,8 @@ show_fitness{FA}(io::IO, fit::FA, problem::OptimizationProblem) = show_fitness(i
 """
     format_fitness(fit, [problem::OptimizationProblem])
 
-    Format fitness into a string.
-    Calls `show_fitness()` under the hood.
+Format fitness into a string.
+Calls `show_fitness()` under the hood.
 """
 function format_fitness(fit::Any, problem::OptimizationProblem)
     buf = IOBuffer(false, true)
@@ -264,9 +264,9 @@ function shutdown_optimizer!{O<:AskTellOptimizer}(ctrl::OptRunController{O})
 end
 
 """
-  `run!(ctrl::OptRunController)`
+    run!(ctrl::OptRunController)
 
-  Run optimization until one of the stopping conditions are satisfied.
+Run optimization until one of the stopping conditions are satisfied.
 """
 function run!(ctrl::OptRunController)
     tr(ctrl, "Starting optimization with optimizer $(name(ctrl.optimizer))\n")
@@ -337,13 +337,13 @@ function write_result(ctrl::OptRunController, filename = "")
 end
 
 """
-  Optimization Controller.
+Optimization Controller.
 
-  Applies specific optimization method to a given problem.
-  Supports restarts and modifying parameter of the method between runs.
-  `runcontrollers` field maintains the list of `OptRunController` instances applied so far.
+Applies specific optimization method to a given problem.
+Supports restarts and modifying parameter of the method between runs.
+`runcontrollers` field maintains the list of `OptRunController` instances applied so far.
 
-  See `OptRunController`.
+See `OptRunController`.
 """
 type OptController{O<:Optimizer, P<:OptimizationProblem}
   optimizer::O   # optimization algorithm
@@ -353,11 +353,11 @@ type OptController{O<:Optimizer, P<:OptimizationProblem}
 end
 
 """
-    Create `OptController` for a given `optimizer` and a `problem`.
+Create `OptController` for a given `optimizer` and a `problem`.
 
-    `params` are any of `OptRunController` parameters plus
-        * `:RngSeed` and `:RandomizeRngSeed` params for controlling the random seed
-        * `:RecoverResults` if intermediate results are returned upon `InterruptException()` (on by default)
+`params` are any of `OptRunController` parameters plus
+    * `:RngSeed` and `:RandomizeRngSeed` params for controlling the random seed
+    * `:RecoverResults` if intermediate results are returned upon `InterruptException()` (on by default)
 """
 function OptController{O<:Optimizer, P<:OptimizationProblem}(optimizer::O, problem::P,
   params::ParamsDictChain)
@@ -369,9 +369,9 @@ numruns(oc::OptController) = length(oc.runcontrollers)
 lastrun(oc::OptController) = oc.runcontrollers[end]
 
 """
-  `update_parameters!(oc::OptController, parameters::Associative)`
+    update_parameters!(oc::OptController, parameters::Associative)
 
-  Update the `OptController` parameters.
+Update the `OptController` parameters.
 """
 function update_parameters!{O<:Optimizer, P<:OptimizationProblem}(oc::OptController{O,P},
   parameters::Parameters = EMPTY_DICT)
@@ -402,9 +402,9 @@ function init_rng!(parameters::Parameters)
 end
 
 """
-  `run!(oc::OptController)`
+    run!(oc::OptController)
 
-  Start a new optimization run, possibly with new parameters and report on results.
+Start a new optimization run, possibly with new parameters and report on results.
 """
 function run!{O<:Optimizer, P<:OptimizationProblem}(oc::OptController{O,P})
 

--- a/src/opt_controller.jl
+++ b/src/opt_controller.jl
@@ -21,7 +21,7 @@ Manages problem optimization using the specified method.
 
 See `OptController`.
 """
-type OptRunController{O<:Optimizer, E<:Evaluator}
+mutable struct OptRunController{O<:Optimizer, E<:Evaluator}
     optimizer::O   # optimization algorithm
     evaluator::E   # problem evaluator
 
@@ -345,7 +345,7 @@ Supports restarts and modifying parameter of the method between runs.
 
 See `OptRunController`.
 """
-type OptController{O<:Optimizer, P<:OptimizationProblem}
+mutable struct OptController{O<:Optimizer, P<:OptimizationProblem}
     optimizer::O   # optimization algorithm
     problem::P     # opt problem
     parameters::ParamsDictChain

--- a/src/opt_controller.jl
+++ b/src/opt_controller.jl
@@ -22,38 +22,38 @@ Manages problem optimization using the specified method.
 See `OptController`.
 """
 type OptRunController{O<:Optimizer, E<:Evaluator}
-  optimizer::O   # optimization algorithm
-  evaluator::E   # problem evaluator
+    optimizer::O   # optimization algorithm
+    evaluator::E   # problem evaluator
 
-  trace_mode::Symbol # controller state trace mode (:verbose, :compact, :silent)
-                     # :silent makes tr() generate no output)
-  save_trace::Bool # FIXME if traces should be saved to a file
-  trace_interval::Float64 # periodicity of calling trace_progress()
+    trace_mode::Symbol # controller state trace mode (:verbose, :compact, :silent)
+                       # :silent makes tr() generate no output)
+    save_trace::Bool # FIXME if traces should be saved to a file
+    trace_interval::Float64 # periodicity of calling trace_progress()
 
-  # termination conditions
-  max_steps::Int      # maximal number of steps
-  max_fevals::Int # maximal number of fitness evaluations
-  max_steps_without_fevals::Int # stop optimization if no func evals in this many steps (indicates a converged/degenerate search)
-  max_steps_without_progress::Int # stop optimization if no improvement in this many steps (indicates a converged/degenerate search)
-  max_time::Float64   # maximal time, 0 to ignore
+    # termination conditions
+    max_steps::Int      # maximal number of steps
+    max_fevals::Int # maximal number of fitness evaluations
+    max_steps_without_fevals::Int # stop optimization if no func evals in this many steps (indicates a converged/degenerate search)
+    max_steps_without_progress::Int # stop optimization if no improvement in this many steps (indicates a converged/degenerate search)
+    max_time::Float64   # maximal time, 0 to ignore
 
-  min_delta_fitness_tol::Float64 # minimal difference between current best fitness and second-best one
-  fitness_tol::Float64  # minimal difference between current best fitness and the known optmimum
+    min_delta_fitness_tol::Float64 # minimal difference between current best fitness and second-best one
+    fitness_tol::Float64  # minimal difference between current best fitness and the known optmimum
 
-  num_steps::Int       # optimization steps done
-  num_better::Int      # number of steps that improved best fitness
+    num_steps::Int       # optimization steps done
+    num_better::Int      # number of steps that improved best fitness
 
-  num_better_since_last_report::Int # ditto, since last call to trace_progress()
-  num_steps_since_last_report::Int # number of steps since last call to trace_progress()
+    num_better_since_last_report::Int # ditto, since last call to trace_progress()
+    num_steps_since_last_report::Int # number of steps since last call to trace_progress()
 
-  last_num_fevals::Int # the number of function evals on the previous step
-  num_steps_without_fevals::Int # the number of steps without the function evals
+    last_num_fevals::Int # the number of function evals on the previous step
+    num_steps_without_fevals::Int # the number of steps without the function evals
 
-  start_time::Float64 # time optimization started, 0 if not running yet
-  stop_time::Float64  # time optimization stopped, 0 if still running
-  last_report_time::Float64 # last time trace_progress() was called
+    start_time::Float64 # time optimization started, 0 if not running yet
+    stop_time::Float64  # time optimization stopped, 0 if still running
+    last_report_time::Float64 # last time trace_progress() was called
 
-  stop_reason::String # the reason for algorithm termination, empty if it's not terminated
+    stop_reason::String # the reason for algorithm termination, empty if it's not terminated
 end
 
 """
@@ -78,7 +78,7 @@ Create `OptRunController` for a given problem using specified `optimizer`.
         * `:SaveParameters` save method/controller parameters to a JSON file
 """
 function OptRunController{O<:Optimizer, E<:Evaluator}(optimizer::O, evaluator::E, params)
-  OptRunController{O,E}(optimizer, evaluator,
+    OptRunController{O,E}(optimizer, evaluator,
         [params[key] for key in Symbol[:TraceMode, :SaveTrace, :TraceInterval,
                       :MaxSteps, :MaxFuncEvals, :MaxNumStepsWithoutFuncEvals, :MaxStepsWithoutProgress, :MaxTime,
                       :MinDeltaFitnessTolerance, :FitnessTolerance]]...,
@@ -97,19 +97,19 @@ OptRunController(orc::OptRunController, params) =
 
 # logging/tracing
 function tr(ctrl::OptRunController, msg::AbstractString, obj = nothing)
-  if ctrl.trace_mode != :silent
-    print(msg)
-    if obj != nothing
-      if isa(obj, AbstractString)
-        print(obj)
-      else
-        showcompact(obj)
-      end
+    if ctrl.trace_mode != :silent
+        print(msg)
+        if obj !== nothing
+            if isa(obj, AbstractString)
+                print(obj)
+            else
+                showcompact(obj)
+            end
+        end
     end
-  end
-  if ctrl.save_trace
-    # No saving for now
-  end
+    if ctrl.save_trace
+        # No saving for now
+    end
 end
 
 optimizer(ctrl::OptRunController) = ctrl.optimizer
@@ -176,24 +176,24 @@ function format_fitness(fit::Any)
 end
 
 function elapsed_time(ctrl::OptRunController)
-  isrunning(ctrl) ? time() - ctrl.start_time : ctrl.stop_time - ctrl.start_time
+    isrunning(ctrl) ? time() - ctrl.start_time : ctrl.stop_time - ctrl.start_time
 end
 
 function check_stop_condition(ctrl::OptRunController)
     if ctrl.max_time > 0 && elapsed_time(ctrl) > ctrl.max_time
-      return "Max time ($(ctrl.max_time) s) reached"
+        return "Max time ($(ctrl.max_time) s) reached"
     end
 
     if ctrl.max_fevals > 0 && num_func_evals(ctrl) > ctrl.max_fevals
-      return "Max number of function evaluations ($(ctrl.max_fevals)) reached"
+        return "Max number of function evaluations ($(ctrl.max_fevals)) reached"
     end
 
     if ctrl.max_steps_without_fevals > 0 && ctrl.num_steps_without_fevals > ctrl.max_steps_without_fevals
-      return "Too many steps ($(ctrl.num_steps_without_fevals)) without any function evaluations (probably search has converged)"
+        return "Too many steps ($(ctrl.num_steps_without_fevals)) without any function evaluations (probably search has converged)"
     end
 
     if ctrl.max_steps > 0 && num_steps(ctrl) > ctrl.max_steps
-      return "Max number of steps ($(ctrl.max_steps)) reached"
+        return "Max number of steps ($(ctrl.max_steps)) reached"
     end
 
     return check_stop_condition(ctrl.evaluator, ctrl)
@@ -202,65 +202,65 @@ function check_stop_condition(ctrl::OptRunController)
 end
 
 function trace_progress(ctrl::OptRunController)
-  # update the counters
-  ctrl.last_report_time = time()
-  total_improvement_rate = ctrl.num_better/num_steps(ctrl)
-  recent_improvement_rate = ctrl.num_better_since_last_report/ctrl.num_steps_since_last_report
-  ctrl.num_better_since_last_report = 0
-  ctrl.num_steps_since_last_report = 0
+    # update the counters
+    ctrl.last_report_time = time()
+    total_improvement_rate = ctrl.num_better/num_steps(ctrl)
+    recent_improvement_rate = ctrl.num_better_since_last_report/ctrl.num_steps_since_last_report
+    ctrl.num_better_since_last_report = 0
+    ctrl.num_steps_since_last_report = 0
 
-  if ctrl.trace_mode == :silent
-      return
-  end
+    if ctrl.trace_mode == :silent
+        return
+    end
 
-  # Always print step number, num fevals and elapsed time
-  tr(ctrl, @sprintf("%.2f secs, %d evals, %d steps",
-      elapsed_time(ctrl), num_func_evals(ctrl), num_steps(ctrl)))
+    # Always print step number, num fevals and elapsed time
+    tr(ctrl, @sprintf("%.2f secs, %d evals, %d steps",
+            elapsed_time(ctrl), num_func_evals(ctrl), num_steps(ctrl)))
 
-  # Only print if this optimizer reports on number of better. They return 0
-  # if they do not.
-  if total_improvement_rate > 0.0
-    tr(ctrl, @sprintf(", improv/step: %.3f (last = %.4f)",
-        total_improvement_rate, recent_improvement_rate))
-  end
+    # Only print if this optimizer reports on number of better. They return 0
+    # if they do not.
+    if total_improvement_rate > 0.0
+        tr(ctrl, @sprintf(", improv/step: %.3f (last = %.4f)",
+                total_improvement_rate, recent_improvement_rate))
+    end
 
-  # Always print fitness if num_evals > 0
-  if num_func_evals(ctrl) > 0
-    tr(ctrl, ", fitness=")
-    show_fitness(STDOUT, best_fitness(ctrl), problem(ctrl))
-  end
+    # Always print fitness if num_evals > 0
+    if num_func_evals(ctrl) > 0
+        tr(ctrl, ", fitness=")
+        show_fitness(STDOUT, best_fitness(ctrl), problem(ctrl))
+    end
 
-  tr(ctrl, "\n")
+    tr(ctrl, "\n")
 
-  trace_state(STDOUT, ctrl.optimizer, ctrl.trace_mode)
+    trace_state(STDOUT, ctrl.optimizer, ctrl.trace_mode)
 end
 
 function step!{O<:AskTellOptimizer}(ctrl::OptRunController{O})
-  # The ask()/tell() interface is more general since you can mix and max
-  # elements from several optimizers using it. However, in this top-level
-  # execution function we do not make use of this flexibility...
-  candidates = ask(ctrl.optimizer)
-  rank_by_fitness!(ctrl.evaluator, candidates)
-  return tell!(ctrl.optimizer, candidates)
+    # The ask()/tell() interface is more general since you can mix and max
+    # elements from several optimizers using it. However, in this top-level
+    # execution function we do not make use of this flexibility...
+    candidates = ask(ctrl.optimizer)
+    rank_by_fitness!(ctrl.evaluator, candidates)
+    return tell!(ctrl.optimizer, candidates)
 end
 
 # step for SteppingOptimizers
 function step!{O<:SteppingOptimizer}(ctrl::OptRunController{O})
-  step!(ctrl.optimizer)
-  return 0
+    step!(ctrl.optimizer)
+    return 0
 end
 
 setup_optimizer!{O<:SteppingOptimizer}(ctrl::OptRunController{O}) =
-  setup!(ctrl.optimizer)
+    setup!(ctrl.optimizer)
 setup_optimizer!{O<:AskTellOptimizer}(ctrl::OptRunController{O}) =
-  setup!(ctrl.optimizer, ctrl.evaluator)
+    setup!(ctrl.optimizer, ctrl.evaluator)
 
 shutdown_optimizer!{O<:SteppingOptimizer}(ctrl::OptRunController{O}) =
-  shutdown!(ctrl.optimizer)
+    shutdown!(ctrl.optimizer)
 
 function shutdown_optimizer!{O<:AskTellOptimizer}(ctrl::OptRunController{O})
-  shutdown!(ctrl.optimizer)
-  shutdown!(ctrl.evaluator)
+    shutdown!(ctrl.optimizer)
+    shutdown!(ctrl.evaluator)
 end
 
 """
@@ -306,34 +306,34 @@ function run!(ctrl::OptRunController)
 end
 
 function show_report(ctrl::OptRunController, population_stats=false)
-  final_elapsed_time = elapsed_time(ctrl)
-  tr(ctrl, "Termination reason: $(ctrl.stop_reason)\n")
-  tr(ctrl, "Steps per second = $(num_steps(ctrl)/final_elapsed_time)\n")
-  tr(ctrl, "Function evals per second = $(num_func_evals(ctrl)/final_elapsed_time)\n")
-  tr(ctrl, "Improvements/step = $(ctrl.num_better/ctrl.max_steps)\n")
-  tr(ctrl, "Total function evaluations = $(num_func_evals(ctrl))\n")
+    final_elapsed_time = elapsed_time(ctrl)
+    tr(ctrl, "Termination reason: $(ctrl.stop_reason)\n")
+    tr(ctrl, "Steps per second = $(num_steps(ctrl)/final_elapsed_time)\n")
+    tr(ctrl, "Function evals per second = $(num_func_evals(ctrl)/final_elapsed_time)\n")
+    tr(ctrl, "Improvements/step = $(ctrl.num_better/ctrl.max_steps)\n")
+    tr(ctrl, "Total function evaluations = $(num_func_evals(ctrl))\n")
 
-  if population_stats && isa(ctrl.optimizer, PopulationOptimizer)
-    tr(ctrl, "\nMean value (in population) per position:",  mean(population(ctrl.optimizer),1))
-    tr(ctrl, "\n\nStd dev (in population) per position:", std(population(ctrl.optimizer),1))
-  end
+    if population_stats && isa(ctrl.optimizer, PopulationOptimizer)
+        tr(ctrl, "\nMean value (in population) per position:",  mean(population(ctrl.optimizer),1))
+        tr(ctrl, "\n\nStd dev (in population) per position:", std(population(ctrl.optimizer),1))
+    end
 
-  tr(ctrl, "\n\nBest candidate found: ", best_candidate(ctrl))
-  tr(ctrl, "\n\nFitness: ")
-  show_fitness(STDOUT, best_fitness(ctrl), problem(ctrl))
-  tr(ctrl, "\n\n")
+    tr(ctrl, "\n\nBest candidate found: ", best_candidate(ctrl))
+    tr(ctrl, "\n\nFitness: ")
+    show_fitness(STDOUT, best_fitness(ctrl), problem(ctrl))
+    tr(ctrl, "\n\n")
 end
 
 function write_result(ctrl::OptRunController, filename = "")
-  if isempty(filename)
-    timestamp = strftime("%y%m%d_%H%M%S", floor(Int, ctrl.start_time))
-    filename = "$(timestamp)_$(problem_summary(ctrl.evaluator))_$(name(ctrl.optimizer)).csv"
-    filename = replace(replace(filename, r"\s+", "_"), r"/", "_")
-  end
-  save_fitness_history_to_csv_file(ctrl.evaluator.archive, filename;
-      header_prefix = "Problem,Dimension,Optimizer",
-      line_prefix = "$(name(problem(ctrl.evaluator))),$(numdims(ctrl.evaluator)),$(name(ctrl.optimizer))",
-      bestfitness = opt_value(problem(ctrl.evaluator)))
+    if isempty(filename)
+        timestamp = strftime("%y%m%d_%H%M%S", floor(Int, ctrl.start_time))
+        filename = "$(timestamp)_$(problem_summary(ctrl.evaluator))_$(name(ctrl.optimizer)).csv"
+        filename = replace(replace(filename, r"\s+", "_"), r"/", "_")
+    end
+    save_fitness_history_to_csv_file(ctrl.evaluator.archive, filename;
+            header_prefix = "Problem,Dimension,Optimizer",
+            line_prefix = "$(name(problem(ctrl.evaluator))),$(numdims(ctrl.evaluator)),$(name(ctrl.optimizer))",
+            bestfitness = opt_value(problem(ctrl.evaluator)))
 end
 
 """
@@ -346,10 +346,10 @@ Supports restarts and modifying parameter of the method between runs.
 See `OptRunController`.
 """
 type OptController{O<:Optimizer, P<:OptimizationProblem}
-  optimizer::O   # optimization algorithm
-  problem::P     # opt problem
-  parameters::ParamsDictChain
-  runcontrollers::Vector{OptRunController{O}}
+    optimizer::O   # optimization algorithm
+    problem::P     # opt problem
+    parameters::ParamsDictChain
+    runcontrollers::Vector{OptRunController{O}}
 end
 
 """
@@ -359,9 +359,10 @@ Create `OptController` for a given `optimizer` and a `problem`.
     * `:RngSeed` and `:RandomizeRngSeed` params for controlling the random seed
     * `:RecoverResults` if intermediate results are returned upon `InterruptException()` (on by default)
 """
-function OptController{O<:Optimizer, P<:OptimizationProblem}(optimizer::O, problem::P,
-  params::ParamsDictChain)
-  OptController{O, P}(optimizer, problem, params, OptRunController{O}[])
+function OptController{O<:Optimizer, P<:OptimizationProblem}(
+    optimizer::O, problem::P,
+    params::ParamsDictChain)
+    OptController{O, P}(optimizer, problem, params, OptRunController{O}[])
 end
 
 problem(oc::OptController) = oc.problem
@@ -373,32 +374,30 @@ lastrun(oc::OptController) = oc.runcontrollers[end]
 
 Update the `OptController` parameters.
 """
-function update_parameters!{O<:Optimizer, P<:OptimizationProblem}(oc::OptController{O,P},
-  parameters::Parameters = EMPTY_DICT)
+function update_parameters!{O<:Optimizer, P<:OptimizationProblem}(oc::OptController{O,P}, parameters::Parameters = EMPTY_DICT)
+    parameters = convert(ParamsDict, parameters)
 
-  parameters = convert(ParamsDict, parameters)
-
-  # Most parameters cannot be changed since the problem and optimizer has already
-  # been setup.
-  valid_params = Set([:MaxTime, :MaxSteps, :MaxFuncEvals, :TraceMode])
-  for k in keys(parameters)
-    if k ∉ valid_params
-      throw(ArgumentError("It is currently not supported to change parameters that can affect the original opt problem or optimizer (here: $(k))"))
+    # Most parameters cannot be changed since the problem and optimizer has already
+    # been setup.
+    valid_params = Set([:MaxTime, :MaxSteps, :MaxFuncEvals, :TraceMode])
+    for k in keys(parameters)
+        if k ∉ valid_params
+            throw(ArgumentError("It is currently not supported to change parameters that can affect the original opt problem or optimizer (here: $(k))"))
+        end
     end
-  end
 
-  # Add new params in front if any are specified and they are valid.
-  if length(parameters) > 0
-    oc.parameters = chain(oc.parameters, parameters)
-    check_valid!(oc.parameters) # We must recheck that new param settings are valid
-  end
+    # Add new params in front if any are specified and they are valid.
+    if length(parameters) > 0
+        oc.parameters = chain(oc.parameters, parameters)
+        check_valid!(oc.parameters) # We must recheck that new param settings are valid
+    end
 end
 
 function init_rng!(parameters::Parameters)
-  if parameters[:RandomizeRngSeed]
-    parameters[:RngSeed] = rand(1:1_000_000)
-    srand(parameters[:RngSeed])
-  end
+    if parameters[:RandomizeRngSeed]
+        parameters[:RngSeed] = rand(1:1_000_000)
+        srand(parameters[:RngSeed])
+    end
 end
 
 """
@@ -407,41 +406,40 @@ end
 Start a new optimization run, possibly with new parameters and report on results.
 """
 function run!{O<:Optimizer, P<:OptimizationProblem}(oc::OptController{O,P})
-
-  # If this is not the first run we create the controller based on the previous one
-  # to reuse the archive etc, otherwise create it based on the problem.
-  ctrl = if numruns(oc) > 0
-    OptRunController(lastrun(oc), oc.parameters)
-  else
-    # No previous run controller so create a new one from optimizer and problem.
-    OptRunController(oc.optimizer, oc.problem, oc.parameters)
-  end
-  push!(oc.runcontrollers, ctrl)
-
-  # If this is the first run we might have to init the RNG.
-  if numruns(oc) == 1
-    init_rng!(oc.parameters)
-  end
-
-  try
-    run!(ctrl)
-    if ctrl.trace_mode != :silent
-        show_report(ctrl)
-    end
-
-    if oc.parameters[:SaveFitnessTraceToCsv]
-      write_results(ctrl)
-    end
-
-    return OptimizationResults(ctrl, oc)
-  catch ex
-    # If it was a ctrl-c interrupt we try to make a result and return it...
-    if get(oc.parameters, :RecoverResults, true) && isa(ex, InterruptException)
-      warn("Optimization interrupted, recovering intermediate results...")
-      ctrl.stop_reason = @sprintf "%s" ex
-      return OptimizationResults(ctrl, oc)
+    # If this is not the first run we create the controller based on the previous one
+    # to reuse the archive etc, otherwise create it based on the problem.
+    ctrl = if numruns(oc) > 0
+        OptRunController(lastrun(oc), oc.parameters)
     else
-      rethrow(ex)
+        # No previous run controller so create a new one from optimizer and problem.
+        OptRunController(oc.optimizer, oc.problem, oc.parameters)
     end
-  end
+    push!(oc.runcontrollers, ctrl)
+
+    # If this is the first run we might have to init the RNG.
+    if numruns(oc) == 1
+        init_rng!(oc.parameters)
+    end
+
+    try
+        run!(ctrl)
+        if ctrl.trace_mode != :silent
+            show_report(ctrl)
+        end
+
+        if oc.parameters[:SaveFitnessTraceToCsv]
+            write_results(ctrl)
+        end
+
+        return OptimizationResults(ctrl, oc)
+    catch ex
+        # If it was a ctrl-c interrupt we try to make a result and return it...
+        if get(oc.parameters, :RecoverResults, true) && isa(ex, InterruptException)
+            warn("Optimization interrupted, recovering intermediate results...")
+            ctrl.stop_reason = @sprintf "%s" ex
+            return OptimizationResults(ctrl, oc)
+        else
+            rethrow(ex)
+        end
+    end
 end

--- a/src/optimization_methods.jl
+++ b/src/optimization_methods.jl
@@ -4,21 +4,21 @@ Single objective optimization methods accepted by `bboptimize()`.
 The values are the method initialization routines or types derived from `Optimizer`.
 """
 const SingleObjectiveMethods = ParamsDict(
-  :random_search => random_search,
-  :de_rand_1_bin => de_rand_1_bin,
-  :de_rand_2_bin => de_rand_2_bin,
-  :de_rand_1_bin_radiuslimited => de_rand_1_bin_radiuslimited,
-  :de_rand_2_bin_radiuslimited => de_rand_2_bin_radiuslimited,
-  :adaptive_de_rand_1_bin => adaptive_de_rand_1_bin,
-  :adaptive_de_rand_1_bin_radiuslimited => adaptive_de_rand_1_bin_radiuslimited,
-  :separable_nes => separable_nes,
-  :xnes => xnes,
-  :dxnes => dxnes,
-  :resampling_memetic_search => resampling_memetic_searcher,
-  :resampling_inheritance_memetic_search => resampling_inheritance_memetic_searcher,
-  :simultaneous_perturbation_stochastic_approximation => SimultaneousPerturbationSA2,
-  :generating_set_search => GeneratingSetSearcher,
-  :probabilistic_descent => direct_search_probabilistic_descent,
+    :random_search => random_search,
+    :de_rand_1_bin => de_rand_1_bin,
+    :de_rand_2_bin => de_rand_2_bin,
+    :de_rand_1_bin_radiuslimited => de_rand_1_bin_radiuslimited,
+    :de_rand_2_bin_radiuslimited => de_rand_2_bin_radiuslimited,
+    :adaptive_de_rand_1_bin => adaptive_de_rand_1_bin,
+    :adaptive_de_rand_1_bin_radiuslimited => adaptive_de_rand_1_bin_radiuslimited,
+    :separable_nes => separable_nes,
+    :xnes => xnes,
+    :dxnes => dxnes,
+    :resampling_memetic_search => resampling_memetic_searcher,
+    :resampling_inheritance_memetic_search => resampling_inheritance_memetic_searcher,
+    :simultaneous_perturbation_stochastic_approximation => SimultaneousPerturbationSA2,
+    :generating_set_search => GeneratingSetSearcher,
+    :probabilistic_descent => direct_search_probabilistic_descent,
 )
 
 const SingleObjectiveMethodNames = sort!(collect(keys(SingleObjectiveMethods)))
@@ -29,7 +29,7 @@ Multi-objective optimization methods accepted by `bboptimize()`.
 The values are the method initialization routines or types derived from `Optimizer`.
 """
 const MultiObjectiveMethods = ParamsDict(
-  :borg_moea => borg_moea
+    :borg_moea => borg_moea
 )
 
 const MultiObjectiveMethodNames = sort!(collect(keys(MultiObjectiveMethods)))

--- a/src/optimization_methods.jl
+++ b/src/optimization_methods.jl
@@ -1,7 +1,7 @@
 """
-   Single objective optimization methods accepted by `bboptimize()`.
+Single objective optimization methods accepted by `bboptimize()`.
 
-   The values are the method initialization routines or types derived from `Optimizer`.
+The values are the method initialization routines or types derived from `Optimizer`.
 """
 const SingleObjectiveMethods = ParamsDict(
   :random_search => random_search,
@@ -24,9 +24,9 @@ const SingleObjectiveMethods = ParamsDict(
 const SingleObjectiveMethodNames = sort!(collect(keys(SingleObjectiveMethods)))
 
 """
-   Multi-objective optimization methods accepted by `bboptimize()`.
+Multi-objective optimization methods accepted by `bboptimize()`.
 
-   The values are the method initialization routines or types derived from `Optimizer`.
+The values are the method initialization routines or types derived from `Optimizer`.
 """
 const MultiObjectiveMethods = ParamsDict(
   :borg_moea => borg_moea
@@ -35,8 +35,8 @@ const MultiObjectiveMethods = ParamsDict(
 const MultiObjectiveMethodNames = sort!(collect(keys(MultiObjectiveMethods)))
 
 """
-  Names of optimization methods accepted by `bboptimize()`,
-  `:Method` keyword argument.
+Names of optimization methods accepted by `bboptimize()`,
+`:Method` keyword argument.
 """
 const MethodNames = sort!(vcat(SingleObjectiveMethodNames,
                                MultiObjectiveMethodNames))

--- a/src/optimization_result.jl
+++ b/src/optimization_result.jl
@@ -1,12 +1,12 @@
 """
-    Base class for archive-specific component
-    of the `OptimizationResults`.
+Base class for archive-specific component
+of the `OptimizationResults`.
 """
 abstract type ArchiveOutput end
 
 """
-    Base class for method-specific component
-    of the `OptimizationResults`.
+Base class for method-specific component
+of the `OptimizationResults`.
 """
 abstract type MethodOutput end
 
@@ -16,11 +16,11 @@ immutable DummyMethodOutput <: MethodOutput end
 (::Type{MethodOutput})(method::Optimizer) = DummyMethodOutput()
 
 """
-  The results of running optimization method.
+The results of running optimization method.
 
-  Returned by `run!(oc::OptRunController)`.
-  Should be compatible (on the API level) with the `Optim` package.
-  See `make_opt_results()`.
+Returned by `run!(oc::OptRunController)`.
+Should be compatible (on the API level) with the `Optim` package.
+See `make_opt_results()`.
 """
 type OptimizationResults
   method::String           # FIXME symbol instead or flexible?
@@ -83,7 +83,7 @@ f_minimum(or::OptimizationResults) = best_fitness(or)
 iteration_converged(or::OptimizationResults) = iterations(or) >= parameters(or)[:MaxSteps]
 
 """
-    `TopListArchive`-specific components of the optimization results.
+`TopListArchive`-specific components of the optimization results.
 """
 immutable TopListArchiveOutput{F,C} <: ArchiveOutput
   best_fitness::F
@@ -96,7 +96,7 @@ end
 (::Type{ArchiveOutput})(archive::TopListArchive) = TopListArchiveOutput(archive)
 
 """
-    Wrapper for `FrontierIndividual` that allows easy access to the problem fitness.
+Wrapper for `FrontierIndividual` that allows easy access to the problem fitness.
 """
 immutable FrontierIndividualWrapper{F,FA} <: FitIndividual{F}
     inner::FrontierIndividual{FA}
@@ -111,7 +111,7 @@ params(indi::FrontierIndividualWrapper) = params(indi.inner)
 archived_fitness(indi::FrontierIndividualWrapper) = fitness(indi.inner)
 
 """
-    `EpsBoxArchive`-specific components of the optimization results.
+`EpsBoxArchive`-specific components of the optimization results.
 """
 immutable EpsBoxArchiveOutput{N,F,FS<:EpsBoxDominanceFitnessScheme} <: ArchiveOutput
   best_fitness::NTuple{N,F}
@@ -132,8 +132,8 @@ end
 pareto_frontier(or::OptimizationResults) = or.archive_output.frontier
 
 """
-  `PopulationOptimizer`-specific components of the `OptimizationResults`.
-  Stores the final population.
+`PopulationOptimizer`-specific components of the `OptimizationResults`.
+Stores the final population.
 """
 immutable PopulationOptimizerOutput{P} <: MethodOutput
   population::P

--- a/src/optimization_result.jl
+++ b/src/optimization_result.jl
@@ -2,13 +2,13 @@
     Base class for archive-specific component
     of the `OptimizationResults`.
 """
-@compat abstract type ArchiveOutput end
+abstract type ArchiveOutput end
 
 """
     Base class for method-specific component
     of the `OptimizationResults`.
 """
-@compat abstract type MethodOutput end
+abstract type MethodOutput end
 
 immutable DummyMethodOutput <: MethodOutput end
 

--- a/src/optimization_result.jl
+++ b/src/optimization_result.jl
@@ -23,29 +23,29 @@ Should be compatible (on the API level) with the `Optim` package.
 See `make_opt_results()`.
 """
 type OptimizationResults
-  method::String           # FIXME symbol instead or flexible?
-  stop_reason::String      # FIXME turn into type hierarchy of immutable reasons with their attached info
-  iterations::Int
-  start_time::Float64           # time (seconds) optimization started
-  elapsed_time::Float64         # time (seconds) optimization finished
-  parameters::Parameters        # all user-specified parameters to bboptimize()
-  f_calls::Int                  # total number of fitness function evaluations
-  fit_scheme::FitnessScheme     # fitness scheme used by the archive
-  archive_output::ArchiveOutput # archive-specific output
-  method_output::MethodOutput   # method-specific output
+    method::String           # FIXME symbol instead or flexible?
+    stop_reason::String      # FIXME turn into type hierarchy of immutable reasons with their attached info
+    iterations::Int
+    start_time::Float64           # time (seconds) optimization started
+    elapsed_time::Float64         # time (seconds) optimization finished
+    parameters::Parameters        # all user-specified parameters to bboptimize()
+    f_calls::Int                  # total number of fitness function evaluations
+    fit_scheme::FitnessScheme     # fitness scheme used by the archive
+    archive_output::ArchiveOutput # archive-specific output
+    method_output::MethodOutput   # method-specific output
 
-  function OptimizationResults(ctrl, oc)
-      new(
-        string(oc.parameters[:Method]),
-        stop_reason(ctrl),
-        num_steps(ctrl),
-        start_time(ctrl), elapsed_time(ctrl),
-        oc.parameters,
-        num_func_evals(ctrl),
-        fitness_scheme(evaluator(ctrl).archive),
-        ArchiveOutput(evaluator(ctrl).archive),
-        MethodOutput(ctrl.optimizer))
-  end
+    function OptimizationResults(ctrl, oc)
+        new(
+            string(oc.parameters[:Method]),
+            stop_reason(ctrl),
+            num_steps(ctrl),
+            start_time(ctrl), elapsed_time(ctrl),
+            oc.parameters,
+            num_func_evals(ctrl),
+            fitness_scheme(evaluator(ctrl).archive),
+            ArchiveOutput(evaluator(ctrl).archive),
+            MethodOutput(ctrl.optimizer))
+    end
 end
 
 stop_reason(or::OptimizationResults) = or.stop_reason
@@ -62,17 +62,17 @@ best_fitness(or::OptimizationResults) = or.archive_output.best_fitness
 numdims(or::OptimizationResults) = length(best_candidate(or))
 
 function general_stop_reason(or::OptimizationResults)
-  detailed_reason = stop_reason(or)
+    detailed_reason = stop_reason(or)
 
-  if ismatch(r"Fitness .* within tolerance .* of optimum", detailed_reason)
-    return "Within fitness tolerance of optimum"
-  end
+    if ismatch(r"Fitness .* within tolerance .* of optimum", detailed_reason)
+        return "Within fitness tolerance of optimum"
+    end
 
-  if ismatch(r"Delta fitness .* below tolerance .*", detailed_reason)
-    return "Delta fitness below tolerance"
-  end
+    if ismatch(r"Delta fitness .* below tolerance .*", detailed_reason)
+        return "Delta fitness below tolerance"
+    end
 
-  return detailed_reason
+    return detailed_reason
 end
 
 # Alternative nomenclature that mimics Optim.jl more closely.
@@ -86,11 +86,11 @@ iteration_converged(or::OptimizationResults) = iterations(or) >= parameters(or)[
 `TopListArchive`-specific components of the optimization results.
 """
 immutable TopListArchiveOutput{F,C} <: ArchiveOutput
-  best_fitness::F
-  best_candidate::C
+    best_fitness::F
+    best_candidate::C
 
-  (::Type{TopListArchiveOutput}){F}(archive::TopListArchive{F}) =
-    new{F,Individual}(best_fitness(archive), best_candidate(archive))
+    (::Type{TopListArchiveOutput}){F}(archive::TopListArchive{F}) =
+        new{F,Individual}(best_fitness(archive), best_candidate(archive))
 end
 
 (::Type{ArchiveOutput})(archive::TopListArchive) = TopListArchiveOutput(archive)
@@ -114,17 +114,18 @@ archived_fitness(indi::FrontierIndividualWrapper) = fitness(indi.inner)
 `EpsBoxArchive`-specific components of the optimization results.
 """
 immutable EpsBoxArchiveOutput{N,F,FS<:EpsBoxDominanceFitnessScheme} <: ArchiveOutput
-  best_fitness::NTuple{N,F}
-  best_candidate::Individual
-  frontier::Vector{FrontierIndividualWrapper{NTuple{N,F},IndexedTupleFitness{N,F}}} # inferred Pareto frontier
-  fit_scheme::FS
+    best_fitness::NTuple{N,F}
+    best_candidate::Individual
+    frontier::Vector{FrontierIndividualWrapper{NTuple{N,F},IndexedTupleFitness{N,F}}} # inferred Pareto frontier
+    fit_scheme::FS
 
-  function (::Type{EpsBoxArchiveOutput}){N,F}(archive::EpsBoxArchive{N,F})
-    fit_scheme = fitness_scheme(archive)
-    new{N,F,typeof(fit_scheme)}(convert(NTuple{N,F}, best_fitness(archive), fit_scheme), best_candidate(archive),
-                                FrontierIndividualWrapper{NTuple{N,F}, IndexedTupleFitness{N,F}}[FrontierIndividualWrapper{NTuple{N,F}}(archive.frontier[i], fit_scheme) for i in find(archive.frontier_isoccupied)],
-                                fit_scheme)
-  end
+    function (::Type{EpsBoxArchiveOutput}){N,F}(archive::EpsBoxArchive{N,F})
+        fit_scheme = fitness_scheme(archive)
+        new{N,F,typeof(fit_scheme)}(convert(NTuple{N,F}, best_fitness(archive), fit_scheme), best_candidate(archive),
+                                    FrontierIndividualWrapper{NTuple{N,F}, IndexedTupleFitness{N,F}}[FrontierIndividualWrapper{NTuple{N,F}}(archive.frontier[i], fit_scheme)
+                                                                                                     for i in find(archive.frontier_isoccupied)],
+                                    fit_scheme)
+    end
 end
 
 (::Type{ArchiveOutput})(archive::EpsBoxArchive) = EpsBoxArchiveOutput(archive)
@@ -136,10 +137,10 @@ pareto_frontier(or::OptimizationResults) = or.archive_output.frontier
 Stores the final population.
 """
 immutable PopulationOptimizerOutput{P} <: MethodOutput
-  population::P
+    population::P
 
-  (::Type{PopulationOptimizerOutput})(method::PopulationOptimizer) =
-    new{typeof(population(method))}(population(method))
+    (::Type{PopulationOptimizerOutput})(method::PopulationOptimizer) =
+        new{typeof(population(method))}(population(method))
 end
 
 (::Type{MethodOutput})(optimizer::PopulationOptimizer) = PopulationOptimizerOutput(optimizer)

--- a/src/optimization_result.jl
+++ b/src/optimization_result.jl
@@ -89,7 +89,7 @@ struct TopListArchiveOutput{F,C} <: ArchiveOutput
     best_fitness::F
     best_candidate::C
 
-    (::Type{TopListArchiveOutput}){F}(archive::TopListArchive{F}) =
+    TopListArchiveOutput(archive::TopListArchive{F}) where F =
         new{F,Individual}(best_fitness(archive), best_candidate(archive))
 end
 
@@ -102,9 +102,10 @@ struct FrontierIndividualWrapper{F,FA} <: FitIndividual{F}
     inner::FrontierIndividual{FA}
     fitness::F
 
-    (::Type{FrontierIndividualWrapper{F}}){F,FA}(
-        indi::FrontierIndividual{FA}, fit_scheme::FitnessScheme{FA}) =
-            new{F, FA}(indi, convert(F, fitness(indi), fit_scheme))
+    FrontierIndividualWrapper{F}(
+            indi::FrontierIndividual{FA},
+            fit_scheme::FitnessScheme{FA}) where {F, FA} =
+        new{F, FA}(indi, convert(F, fitness(indi), fit_scheme))
 end
 
 params(indi::FrontierIndividualWrapper) = params(indi.inner)
@@ -119,9 +120,10 @@ struct EpsBoxArchiveOutput{N,F,FS<:EpsBoxDominanceFitnessScheme} <: ArchiveOutpu
     frontier::Vector{FrontierIndividualWrapper{NTuple{N,F},IndexedTupleFitness{N,F}}} # inferred Pareto frontier
     fit_scheme::FS
 
-    function (::Type{EpsBoxArchiveOutput}){N,F}(archive::EpsBoxArchive{N,F})
+    function EpsBoxArchiveOutput(archive::EpsBoxArchive{N,F}) where {N,F}
         fit_scheme = fitness_scheme(archive)
-        new{N,F,typeof(fit_scheme)}(convert(NTuple{N,F}, best_fitness(archive), fit_scheme), best_candidate(archive),
+        new{N,F,typeof(fit_scheme)}(convert(NTuple{N,F}, best_fitness(archive), fit_scheme),
+                                    best_candidate(archive),
                                     FrontierIndividualWrapper{NTuple{N,F}, IndexedTupleFitness{N,F}}[FrontierIndividualWrapper{NTuple{N,F}}(archive.frontier[i], fit_scheme)
                                                                                                      for i in find(archive.frontier_isoccupied)],
                                     fit_scheme)
@@ -139,7 +141,8 @@ Stores the final population.
 struct PopulationOptimizerOutput{P} <: MethodOutput
     population::P
 
-    (::Type{PopulationOptimizerOutput})(method::PopulationOptimizer) =
+    # FIXME PO is only required so that julia doesn't think it's an old inner ctor syntax
+    PopulationOptimizerOutput(method::PO) where {PO<:PopulationOptimizer} =
         new{typeof(population(method))}(population(method))
 end
 

--- a/src/optimization_result.jl
+++ b/src/optimization_result.jl
@@ -10,7 +10,7 @@ of the `OptimizationResults`.
 """
 abstract type MethodOutput end
 
-immutable DummyMethodOutput <: MethodOutput end
+struct DummyMethodOutput <: MethodOutput end
 
 # no method-specific output by default
 (::Type{MethodOutput})(method::Optimizer) = DummyMethodOutput()
@@ -22,7 +22,7 @@ Returned by `run!(oc::OptRunController)`.
 Should be compatible (on the API level) with the `Optim` package.
 See `make_opt_results()`.
 """
-type OptimizationResults
+mutable struct OptimizationResults
     method::String           # FIXME symbol instead or flexible?
     stop_reason::String      # FIXME turn into type hierarchy of immutable reasons with their attached info
     iterations::Int
@@ -85,7 +85,7 @@ iteration_converged(or::OptimizationResults) = iterations(or) >= parameters(or)[
 """
 `TopListArchive`-specific components of the optimization results.
 """
-immutable TopListArchiveOutput{F,C} <: ArchiveOutput
+struct TopListArchiveOutput{F,C} <: ArchiveOutput
     best_fitness::F
     best_candidate::C
 
@@ -98,7 +98,7 @@ end
 """
 Wrapper for `FrontierIndividual` that allows easy access to the problem fitness.
 """
-immutable FrontierIndividualWrapper{F,FA} <: FitIndividual{F}
+struct FrontierIndividualWrapper{F,FA} <: FitIndividual{F}
     inner::FrontierIndividual{FA}
     fitness::F
 
@@ -113,7 +113,7 @@ archived_fitness(indi::FrontierIndividualWrapper) = fitness(indi.inner)
 """
 `EpsBoxArchive`-specific components of the optimization results.
 """
-immutable EpsBoxArchiveOutput{N,F,FS<:EpsBoxDominanceFitnessScheme} <: ArchiveOutput
+struct EpsBoxArchiveOutput{N,F,FS<:EpsBoxDominanceFitnessScheme} <: ArchiveOutput
     best_fitness::NTuple{N,F}
     best_candidate::Individual
     frontier::Vector{FrontierIndividualWrapper{NTuple{N,F},IndexedTupleFitness{N,F}}} # inferred Pareto frontier
@@ -136,7 +136,7 @@ pareto_frontier(or::OptimizationResults) = or.archive_output.frontier
 `PopulationOptimizer`-specific components of the `OptimizationResults`.
 Stores the final population.
 """
-immutable PopulationOptimizerOutput{P} <: MethodOutput
+struct PopulationOptimizerOutput{P} <: MethodOutput
     population::P
 
     (::Type{PopulationOptimizerOutput})(method::PopulationOptimizer) =

--- a/src/optimizer.jl
+++ b/src/optimizer.jl
@@ -1,13 +1,13 @@
 """
   Base abstract class for black-box optimization algorithms.
 """
-@compat abstract type Optimizer end
+abstract type Optimizer end
 
 """
     Optimizers derived from `SteppingOptimizer` implement classical iterative optimization scheme
     `step!()` → `step!()` → …
 """
-@compat abstract type SteppingOptimizer <: Optimizer end
+abstract type SteppingOptimizer <: Optimizer end
 evaluator(so::SteppingOptimizer) = so.evaluator
 
 """
@@ -22,7 +22,7 @@ function step! end # FIXME avoid defining 0-arg function
   `ask()` → ..eval fitness.. → `tell!()`
   sequence at each step.
 """
-@compat abstract type AskTellOptimizer <: Optimizer end
+abstract type AskTellOptimizer <: Optimizer end
 
 """
   `ask(ato::AskTellOptimizer)`
@@ -81,7 +81,7 @@ function tell! end # FIXME avoid defining 0-arg function
 """
   Base class for population-based optimization methods.
 """
-@compat abstract type PopulationOptimizer <: AskTellOptimizer end
+abstract type PopulationOptimizer <: AskTellOptimizer end
 
 population(popopt::PopulationOptimizer) = popopt.population
 popsize(popopt::PopulationOptimizer) = popsize(population(popopt))

--- a/src/optimizer.jl
+++ b/src/optimizer.jl
@@ -1,39 +1,39 @@
 """
-  Base abstract class for black-box optimization algorithms.
+Base abstract class for black-box optimization algorithms.
 """
 abstract type Optimizer end
 
 """
-    Optimizers derived from `SteppingOptimizer` implement classical iterative optimization scheme
-    `step!()` → `step!()` → …
+Optimizers derived from `SteppingOptimizer` implement classical iterative optimization scheme
+`step!()` → `step!()` → …
 """
 abstract type SteppingOptimizer <: Optimizer end
 evaluator(so::SteppingOptimizer) = so.evaluator
 
 """
-  `step!(opt::SteppingOptimizer)`
+    step!(opt::SteppingOptimizer)
 
-  Do one iteration of the method.
+Do one iteration of the method.
 """
 function step! end # FIXME avoid defining 0-arg function
 
 """
-  Base abstract class for optimizers that perform
-  `ask()` → ..eval fitness.. → `tell!()`
-  sequence at each step.
+Base abstract class for optimizers that perform
+`ask()` → ..eval fitness.. → `tell!()`
+sequence at each step.
 """
 abstract type AskTellOptimizer <: Optimizer end
 
 """
-  `ask(ato::AskTellOptimizer)`
+    ask(ato::AskTellOptimizer)
 
-  Ask for a new candidate solution to be generated, and a list of individuals
-  it should be ranked with.
+Ask for a new candidate solution to be generated, and a list of individuals
+it should be ranked with.
 
-  The individuals are supplied as an array of tuples
-  with the individual and its index.
+The individuals are supplied as an array of tuples
+with the individual and its index.
 
-  See also `tell!()`
+See also `tell!()`
 """
 function ask end # FIXME avoid defining 0-arg function
 
@@ -68,18 +68,18 @@ function ask end # FIXME avoid defining 0-arg function
 # approximation of it. Different archival strategies can be implemented.
 
 """
-  `tell!(ato::AskTellOptimizer, rankedCandidates)`
+    tell!(ato::AskTellOptimizer, rankedCandidates)
 
-  Tell the optimizer about the ranking of candidates.
-  Returns the number of `rankedCandidates` that were inserted into the population,
-  because of the improved fitness.
+Tell the optimizer about the ranking of candidates.
+Returns the number of `rankedCandidates` that were inserted into the population,
+because of the improved fitness.
 
-  See also `ask()`.
+See also `ask()`.
 """
 function tell! end # FIXME avoid defining 0-arg function
 
 """
-  Base class for population-based optimization methods.
+Base class for population-based optimization methods.
 """
 abstract type PopulationOptimizer <: AskTellOptimizer end
 
@@ -114,11 +114,11 @@ function name(o::Optimizer)
 end
 
 """
-  `trace_state(io::IO, optimizer::Optimizer, mode::Symbol)`
+    trace_state(io::IO, optimizer::Optimizer, mode::Symbol)
 
-  Trace the current optimization state to a given IO stream.
-  Called by `OptRunController` `trace_progress()`.
+Trace the current optimization state to a given IO stream.
+Called by `OptRunController` `trace_progress()`.
 
-  Override it for your optimizer to generate method-specific diagnostic traces.
+Override it for your optimizer to generate method-specific diagnostic traces.
 """
 function trace_state(io::IO, optimizer::Optimizer, mode::Symbol) end

--- a/src/optimizer.jl
+++ b/src/optimizer.jl
@@ -87,30 +87,29 @@ population(popopt::PopulationOptimizer) = popopt.population
 popsize(popopt::PopulationOptimizer) = popsize(population(popopt))
 
 function setup!(o::SteppingOptimizer)
-  # Do nothing, override if you need to setup prior to the optimization loop
+    # Do nothing, override if you need to setup prior to the optimization loop
 end
 
 function setup!(o::AskTellOptimizer, evaluator::Evaluator)
-  # Do nothing, override if you need to setup prior to the optimization loop
+    # Do nothing, override if you need to setup prior to the optimization loop
 end
 
 function shutdown!(o::Optimizer)
-  # Do nothing, override if you need to setup prior to the optimization loop
+    # Do nothing, override if you need to setup prior to the optimization loop
 end
 
-function shutdown!(o::SteppingOptimizer)
+shutdown!(o::SteppingOptimizer) =
   shutdown!(evaluator(o)) # shutdown the evaluator
-end
 
 # The standard name function converts the type of the optimizer to a string
 # and strips off trailing "Opt".
 function name(o::Optimizer)
-  s = string(typeof(o))
-  if s[end-2:end] == "Opt"
-    return s[1:end-3]
-  else
-    return s
-  end
+    s = string(typeof(o))
+    if s[end-2:end] == "Opt"
+        return s[1:end-3]
+    else
+        return s
+    end
 end
 
 """

--- a/src/parallel_evaluator.jl
+++ b/src/parallel_evaluator.jl
@@ -1,5 +1,5 @@
 """
-  Internal data for the worker process of the parallel evaluator.
+Internal data for the worker process of the parallel evaluator.
 """
 immutable ParallelEvaluatorWorker{P<:OptimizationProblem}
   problem::P
@@ -17,7 +17,7 @@ fitness{P}(params::Individual, worker_ref::ParallelEvaluatorWorkerRef{P}) =
   fitness(params, fetch(fetch(worker_ref))::ParallelEvaluatorWorker{P})
 
 """
-  Current state of fitness function evaluation for the vector of candidates.
+Current state of fitness function evaluation for the vector of candidates.
 """
 type ParallelEvaluationState{F, FS}
   fitness_scheme::FS
@@ -42,8 +42,8 @@ is_stopped(estate::ParallelEvaluationState) = estate.next_index == 0
 abort!(estate::ParallelEvaluationState) = (estate.next_index = 0)
 
 """
-  Reset the current `ParallelEvaluationState` and the vector
-  of candidates that need fitness evaluation.
+Reset the current `ParallelEvaluationState` and the vector
+of candidates that need fitness evaluation.
 """
 function reset!{F}(estate::ParallelEvaluationState{F}, candidates::Vector{Candidate{F}})
   estate.candidates = candidates
@@ -54,8 +54,8 @@ function reset!{F}(estate::ParallelEvaluationState{F}, candidates::Vector{Candid
 end
 
 """
-  Get the index of the next candidate for evaluation
-  based on the Base.pmap() code.
+Get the index of the next candidate for evaluation
+based on the Base.pmap() code.
 """
 function next_candidate!(estate::ParallelEvaluationState, worker_ix::Int)
     @assert !estate.worker_busy[worker_ix]
@@ -94,7 +94,7 @@ function next_candidate!(estate::ParallelEvaluationState, worker_ix::Int)
 end
 
 """
-  Notify that the worker process is finished and reset its busy flag.
+Notify that the worker process is finished and reset its busy flag.
 """
 function worker_finished!(estate::ParallelEvaluationState, worker_ix::Int)
   @assert estate.worker_busy[worker_ix]
@@ -104,8 +104,8 @@ function worker_finished!(estate::ParallelEvaluationState, worker_ix::Int)
 end
 
 """
-  Fitness evaluator that distributes candidates fitness calculation
-  among several worker processes.
+Fitness evaluator that distributes candidates fitness calculation
+among several worker processes.
 """
 type ParallelEvaluator{F, FS, P<:OptimizationProblem} <: Evaluator{P}
   problem::P

--- a/src/parallel_evaluator.jl
+++ b/src/parallel_evaluator.jl
@@ -4,7 +4,7 @@ Internal data for the worker process of the parallel evaluator.
 struct ParallelEvaluatorWorker{P<:OptimizationProblem}
     problem::P
 
-    (::Type{ParallelEvaluatorWorker}){P}(problem::P) =
+    ParallelEvaluatorWorker(problem::P) where {P<:OptimizationProblem} =
         new{P}(problem)
 end
 
@@ -31,8 +31,8 @@ mutable struct ParallelEvaluationState{F, FS}
                                       # fitness calculation
     next_index::Int                   # index of the next candidate to calculate fitness
 
-    function (::Type{ParallelEvaluationState}){FS<:FitnessScheme}(fitness_scheme::FS,
-                                                                  nworkers::Int)
+    function ParallelEvaluationState(fitness_scheme::FS,
+                                     nworkers::Int) where {FS<:FitnessScheme}
         F = fitness_type(fitness_scheme)
         new{F,FS}(fitness_scheme, Vector{Candidate{F}}(),
                   fill(false, nworkers), Vector{Int}(), Condition(), 0)

--- a/src/parallel_evaluator.jl
+++ b/src/parallel_evaluator.jl
@@ -2,39 +2,41 @@
 Internal data for the worker process of the parallel evaluator.
 """
 immutable ParallelEvaluatorWorker{P<:OptimizationProblem}
-  problem::P
+    problem::P
 
-  (::Type{ParallelEvaluatorWorker}){P}(problem::P) = new{P}(problem)
+    (::Type{ParallelEvaluatorWorker}){P}(problem::P) =
+        new{P}(problem)
 end
 
 fitness(params::Individual, worker::ParallelEvaluatorWorker) =
-  fitness(params, worker.problem)
+    fitness(params, worker.problem)
 
 const ChannelRef{T} = RemoteChannel{Channel{T}}
 const ParallelEvaluatorWorkerRef{P} = ChannelRef{ParallelEvaluatorWorker{P}}
 
 fitness{P}(params::Individual, worker_ref::ParallelEvaluatorWorkerRef{P}) =
-  fitness(params, fetch(fetch(worker_ref))::ParallelEvaluatorWorker{P})
+    fitness(params, fetch(fetch(worker_ref))::ParallelEvaluatorWorker{P})
 
 """
 Current state of fitness function evaluation for the vector of candidates.
 """
 type ParallelEvaluationState{F, FS}
-  fitness_scheme::FS
-  candidates::Vector{Candidate{F}}  # candidates to calculate fitness for
+    fitness_scheme::FS
+    candidates::Vector{Candidate{F}}  # candidates to calculate fitness for
 
-  worker_busy::Vector{Bool}         # if the worker is busy calculating
-  retry_queue::Vector{Int}          # queue to candidate indices to retry
+    worker_busy::Vector{Bool}         # if the worker is busy calculating
+    retry_queue::Vector{Int}          # queue to candidate indices to retry
 
-  worker_finished::Condition        # gets notified each time worker is done
-                                    # fitness calculation
-  next_index::Int                   # index of the next candidate to calculate fitness
+    worker_finished::Condition        # gets notified each time worker is done
+                                      # fitness calculation
+    next_index::Int                   # index of the next candidate to calculate fitness
 
-  function (::Type{ParallelEvaluationState}){FS<:FitnessScheme}(fitness_scheme::FS, nworkers::Int)
-    F = fitness_type(fitness_scheme)
-    new{F,FS}(fitness_scheme, Vector{Candidate{F}}(),
-              fill(false, nworkers), Vector{Int}(), Condition(), 0)
-  end
+    function (::Type{ParallelEvaluationState}){FS<:FitnessScheme}(fitness_scheme::FS,
+                                                                  nworkers::Int)
+        F = fitness_type(fitness_scheme)
+        new{F,FS}(fitness_scheme, Vector{Candidate{F}}(),
+                  fill(false, nworkers), Vector{Int}(), Condition(), 0)
+    end
 end
 
 is_stopped(estate::ParallelEvaluationState) = estate.next_index == 0
@@ -46,11 +48,11 @@ Reset the current `ParallelEvaluationState` and the vector
 of candidates that need fitness evaluation.
 """
 function reset!{F}(estate::ParallelEvaluationState{F}, candidates::Vector{Candidate{F}})
-  estate.candidates = candidates
-  fill!(estate.worker_busy, false)
-  empty!(estate.retry_queue)
-  estate.next_index = 1
-  return estate
+    estate.candidates = candidates
+    fill!(estate.worker_busy, false)
+    empty!(estate.retry_queue)
+    estate.next_index = 1
+    return estate
 end
 
 """
@@ -64,30 +66,30 @@ function next_candidate!(estate::ParallelEvaluationState, worker_ix::Int)
     if !is_stopped(estate) && estate.next_index <= length(estate.candidates)
         # find the next candidate with unevaluated fitness
         while !is_stopped(estate) && estate.next_index <= length(estate.candidates)
-          if isnafitness(estate.candidates[estate.next_index].fitness, estate.fitness_scheme)
-            task_ix = estate.next_index
-            estate.next_index += 1
-            break;
-          else
-            estate.next_index += 1
-          end
+            if isnafitness(estate.candidates[estate.next_index].fitness, estate.fitness_scheme)
+                task_ix = estate.next_index
+                estate.next_index += 1
+                break;
+            else
+                estate.next_index += 1
+            end
         end
     end
     if task_ix == 0
-      if !isempty(estate.retry_queue)
-        task_ix = shift!(estate.retry_queue)
-      else
-        # Handles the condition where we have finished processing the requested
-        # lsts as well as any retryqueue entries, but there are still some jobs
-        # active that may result in an error and have to be retried.
-        while any(estate.worker_busy)
-            wait(estate.worker_finished)
-            if !isempty(estate.retry_queue)
-                task_ix = shift!(estate.retry_queue)
-                break
+        if !isempty(estate.retry_queue)
+            task_ix = shift!(estate.retry_queue)
+        else
+            # Handles the condition where we have finished processing the requested
+            # lsts as well as any retryqueue entries, but there are still some jobs
+            # active that may result in an error and have to be retried.
+            while any(estate.worker_busy)
+                wait(estate.worker_finished)
+                if !isempty(estate.retry_queue)
+                    task_ix = shift!(estate.retry_queue)
+                    break
+                end
             end
         end
-      end
     end
     estate.worker_busy[worker_ix] = task_ix != 0
     return task_ix
@@ -97,10 +99,10 @@ end
 Notify that the worker process is finished and reset its busy flag.
 """
 function worker_finished!(estate::ParallelEvaluationState, worker_ix::Int)
-  @assert estate.worker_busy[worker_ix]
-  estate.worker_busy[worker_ix] = false
-  notify(estate.worker_finished; all=true)
-  return estate
+    @assert estate.worker_busy[worker_ix]
+    estate.worker_busy[worker_ix] = false
+    notify(estate.worker_finished; all=true)
+    return estate
 end
 
 """
@@ -108,13 +110,13 @@ Fitness evaluator that distributes candidates fitness calculation
 among several worker processes.
 """
 type ParallelEvaluator{F, FS, P<:OptimizationProblem} <: Evaluator{P}
-  problem::P
-  archive::Archive
-  num_evals::Int
-  last_fitness::F
+    problem::P
+    archive::Archive
+    num_evals::Int
+    last_fitness::F
 
-  worker_refs::Vector{ParallelEvaluatorWorkerRef{P}}
-  eval_state::ParallelEvaluationState{F, FS}
+    worker_refs::Vector{ParallelEvaluatorWorkerRef{P}}
+    eval_state::ParallelEvaluationState{F, FS}
 end
 
 function ParallelEvaluator{P<:OptimizationProblem}(
@@ -167,12 +169,12 @@ function update_fitness!{F}(e::ParallelEvaluator{F}, candidates::Vector{Candidat
         end
     end
 
-    candidates
+    return candidates
 end
 
 # FIXME it's not efficient to calculate fitness like that with `ParallelEvaluator`
 function fitness{F}(params::Individual, e::ParallelEvaluator{F})
-  candi = Candidate{F}(params)
-  update_fitness!(e, [candi])
-  candi.fitness
+    candi = Candidate{F}(params)
+    update_fitness!(e, [candi])
+    return candi.fitness
 end

--- a/src/parallel_evaluator.jl
+++ b/src/parallel_evaluator.jl
@@ -10,8 +10,8 @@ end
 fitness(params::Individual, worker::ParallelEvaluatorWorker) =
   fitness(params, worker.problem)
 
-@compat const ChannelRef{T} = @compat RemoteChannel{Channel{T}}
-@compat const ParallelEvaluatorWorkerRef{P} = ChannelRef{ParallelEvaluatorWorker{P}}
+const ChannelRef{T} = RemoteChannel{Channel{T}}
+const ParallelEvaluatorWorkerRef{P} = ChannelRef{ParallelEvaluatorWorker{P}}
 
 fitness{P}(params::Individual, worker_ref::ParallelEvaluatorWorkerRef{P}) =
   fitness(params, fetch(fetch(worker_ref))::ParallelEvaluatorWorker{P})
@@ -124,7 +124,7 @@ function ParallelEvaluator{P<:OptimizationProblem}(
     ParallelEvaluator{fitness_type(fs), typeof(fs), P}(problem,
         archive,
         0, nafitness(fs),
-        [@compat RemoteChannel(function ()
+        [RemoteChannel(function ()
                      # create fake channel and put problem there
                      ch = Channel{ParallelEvaluatorWorker{P}}(1)
                      put!(ch, ParallelEvaluatorWorker(copy(problem)))
@@ -152,7 +152,7 @@ function update_fitness!{F}(e::ParallelEvaluator{F}, candidates::Vector{Candidat
                 while (candi_ix = next_candidate!(e.eval_state, widx)) != 0
                     try
                         candi = candidates[candi_ix]
-                        candi.fitness = @compat remotecall_fetch(fitness, wref.where, candi.params, wref)
+                        candi.fitness = remotecall_fetch(fitness, wref.where, candi.params, wref)
                         e.last_fitness = candi.fitness
                         e.num_evals += 1
                         add_candidate!(e.archive, candi.fitness, candi.params, e.num_evals)

--- a/src/parallel_evaluator.jl
+++ b/src/parallel_evaluator.jl
@@ -1,7 +1,7 @@
 """
 Internal data for the worker process of the parallel evaluator.
 """
-immutable ParallelEvaluatorWorker{P<:OptimizationProblem}
+struct ParallelEvaluatorWorker{P<:OptimizationProblem}
     problem::P
 
     (::Type{ParallelEvaluatorWorker}){P}(problem::P) =
@@ -20,7 +20,7 @@ fitness{P}(params::Individual, worker_ref::ParallelEvaluatorWorkerRef{P}) =
 """
 Current state of fitness function evaluation for the vector of candidates.
 """
-type ParallelEvaluationState{F, FS}
+mutable struct ParallelEvaluationState{F, FS}
     fitness_scheme::FS
     candidates::Vector{Candidate{F}}  # candidates to calculate fitness for
 
@@ -109,7 +109,7 @@ end
 Fitness evaluator that distributes candidates fitness calculation
 among several worker processes.
 """
-type ParallelEvaluator{F, FS, P<:OptimizationProblem} <: Evaluator{P}
+mutable struct ParallelEvaluator{F, FS, P<:OptimizationProblem} <: Evaluator{P}
     problem::P
     archive::Archive
     num_evals::Int

--- a/src/parameters.jl
+++ b/src/parameters.jl
@@ -112,5 +112,5 @@ The default placeholder value for parameters argument.
 """
 const EMPTY_PARAMS = ParamsDict()
 
-Base.convert(::Type{Dict{Symbol,Any}}, kwargs::Vector{Any}) =
+kwargs2dict(kwargs::Vector{Any}) =
     Dict(Tuple{Symbol,Any}[(convert(Symbol, k), convert(Any,v)) for (k,v) in kwargs])

--- a/src/parameters.jl
+++ b/src/parameters.jl
@@ -2,7 +2,7 @@
 An ordered set of dicts that are examined one after another to find the parameter value.
 Returns nothing if no param setting is found in any of the dicts.
 """
-type DictChain{K,V} <: Associative{K,V}
+mutable struct DictChain{K,V} <: Associative{K,V}
     dicts::Vector{Associative{K,V}}  # First dict is searched first and then in order until the last
 
     DictChain(dicts::Vector{Associative{K,V}}) = new(dicts)

--- a/src/parameters.jl
+++ b/src/parameters.jl
@@ -16,9 +16,13 @@ end
 
 # (Associative{K,V}...) ctor is not triggered, so here's 1-, 2- and 3-argument
 # versions of it, until there's a better way
-DictChain{K,V}(dict::Associative{K,V}) = DictChain{K,V}(dict)
-DictChain{K,V}(dict1::Associative{K,V}, dict2::Associative{K,V}) = DictChain{K,V}(dict1, dict2)
-DictChain{K,V}(dict1::Associative{K,V}, dict2::Associative{K,V}, dict3::Associative{K,V}) = DictChain{K,V}(dict1, dict2, dict3)
+DictChain(dict::Associative{K,V}) where {K,V} = DictChain{K,V}(dict)
+DictChain(dict1::Associative{K,V}, dict2::Associative{K,V}) where {K,V} =
+    DictChain{K,V}(dict1, dict2)
+DictChain(dict1::Associative{K,V},
+          dict2::Associative{K,V},
+          dict3::Associative{K,V}) where {K,V} =
+    DictChain{K,V}(dict1, dict2, dict3)
 
 function Base.show(io::IO, dc::DictChain)
     print(io, typeof(dc), "[")
@@ -31,40 +35,40 @@ end
 
 Base.show(io::IO, ::MIME{Symbol("text/plain")}, dc::DictChain) = show(io, dc)
 
-function Base.getindex{K,V}(p::DictChain{K,V}, key)
+function Base.getindex(p::DictChain, key)
     for d in p.dicts
         haskey(d, key) && return getindex(d, key)
     end
     throw(KeyError(key))
 end
 
-function Base.setindex!{K,V}(p::DictChain{K,V}, value, key)
+function Base.setindex!(p::DictChain{K,V}, value, key) where {K,V}
     isempty(p.dicts) && push!(p.dicts, Dict{K,V}()) # add new dictionary on top
     setindex!(first(p.dicts), value, key)
 end
 
-function Base.haskey{K,V}(p::DictChain{K,V}, key)
+function Base.haskey(p::DictChain, key)
     for d in p.dicts
         haskey(d, key) && return true
     end
     return false
 end
 
-Base.get{K,V}(p::DictChain{K,V}, key, default = nothing) =
+Base.get(p::DictChain, key, default = nothing) =
     return haskey(p, key) ? getindex(p, key) : default
 
 # In a merge the last parameter should be prioritized since this is the way
 # the normal Julia merge() of dicts works.
-Base.merge{K,V}(p1::DictChain{K,V}, p2::Dict{K,V}) = DictChain{K,V}([p2; p1.dicts])
-Base.merge{K,V}(p1::DictChain{K,V}, p2::DictChain{K,V}) = DictChain{K,V}([p2.dicts; p1.dicts])
-Base.merge{K,V}(p1::Dict{K,V}, p2::DictChain{K,V}) = DictChain{K,V}([p2.dicts; p1])
+Base.merge(p1::DictChain{K,V}, p2::Dict{K,V}) where {K,V} = DictChain{K,V}([p2; p1.dicts])
+Base.merge(p1::DictChain{K,V}, p2::DictChain{K,V}) where {K,V} = DictChain{K,V}([p2.dicts; p1.dicts])
+Base.merge(p1::Dict{K,V}, p2::DictChain{K,V}) where {K,V} = DictChain{K,V}([p2.dicts; p1])
 
-function Base.merge!{K,V}(dc::DictChain{K,V}, d::Dict{K,V})
+function Base.merge!(dc::DictChain{K,V}, d::Dict{K,V}) where {K,V}
     insert!(dc.dicts, 1, d)
     return dc
 end
 
-function Base.merge!{K,V}(d::Dict{K,V}, dc::DictChain{K,V})
+function Base.merge!(d::Dict{K,V}, dc::DictChain{K,V}) where {K,V}
     for dict in reverse(dc.dicts)
         merge!(d, dict)
     end
@@ -77,15 +81,15 @@ end
 # merge() grows horizontally (extends dicts vector),
 # whereas chain() grows vertically
 # (references its two arguments in the new 2-element dicts vector)
-chain{K,V}(p1::Associative{K,V}, p2::Associative{K,V}) = DictChain(p2, p1)
-chain{K,V}(p1::Associative{K,V}, p2::Associative{K,V}...) = DictChain(chain(p2...), p1)
+chain(p1::Associative{K,V}, p2::Associative{K,V}) where {K,V} = DictChain(p2, p1)
+chain(p1::Associative{K,V}, p2::Associative{K,V}...) where {K,V} = DictChain(chain(p2...), p1)
 
 flatten(d::Associative) = d
-flatten{K,V}(d::DictChain{K,V}) = convert(Dict{K,V}, d)
+flatten(d::DictChain{K,V}) where {K,V} = convert(Dict{K,V}, d)
 
-Base.convert{K,V}(::Type{Dict{K,V}}, dc::DictChain{K,V}) = merge!(Dict{K,V}(), dc)
+Base.convert(::Type{Dict{K,V}}, dc::DictChain{K,V}) where {K,V} = merge!(Dict{K,V}(), dc)
 
-function Base.delete!{K,V}(p::DictChain{K,V}, key)
+function Base.delete!(p::DictChain, key)
     for d in p.dicts
         delete!(d, key)
     end

--- a/src/parameters.jl
+++ b/src/parameters.jl
@@ -1,6 +1,6 @@
 """
-  An ordered set of dicts that are examined one after another to find the parameter value.
-  Returns nothing if no param setting is found in any of the dicts.
+An ordered set of dicts that are examined one after another to find the parameter value.
+Returns nothing if no param setting is found in any of the dicts.
 """
 type DictChain{K,V} <: Associative{K,V}
   dicts::Vector{Associative{K,V}}  # First dict is searched first and then in order until the last
@@ -98,18 +98,18 @@ function Base.delete!{K,V}(p::DictChain{K,V}, key)
 end
 
 """
-  The parameters storage type for `BlackBoxOptim`.
+The parameters storage type for `BlackBoxOptim`.
 """
 const Parameters = Associative{Symbol,Any}
 
 """
-  The default parameters storage in `BlackBoxOptim`.
+The default parameters storage in `BlackBoxOptim`.
 """
 const ParamsDict = Dict{Symbol,Any}
 const ParamsDictChain = DictChain{Symbol,Any}
 
 """
-  The default placeholder value for parameters argument.
+The default placeholder value for parameters argument.
 """
 const EMPTY_PARAMS = ParamsDict()
 

--- a/src/parameters.jl
+++ b/src/parameters.jl
@@ -100,13 +100,13 @@ end
 """
   The parameters storage type for `BlackBoxOptim`.
 """
-@compat const Parameters = Associative{Symbol,Any}
+const Parameters = Associative{Symbol,Any}
 
 """
   The default parameters storage in `BlackBoxOptim`.
 """
-@compat const ParamsDict = Dict{Symbol,Any}
-@compat const ParamsDictChain = DictChain{Symbol,Any}
+const ParamsDict = Dict{Symbol,Any}
+const ParamsDictChain = DictChain{Symbol,Any}
 
 """
   The default placeholder value for parameters argument.

--- a/src/parameters.jl
+++ b/src/parameters.jl
@@ -5,12 +5,13 @@ Returns nothing if no param setting is found in any of the dicts.
 mutable struct DictChain{K,V} <: Associative{K,V}
     dicts::Vector{Associative{K,V}}  # First dict is searched first and then in order until the last
 
-    DictChain(dicts::Vector{Associative{K,V}}) = new(dicts)
+    DictChain{K,V}(dicts::Vector{Associative{K,V}}) where {K,V} = new{K,V}(dicts)
 
     # empty dicts vector
-    DictChain() = new(Vector{Associative{K,V}}())
+    DictChain{K,V}() where {K,V} = new(Vector{Associative{K,V}}())
 
-    DictChain(dicts::Associative{K,V}...) = new(Associative{K,V}[dict for dict in dicts])
+    DictChain{K,V}(dicts::Associative{K,V}...) where {K,V} =
+        new(Associative{K,V}[dict for dict in dicts])
 end
 
 # (Associative{K,V}...) ctor is not triggered, so here's 1-, 2- and 3-argument

--- a/src/population.jl
+++ b/src/population.jl
@@ -2,19 +2,19 @@
   The base abstract type for the collection of candidate solutions
   in the population-based optimization methods.
 """
-@compat abstract type Population end
+abstract type Population end
 """
   The base abstract types for population that also stores the candidates
   fitness.
 
   `F` is the fitness type.
 """
-@compat abstract type PopulationWithFitness{F} <: Population end
+abstract type PopulationWithFitness{F} <: Population end
 
 """
   The simplest `Population` implementation -- a matrix of floats, each column is an individual.
 """
-@compat const PopulationMatrix = Matrix{Float64}
+const PopulationMatrix = Matrix{Float64}
 
 popsize(pop::PopulationMatrix) = size(pop, 2)
 numdims(pop::PopulationMatrix) = size(pop, 1)

--- a/src/population.jl
+++ b/src/population.jl
@@ -1,18 +1,19 @@
 """
-  The base abstract type for the collection of candidate solutions
-  in the population-based optimization methods.
+The base abstract type for the collection of candidate solutions
+in the population-based optimization methods.
 """
 abstract type Population end
-"""
-  The base abstract types for population that also stores the candidates
-  fitness.
 
-  `F` is the fitness type.
+"""
+The base abstract types for population that also stores the candidates
+fitness.
+
+`F` is the fitness type.
 """
 abstract type PopulationWithFitness{F} <: Population end
 
 """
-  The simplest `Population` implementation -- a matrix of floats, each column is an individual.
+The simplest `Population` implementation -- a matrix of floats, each column is an individual.
 """
 const PopulationMatrix = Matrix{Float64}
 
@@ -45,7 +46,7 @@ function rand_indexes(a::AbstractArray{Int}, k::Int)
 end
 
 """
-  The default implementation of `PopulationWithFitness{F}`.
+The default implementation of `PopulationWithFitness{F}`.
 """
 type FitPopulation{F} <: PopulationWithFitness{F}
   # The population is a matrix of floats, each column being an individual.
@@ -105,9 +106,9 @@ Base.getindex(pop::FitPopulation, indi_ixs) = pop.individuals[:, indi_ixs]
 """
     viewer(population, individual_index)
 
-    Get vector-slice of the population matrix for the specified
-    individual.
-    Does not allocate any additional space, while still providing the same lookup performance.
+Get vector-slice of the population matrix for the specified
+individual.
+Does not allocate any additional space, while still providing the same lookup performance.
 """
 viewer(pop::FitPopulation, indi_ix) = view(pop.individuals, :, indi_ix)
 
@@ -141,11 +142,11 @@ fitness_type{F}(pop::FitPopulation{F}) = F
 candidate_type{F}(pop::FitPopulation{F}) = Candidate{F}
 
 """
-  `acquire_candi(pop::FitPopulation[, {ix::Int, candi::Candidate}])`
+    acquire_candi(pop::FitPopulation[, {ix::Int, candi::Candidate}])
 
-  Get individual from a pool, or create one if the pool is empty.
-  By default the individual is not initialized, but if `ix` or `candi` is specified,
-  the corresponding fields of the new candidate are set to the given values.
+Get individual from a pool, or create one if the pool is empty.
+By default the individual is not initialized, but if `ix` or `candi` is specified,
+the corresponding fields of the new candidate are set to the given values.
 """
 function acquire_candi{F}(pop::FitPopulation{F})
   if isempty(pop.candi_pool)
@@ -174,13 +175,13 @@ end
 acquire_candi{F}(pop::FitPopulation{F}, candi::Candidate{F}) = copy!(acquire_candi(pop), candi)
 
 """
-  Put the candidate back to the pool.
+Put the candidate back to the pool.
 """
 release_candi{F}(pop::FitPopulation{F}, candi::Candidate{F}) = push!(pop.candi_pool, candi)
 
 """
-  Put the candidate back into the pool and copy the values
-  into the corresponding individual of the population (`candi.index` should be set).
+Put the candidate back into the pool and copy the values
+into the corresponding individual of the population (`candi.index` should be set).
 """
 function accept_candi!{F}(pop::FitPopulation{F}, candi::Candidate{F})
   pop.individuals[:, candi.index] = candi.params
@@ -189,10 +190,10 @@ function accept_candi!{F}(pop::FitPopulation{F}, candi::Candidate{F})
 end
 
 """
-  Reset the candidate fitness.
+Reset the candidate fitness.
 
-  Need it when the candidate parameters have changed, but the stored fitness
-  is still for the old parameter set.
+Need it when the candidate parameters have changed, but the stored fitness
+is still for the old parameter set.
 """
 function reset_fitness!{F}(candi::Candidate{F}, pop::FitPopulation{F})
   candi.fitness = pop.nafitness
@@ -202,9 +203,9 @@ end
 candi_pool_size(pop::FitPopulation) = length(pop.candi_pool)
 
 """
-  Generate a population for a given problem.
+Generate a population for a given problem.
 
-  The default method to generate a population, uses Latin Hypercube Sampling.
+The default method to generate a population, uses Latin Hypercube Sampling.
 """
 function population{F}(problem::OptimizationProblem,
                        options::Parameters = EMPTY_PARAMS,

--- a/src/population.jl
+++ b/src/population.jl
@@ -22,8 +22,8 @@ numdims(pop::PopulationMatrix) = size(pop, 1)
 params_mean(pop::PopulationMatrix) = mean(pop, 1)
 params_std(pop::PopulationMatrix) = std(pop, 1)
 
-popsize(pop::Vector{<:Candidate}) = length(pop)
-numdims(pop::Vector{<:Candidate}) = isempty(pop) ? 0 : length(pop[1].params)
+popsize(pop::AbstractVector{<:Candidate}) = length(pop)
+numdims(pop::AbstractVector{<:Candidate}) = isempty(pop) ? 0 : length(pop[1].params)
 
 viewer(pop::PopulationMatrix, indi_ix) = view(pop, :, indi_ix)
 

--- a/src/population.jl
+++ b/src/population.jl
@@ -48,7 +48,7 @@ end
 """
 The default implementation of `PopulationWithFitness{F}`.
 """
-type FitPopulation{F} <: PopulationWithFitness{F}
+mutable struct FitPopulation{F} <: PopulationWithFitness{F}
     # The population is a matrix of floats, each column being an individual.
     individuals::PopulationMatrix
 

--- a/src/population.jl
+++ b/src/population.jl
@@ -49,19 +49,23 @@ end
 The default implementation of `PopulationWithFitness{F}`.
 """
 type FitPopulation{F} <: PopulationWithFitness{F}
-  # The population is a matrix of floats, each column being an individual.
-  individuals::PopulationMatrix
+    # The population is a matrix of floats, each column being an individual.
+    individuals::PopulationMatrix
 
-  nafitness::F
-  fitness::Vector{F}
-  ntransient::Int                  # how many transient members are in the population
+    nafitness::F
+    fitness::Vector{F}
+    ntransient::Int                  # how many transient members are in the population
 
-  candi_pool::Vector{Candidate{F}} # pool of reusable candidates
+    candi_pool::Vector{Candidate{F}} # pool of reusable candidates
 
-  function FitPopulation(individuals::PopulationMatrix, nafitness::F, fitness::Vector{F}; ntransient::Integer=0)
-    popsize(individuals) == length(fitness) || throw(DimensionMismatch("Fitness vector length does not match the population size"))
-    new(individuals, nafitness, fitness, ntransient, Vector{Candidate{F}}())
-  end
+    function FitPopulation(individuals::PopulationMatrix,
+                           nafitness::F,
+                           fitness::Vector{F};
+                           ntransient::Integer=0)
+        popsize(individuals) == length(fitness) || throw(DimensionMismatch("Fitness vector length does not match the population size"))
+        new(individuals, nafitness, fitness, ntransient,
+            Vector{Candidate{F}}())
+    end
 end
 
 FitPopulation{F}(individuals::PopulationMatrix, nafitness::F,
@@ -118,24 +122,24 @@ Base.setindex!(pop::FitPopulation, indi::Individual, ::Colon, indi_ix::Integer) 
 function Base.setindex!(pop::FitPopulation, indi::Individual, indi_ix::Integer)
     pop.individuals[:, indi_ix] = indi
     pop.fitness[indi_ix] = pop.nafitness
-    pop
+    return pop
 end
 
 function Base.setindex!{F}(pop::FitPopulation{F}, indi::FitIndividual{F}, indi_ix::Integer)
     pop.individuals[:, indi_ix] = params(indi)
     pop.fitness[indi_ix] = fitness(indi)
-    pop
+    return pop
 end
 
 function Base.append!{F}(pop::FitPopulation{F}, extra_pop::FitPopulation{F})
-  pop.ntransient == 0 || throw(error("Appending to the population with transients not supported (yet)"))
-  numdims(pop) == numdims(extra_pop) ||
-    throw(DimensionMismatch("Cannot append population, "*
-                            "the number of parameters differs "*
-                            "($(numdims(pop)) vs $(numdims(extra_pop)))"))
-  pop.individuals = hcat(pop.individuals, extra_pop.individuals)
-  append!(pop.fitness, extra_pop.fitness)
-  return pop
+    pop.ntransient == 0 || throw(error("Appending to the population with transients not supported (yet)"))
+    numdims(pop) == numdims(extra_pop) ||
+        throw(DimensionMismatch("Cannot append population, "*
+                                "the number of parameters differs "*
+                                "($(numdims(pop)) vs $(numdims(extra_pop)))"))
+    pop.individuals = hcat(pop.individuals, extra_pop.individuals)
+    append!(pop.fitness, extra_pop.fitness)
+    return pop
 end
 
 fitness_type{F}(pop::FitPopulation{F}) = F
@@ -149,14 +153,14 @@ By default the individual is not initialized, but if `ix` or `candi` is specifie
 the corresponding fields of the new candidate are set to the given values.
 """
 function acquire_candi{F}(pop::FitPopulation{F})
-  if isempty(pop.candi_pool)
-    return Candidate{F}(Individual(numdims(pop)), -1, pop.nafitness)
-  end
-  res = pop!(pop.candi_pool)
-  # reset reference to genetic operation
-  res.extra = NO_GEN_OP
-  res.tag = 0
-  return res
+    if isempty(pop.candi_pool)
+        return Candidate{F}(Individual(numdims(pop)), -1, pop.nafitness)
+    end
+    res = pop!(pop.candi_pool)
+    # reset reference to genetic operation
+    res.extra = NO_GEN_OP
+    res.tag = 0
+    return res
 end
 
 acquire_candis{F}(pop::FitPopulation{F}, n::Integer) =
@@ -172,21 +176,23 @@ function acquire_candi(pop::FitPopulation, ix::Int)
 end
 
 # Get an individual from a pool and sets it to another candidate.
-acquire_candi{F}(pop::FitPopulation{F}, candi::Candidate{F}) = copy!(acquire_candi(pop), candi)
+acquire_candi{F}(pop::FitPopulation{F}, candi::Candidate{F}) =
+    copy!(acquire_candi(pop), candi)
 
 """
 Put the candidate back to the pool.
 """
-release_candi{F}(pop::FitPopulation{F}, candi::Candidate{F}) = push!(pop.candi_pool, candi)
+release_candi{F}(pop::FitPopulation{F}, candi::Candidate{F}) =
+    push!(pop.candi_pool, candi)
 
 """
 Put the candidate back into the pool and copy the values
 into the corresponding individual of the population (`candi.index` should be set).
 """
 function accept_candi!{F}(pop::FitPopulation{F}, candi::Candidate{F})
-  pop.individuals[:, candi.index] = candi.params
-  pop.fitness[candi.index] = candi.fitness
-  release_candi(pop, candi)
+    pop.individuals[:, candi.index] = candi.params
+    pop.fitness[candi.index] = candi.fitness
+    release_candi(pop, candi)
 end
 
 """
@@ -196,8 +202,8 @@ Need it when the candidate parameters have changed, but the stored fitness
 is still for the old parameter set.
 """
 function reset_fitness!{F}(candi::Candidate{F}, pop::FitPopulation{F})
-  candi.fitness = pop.nafitness
-  return candi
+    candi.fitness = pop.nafitness
+    return candi
 end
 
 candi_pool_size(pop::FitPopulation) = length(pop.candi_pool)
@@ -211,16 +217,16 @@ function population{F}(problem::OptimizationProblem,
                        options::Parameters = EMPTY_PARAMS,
                        nafitness::F = nafitness(fitness_scheme(problem));
                        ntransient::Integer = 0)
-  if !haskey(options, :Population)
-      pop = rand_individuals_lhs(search_space(problem), get(options, :PopulationSize, 50) + ntransient)
-  else
-     pop = options[:Population]
-  end
-  if isa(pop, Population)
-    return pop
-  elseif isa(pop, PopulationMatrix)
-    return FitPopulation(pop, nafitness, ntransient=ntransient)
-  else
-    throw(ArgumentError("\"Population\" parameter is of unsupported type: $(typeof(pop))"))
-  end
+    if !haskey(options, :Population)
+        pop = rand_individuals_lhs(search_space(problem), get(options, :PopulationSize, 50) + ntransient)
+    else
+        pop = options[:Population]
+    end
+    if isa(pop, Population)
+        return pop
+    elseif isa(pop, PopulationMatrix)
+        return FitPopulation(pop, nafitness, ntransient=ntransient)
+    else
+        throw(ArgumentError("\"Population\" parameter is of unsupported type: $(typeof(pop))"))
+    end
 end

--- a/src/population.jl
+++ b/src/population.jl
@@ -60,18 +60,14 @@ mutable struct FitPopulation{F} <: PopulationWithFitness{F}
 
     function FitPopulation(individuals::PopulationMatrix,
                            nafitness::F,
-                           fitness::Vector{F};
-                           ntransient::Integer=0)
-        popsize(individuals) == length(fitness) || throw(DimensionMismatch("Fitness vector length does not match the population size"))
-        new(individuals, nafitness, fitness, ntransient,
-            Vector{Candidate{F}}())
+                           fitness::Vector{F} = fill(nafitness, popsize(individuals));
+                           ntransient::Integer=0) where {F}
+        popsize(individuals) == length(fitness) ||
+            throw(DimensionMismatch("Fitness vector length does not match the population size"))
+        new{F}(individuals, nafitness, copy(fitness), ntransient,
+               Vector{Candidate{F}}())
     end
 end
-
-FitPopulation{F}(individuals::PopulationMatrix, nafitness::F,
-                 fitnesses::Vector{F} = fill(nafitness, popsize(individuals));
-                 ntransient::Integer=0) =
-  FitPopulation{F}(individuals, nafitness, fitnesses, ntransient=ntransient)
 
 FitPopulation(fs::FitnessScheme, individuals::PopulationMatrix;
               ntransient::Integer=0) =

--- a/src/problem.jl
+++ b/src/problem.jl
@@ -34,9 +34,9 @@ mutable struct FunctionBasedProblem{FS<:FitnessScheme,SS<:SearchSpace,FO} <: Opt
     ss::SS                # search space
     opt_value::FO         # known optimal value or nothing
 
-    function (::Type{FunctionBasedProblem}){FS<:FitnessScheme,SS<:SearchSpace,FO}(objfunc::Function, name::String,
-                                                                                  fitness_scheme::FS, ss::SS,
-                                                                                  opt_value::FO = nothing)
+    function FunctionBasedProblem(objfunc::Function, name::String,
+                                  fitness_scheme::FS, ss::SS,
+                                  opt_value::FO = nothing) where {FS<:FitnessScheme,SS<:SearchSpace,FO}
         if FO <: Number
             fitness_type(fitness_scheme) == FO ||
                 throw(ArgumentError("Fitness type ($(fitness_type(fitness_scheme))) and opt_value type ($(FO)) do not match"))

--- a/src/problem.jl
+++ b/src/problem.jl
@@ -27,7 +27,7 @@ defined by some Julia `Function` and search space.
 Optionally, a known optimal value could be provided to terminate
 the optimization once it is reached.
 """
-type FunctionBasedProblem{FS<:FitnessScheme,SS<:SearchSpace,FO} <: OptimizationProblem{FS}
+mutable struct FunctionBasedProblem{FS<:FitnessScheme,SS<:SearchSpace,FO} <: OptimizationProblem{FS}
     objfunc::Function     # Objective function
     name::String
     fitness_scheme::FS

--- a/src/problem.jl
+++ b/src/problem.jl
@@ -2,7 +2,7 @@
   The base abstract type for all optimization problems.
   `FS` is a type of a problem's `FitnessScheme`.
 """
-@compat abstract type OptimizationProblem{FS<:FitnessScheme} end
+abstract type OptimizationProblem{FS<:FitnessScheme} end
 
 # common definitions for `OptimizationProblem`
 # (enforce field names of subtypes)

--- a/src/problem.jl
+++ b/src/problem.jl
@@ -1,6 +1,6 @@
 """
-  The base abstract type for all optimization problems.
-  `FS` is a type of a problem's `FitnessScheme`.
+The base abstract type for all optimization problems.
+`FS` is a type of a problem's `FitnessScheme`.
 """
 abstract type OptimizationProblem{FS<:FitnessScheme} end
 
@@ -14,18 +14,18 @@ search_space(p::OptimizationProblem) = p.ss
 numdims(p::OptimizationProblem) = numdims(search_space(p))
 
 """
-  Checks if the current best fitness is within the given range
-  of a known best fitness.
-  By default the best fitness is unknown.
+Checks if the current best fitness is within the given range
+of a known best fitness.
+By default the best fitness is unknown.
 """
 fitness_is_within_ftol(p::OptimizationProblem, fitness, atol::Number) = false
 
 """
-  `OptimizationProblem` with the objective function
-   defined by some Julia `Function` and search space.
+`OptimizationProblem` with the objective function
+defined by some Julia `Function` and search space.
 
-   Optionally, a known optimal value could be provided to terminate
-   the optimization once it is reached.
+Optionally, a known optimal value could be provided to terminate
+the optimization once it is reached.
 """
 type FunctionBasedProblem{FS<:FitnessScheme,SS<:SearchSpace,FO} <: OptimizationProblem{FS}
   objfunc::Function     # Objective function
@@ -49,9 +49,9 @@ end
 objfunc(p::FunctionBasedProblem) = p.objfunc
 
 """
-  `fitness(x, p::OptimizationProblem)`
+    fitness(x, p::OptimizationProblem)
 
-  Evaluates the fitness of a candidate.
+Evaluates the fitness of a candidate.
 """
 fitness(x, p::FunctionBasedProblem) = objfunc(p)(x)
 

--- a/src/problem.jl
+++ b/src/problem.jl
@@ -65,8 +65,8 @@ Base.copy(p::FunctionBasedProblem) =
 opt_value(p::FunctionBasedProblem) = p.opt_value
 
 # checks if the optimal fitness is reached for bounded scalar problem
-fitness_is_within_ftol{FS,SS,F<:Number}(p::FunctionBasedProblem{FS,SS,F},
-                                        fitness::F, atol::Number) = norm(opt_value(p) - fitness) < atol
+fitness_is_within_ftol(p::FunctionBasedProblem{<:FitnessScheme, <:SearchSpace, <:Number},
+                       fitness, atol::Number) = norm(opt_value(p) - fitness) < atol
 
 # no check for unbounded problem (by default, see the definition for OptimizationProblem above)
 # fitness_is_within_ftol{FS,SS}(p::FunctionBasedProblem{FS,SS,Void}, fitness::Number, atol::Number) = true

--- a/src/problem.jl
+++ b/src/problem.jl
@@ -28,22 +28,25 @@ Optionally, a known optimal value could be provided to terminate
 the optimization once it is reached.
 """
 type FunctionBasedProblem{FS<:FitnessScheme,SS<:SearchSpace,FO} <: OptimizationProblem{FS}
-  objfunc::Function     # Objective function
-  name::String
-  fitness_scheme::FS
-  ss::SS                # search space
-  opt_value::FO         # known optimal value or nothing
+    objfunc::Function     # Objective function
+    name::String
+    fitness_scheme::FS
+    ss::SS                # search space
+    opt_value::FO         # known optimal value or nothing
 
-  function (::Type{FunctionBasedProblem}){FS<:FitnessScheme,SS<:SearchSpace,FO}(objfunc::Function, name::String, fitness_scheme::FS, ss::SS, opt_value::FO = nothing)
-    if FO <: Number
-      fitness_type(fitness_scheme) == FO || throw(ArgumentError("Fitness type ($(fitness_type(fitness_scheme))) and opt_value type ($(FO)) do not match"))
-      if isnafitness(opt_value, fitness_scheme) # if NA fitness is given, the problem is unbouned
-        opt_value = nothing
-        #throw(ArgumentError("Known optimal value cannot be NA"))
-      end
+    function (::Type{FunctionBasedProblem}){FS<:FitnessScheme,SS<:SearchSpace,FO}(objfunc::Function, name::String,
+                                                                                  fitness_scheme::FS, ss::SS,
+                                                                                  opt_value::FO = nothing)
+        if FO <: Number
+            fitness_type(fitness_scheme) == FO ||
+                throw(ArgumentError("Fitness type ($(fitness_type(fitness_scheme))) and opt_value type ($(FO)) do not match"))
+            if isnafitness(opt_value, fitness_scheme) # if NA fitness is given, the problem is unbouned
+                opt_value = nothing
+                #throw(ArgumentError("Known optimal value cannot be NA"))
+            end
+        end
+        new{FS,SS,typeof(opt_value)}(objfunc, name, fitness_scheme, ss, opt_value)
     end
-    new{FS,SS,typeof(opt_value)}(objfunc, name, fitness_scheme, ss, opt_value)
-  end
 end
 
 objfunc(p::FunctionBasedProblem) = p.objfunc
@@ -56,12 +59,14 @@ Evaluates the fitness of a candidate.
 fitness(x, p::FunctionBasedProblem) = objfunc(p)(x)
 
 Base.copy(p::FunctionBasedProblem) =
-  FunctionBasedProblem(deepcopy(p.objfunc), deepcopy(p.name), p.fitness_scheme, p.ss, p.opt_value)
+    FunctionBasedProblem(deepcopy(p.objfunc), deepcopy(p.name),
+                         p.fitness_scheme, p.ss, p.opt_value)
 
 opt_value(p::FunctionBasedProblem) = p.opt_value
 
 # checks if the optimal fitness is reached for bounded scalar problem
-fitness_is_within_ftol{FS,SS,F<:Number}(p::FunctionBasedProblem{FS,SS,F}, fitness::F, atol::Number) = norm(opt_value(p) - fitness) < atol
+fitness_is_within_ftol{FS,SS,F<:Number}(p::FunctionBasedProblem{FS,SS,F},
+                                        fitness::F, atol::Number) = norm(opt_value(p) - fitness) < atol
 
 # no check for unbounded problem (by default, see the definition for OptimizationProblem above)
 # fitness_is_within_ftol{FS,SS}(p::FunctionBasedProblem{FS,SS,Void}, fitness::Number, atol::Number) = true

--- a/src/problems/bbob.jl
+++ b/src/problems/bbob.jl
@@ -23,8 +23,8 @@ evaluate(f::BBOBFunction, x) = evalfull(f, x)[0]
 
 # Returns a float penalty for being outside of boundaries [-5, 5]
 function defaultboundaryhandling(x, fac = 1.0)
-  xoutside = maximum(vcat(zeros(size(x)), abs(x) - 5), 1) .* sign(x)
-  fac * sum(xoutside.^2)
+    xoutside = maximum(vcat(zeros(size(x)), abs(x) - 5), 1) .* sign(x)
+    return fac * sum(xoutside.^2)
 end
 
 # Most functions do not have a penalty outside the boundaries though so return
@@ -32,31 +32,31 @@ end
 boundaryhandling(f::BBOBFunction, x) = 0
 
 function evalfull(f::BBOBFunction, x)
-  fadd = getfopt(f)
-  curshape, dim = size(x)
-  # it is assumed x are row vectors
+    fadd = getfopt(f)
+    curshape, dim = size(x)
+    # it is assumed x are row vectors
 
-  if f.lastshape != curshape
-    initwithsize(curshape, dim)
-  end
+    if f.lastshape != curshape
+      initwithsize(curshape, dim)
+    end
 
-  # BOUNDARY HANDLING
-  fadd += boundaryhandling(f, x)
+    # BOUNDARY HANDLING
+    fadd += boundaryhandling(f, x)
 
-  # TRANSFORMATION IN SEARCH SPACE
-  x = x - arrxopt(f) # cannot be replaced with x -= arrxopt! RF: Why???
+    # TRANSFORMATION IN SEARCH SPACE
+    x = x - arrxopt(f) # cannot be replaced with x -= arrxopt! RF: Why???
 
-  # COMPUTATION core
-  ftrue = compute_core(f, x)
-  fval = noise(f.noisefunc, ftrue)
+    # COMPUTATION core
+    ftrue = compute_core(f, x)
+    fval = noise(f.noisefunc, ftrue)
 
-  # FINALIZE
-  ftrue += fadd
-  fval += fadd
-  return (fval, ftrue)
+    # FINALIZE
+    ftrue += fadd
+    fval += fadd
+    return (fval, ftrue)
 end
 
-# All BBOBFunction functions must implement evalfull, which return noisy and 
+# All BBOBFunction functions must implement evalfull, which return noisy and
 # noise-free value, the latter for recording purpose.
 # evalfull(f::BBOBFunction, x) = ...
 
@@ -75,20 +75,20 @@ end
 noise(f::BBOBNfreeFunction, ftrue) = copy(ftrue) # no noise added
 
 type BBOBGaussFunction <: BBOBNoiseFunction
-  gaussbeta::Float64
+    gaussbeta::Float64
 end
 noise(f::BBOBGaussFunction, ftrue) = fGauss(ftrue, f.gaussbeta)
 
 type BBOBUniformFunction <: BBOBNoiseFunction
-  unifalphafac::Float64
-  unifbeta::Float64
+    unifalphafac::Float64
+    unifbeta::Float64
 end
-noise(f::BBOBUniformFunction, ftrue) = 
-  fUniform(ftrue, f.unifalphafac * (0.49 + 1. / f.dim), f.unifbeta)
+noise(f::BBOBUniformFunction, ftrue) =
+    fUniform(ftrue, f.unifalphafac * (0.49 + 1. / f.dim), f.unifbeta)
 
 type BBOBCauchyFunction <: BBOBNoiseFunction
-  cauchyalpha::Float64
-  cauchyp::Float64
+    cauchyalpha::Float64
+    cauchyp::Float64
 end
 noise(f::BBOBCauchyFunction, ftrue) = fCauchy(ftrue, f.cauchyalpha, f.cauchyp)
 
@@ -97,17 +97,17 @@ compute_core(f::FSphere, x) = sum(x.^2)
 
 # Sphere without noise
 type F1 <: FSphere{BBOBNfreeFunction}
-  funId::Int
-  noisefunc::BBOBNoiseFunction
-  F1() = new(1, BBOBNfreeFunction())
+    funId::Int
+    noisefunc::BBOBNoiseFunction
+    F1() = new(1, BBOBNfreeFunction())
 end
 boundaryhandling(f::F1, x) = 0
 
 # Sphere with Gaussian noise
 type F101 <: FSphere{BBOBGaussFunction}
-  funId::Int
-  noisefunc::BBOBNoiseFunction
-  F101 = new(101, BBOBGaussFunction(0.01))
+    funId::Int
+    noisefunc::BBOBNoiseFunction
+    F101 = new(101, BBOBGaussFunction(0.01))
 end
 
 # Run an optimizer like in the COCO (COmparing Continuous Optimizers) sw,
@@ -116,7 +116,7 @@ end
 # COCO method: MY_OPTIMIZER in MY_OPTIMIZER.m
 # COCO differences:
 #  - We send in an optimizer instead of changing the code each time we want to evaluate an optimizer.
-#function coco_run_optimizer(optimizer, problem, numDimensions, 
+#function coco_run_optimizer(optimizer, problem, numDimensions,
 #  funcTarget, maxFunevals; populationSize = 200)
 #  maxfunevals = min(1e8 * numDimensions, maxFunevals)
 #  popsize = min(maxFunevals, populationSize)
@@ -132,7 +132,7 @@ end
 #    if feval(FUN, 'fbest') < ftarget         % COCO-task achieved
 #      break;                                 % (works also for noisy functions)
 #    end
-#  end  
+#  end
 #end
 #
 #function coco

--- a/src/problems/bbob.jl
+++ b/src/problems/bbob.jl
@@ -70,23 +70,23 @@ end
 abstract type BBOBNoiseFunction end
 
 # Different types depending on the noise function used.
-type BBOBNfreeFunction <: BBOBNoiseFunction
+struct BBOBNfreeFunction <: BBOBNoiseFunction
 end
 noise(f::BBOBNfreeFunction, ftrue) = copy(ftrue) # no noise added
 
-type BBOBGaussFunction <: BBOBNoiseFunction
+struct BBOBGaussFunction <: BBOBNoiseFunction
     gaussbeta::Float64
 end
 noise(f::BBOBGaussFunction, ftrue) = fGauss(ftrue, f.gaussbeta)
 
-type BBOBUniformFunction <: BBOBNoiseFunction
+struct BBOBUniformFunction <: BBOBNoiseFunction
     unifalphafac::Float64
     unifbeta::Float64
 end
 noise(f::BBOBUniformFunction, ftrue) =
     fUniform(ftrue, f.unifalphafac * (0.49 + 1. / f.dim), f.unifbeta)
 
-type BBOBCauchyFunction <: BBOBNoiseFunction
+struct BBOBCauchyFunction <: BBOBNoiseFunction
     cauchyalpha::Float64
     cauchyp::Float64
 end
@@ -96,7 +96,7 @@ abstract type FSphere{NoiseFunc} <: BBOBFunction end
 compute_core(f::FSphere, x) = sum(x.^2)
 
 # Sphere without noise
-type F1 <: FSphere{BBOBNfreeFunction}
+struct F1 <: FSphere{BBOBNfreeFunction}
     funId::Int
     noisefunc::BBOBNoiseFunction
     F1() = new(1, BBOBNfreeFunction())
@@ -104,7 +104,7 @@ end
 boundaryhandling(f::F1, x) = 0
 
 # Sphere with Gaussian noise
-type F101 <: FSphere{BBOBGaussFunction}
+struct F101 <: FSphere{BBOBGaussFunction}
     funId::Int
     noisefunc::BBOBNoiseFunction
     F101 = new(101, BBOBGaussFunction(0.01))

--- a/src/problems/bbob.jl
+++ b/src/problems/bbob.jl
@@ -4,7 +4,7 @@
 module COCO
 
 # BBOB test functions are optimization problems
-@compat abstract type BBOBFunction <: OptimizationProblem end
+abstract type BBOBFunction <: OptimizationProblem end
 
 # Number of dimensions.
 ndims(f::BBOBFunction) = f.ndims
@@ -67,7 +67,7 @@ end
 # we can use Julia's type system to model the noise functions in a better
 # way than how it is done in Python. Thus a noise function need not be a
 # BBOBFunction.
-@compat abstract type BBOBNoiseFunction end
+abstract type BBOBNoiseFunction end
 
 # Different types depending on the noise function used.
 type BBOBNfreeFunction <: BBOBNoiseFunction
@@ -92,7 +92,7 @@ type BBOBCauchyFunction <: BBOBNoiseFunction
 end
 noise(f::BBOBCauchyFunction, ftrue) = fCauchy(ftrue, f.cauchyalpha, f.cauchyp)
 
-@compat abstract type FSphere{NoiseFunc} <: BBOBFunction end
+abstract type FSphere{NoiseFunc} <: BBOBFunction end
 compute_core(f::FSphere, x) = sum(x.^2)
 
 # Sphere without noise

--- a/src/problems/bbob/separable_functions.jl
+++ b/src/problems/bbob/separable_functions.jl
@@ -1,4 +1,4 @@
 # Computational cores of BBOB separable functions f1-f5
 
 # f1 = Sphere function
-sphere_function(x::Vector{<:Number}) = sum(abs2, x, 1)
+sphere_function(x::AbstractVector{<:Number}) = sum(abs2, x, 1)

--- a/src/problems/bbob/separable_functions.jl
+++ b/src/problems/bbob/separable_functions.jl
@@ -1,4 +1,4 @@
 # Computational cores of BBOB separable functions f1-f5
 
 # f1 = Sphere function
-sphere_function{T <: Number}(x::Vector{T}) = sum(abs2, x, 1)
+sphere_function(x::Vector{<:Number}) = sum(abs2, x, 1)

--- a/src/problems/multi_objective.jl
+++ b/src/problems/multi_objective.jl
@@ -1,5 +1,5 @@
 """
-  ``(N-1)``-dimensional manifold in ``N``-dimensional space.
+``(N-1)``-dimensional manifold in ``N``-dimensional space.
 """
 immutable Hypersurface{N,SS<:SearchSpace}
     manifold::Function
@@ -16,8 +16,8 @@ end
 """
     generate(surf::Hypersurface, fs::EpsBoxDominanceFitnessScheme, param_step = 0.1*fs.ϵ)
 
-    Generate the points of the hypersurface using the
-    discretization defined by ϵ-box fitness schema.
+Generate the points of the hypersurface using the
+discretization defined by ϵ-box fitness schema.
 """
 @generated function generate{N,F,NP}(surf::Hypersurface{N}, fs::EpsBoxDominanceFitnessScheme{N,F}, ::Type{Val{NP}}, param_step::Vector{F} = 0.1*fs.ϵ)
     quote
@@ -40,7 +40,7 @@ end
 """
     nondominated(fitnesses, fit_scheme)
 
-    Filter `fitnesses` removing all dominated values.
+Filter `fitnesses` removing all dominated values.
 """
 function nondominated{N,F}(fitnesses, fit_scheme::EpsBoxDominanceFitnessScheme{N,F})
     arch = EpsBoxArchive(fit_scheme)
@@ -55,7 +55,7 @@ end
 """
     distance(a::NTuple{N,F}, b::NTuple{N,F})
 
-    Euclidean distance from `a` to `b`.
+Euclidean distance from `a` to `b`.
 """
 @generated function distance{N,F}(a::NTuple{N,F}, b::NTuple{N,F})
     quote
@@ -68,7 +68,7 @@ end
 """
     IGD(A::Vector{NTuple{N,F}}, B::Vector{NTuple{N,F}}, [two_sided=true])
 
-    The average Euclidean distance from the points of `A` to the points of `B`.
+The average Euclidean distance from the points of `A` to the points of `B`.
 """
 IGD{N,F<:Number}(A::Vector{NTuple{N,F}}, B::Vector{NTuple{N,F}}) =
     sum(a -> minimum(b -> distance(a, b), B), A) / length(A)
@@ -76,9 +76,9 @@ IGD{N,F<:Number}(A::Vector{NTuple{N,F}}, B::Vector{NTuple{N,F}}) =
 """
     IGD(ref::Hypersurface, sol::Vector{FitIndividual}, [two_sided=true])
 
-    Average Euclidean distance from the exact Pareto frontier of the problem (`ref`)
-    to the solution (`sol`) produced by the optimization method.
-    If `two_sided` is on, returns the maximum of `IGD(sol, ref)` and `IGD(nondominated(ref), sol)`.
+Average Euclidean distance from the exact Pareto frontier of the problem (`ref`)
+to the solution (`sol`) produced by the optimization method.
+If `two_sided` is on, returns the maximum of `IGD(sol, ref)` and `IGD(nondominated(ref), sol)`.
 """
 function IGD{N,F<:Number,T<:FrontierIndividualWrapper,NP}(ref::Hypersurface{N}, sol::AbstractVector{T},
                              fit_scheme::EpsBoxDominanceFitnessScheme{N,F},
@@ -99,7 +99,7 @@ function IGD{N,F<:Number,T<:FrontierIndividualWrapper,NP}(ref::Hypersurface{N}, 
 end
 
 """
-   CEC09 Unconstrained Problem 8 objective function.
+CEC09 Unconstrained Problem 8 objective function.
 """
 function CEC09_UP8(x::Vector{Float64})
     N = length(x)
@@ -126,8 +126,8 @@ function CEC09_UP8(x::Vector{Float64})
 end
 
 """
-   CEC09 Unconstrained Problem 8 Pareto Frontier.
-   Parameterized by t[1]=f[1] and t[2]=f[2].
+CEC09 Unconstrained Problem 8 Pareto Frontier.
+Parameterized by t[1]=f[1] and t[2]=f[2].
 """
 function CEC09_UP8_PF{NP}(t::Vector{Float64}, ::Type{Val{NP}})
     d=sum(abs2, t)
@@ -135,10 +135,10 @@ function CEC09_UP8_PF{NP}(t::Vector{Float64}, ::Type{Val{NP}})
 end
 
 """
-   The collection of CEC09 unconstrained
-   multi-objective problems.
+The collection of CEC09 unconstrained
+multi-objective problems.
 
-   See http://dces.essex.ac.uk/staff/zhang/MOEAcompetition/cec09testproblem0904.pdf.pdf
+See http://dces.essex.ac.uk/staff/zhang/MOEAcompetition/cec09testproblem0904.pdf.pdf
 """
 const CEC09_Unconstrained_Set = Dict{Int,FunctionBasedProblemFamily}(
     8 => FunctionBasedProblemFamily(CEC09_UP8, "CEC09 UP8",  ParetoFitnessScheme{3}(is_minimizing=true),

--- a/src/problems/multi_objective.jl
+++ b/src/problems/multi_objective.jl
@@ -19,13 +19,17 @@ end
 Generate the points of the hypersurface using the
 discretization defined by ϵ-box fitness schema.
 """
-@generated function generate{N,F,NP}(surf::Hypersurface{N}, fs::EpsBoxDominanceFitnessScheme{N,F}, ::Type{Val{NP}}, param_step::Vector{F} = 0.1*fs.ϵ)
+@generated function generate{N,F,NP}(surf::Hypersurface{N},
+                                     fs::EpsBoxDominanceFitnessScheme{N,F},
+                                     ::Type{Val{NP}},
+                                     param_step::Vector{F} = 0.1*fs.ϵ)
     quote
         #archive = EpsBoxArchive(fs)
         pf = Dict{NTuple{N,Int}, IndexedTupleFitness{N,F}}()
         param = Vector{Float64}(N-1)
         #hat_compare = HatCompare(fs)
-        Base.Cartesian.@nloops $(N-1) t d->linspace(surf.parameter_space.mins[d], surf.parameter_space.maxs[d], ceil(Int, surf.parameter_space.deltas[d]/param_step[d])) d->param[d]=t_d begin
+        Base.Cartesian.@nloops $(N-1) t d->linspace(surf.parameter_space.mins[d], surf.parameter_space.maxs[d],
+                                                    ceil(Int, surf.parameter_space.deltas[d]/param_step[d])) d->param[d]=t_d begin
             fit = surf.manifold(param, Val{NP})
             if !isnafitness(fit, fs) # NA if given parameters do not correspond to any point on the manifold
                 ifit = convert(IndexedTupleFitness, fit, fs)

--- a/src/problems/multi_objective.jl
+++ b/src/problems/multi_objective.jl
@@ -5,7 +5,7 @@ struct Hypersurface{N,SS<:SearchSpace}
     manifold::Function
     parameter_space::SS
 
-    function (::Type{Hypersurface}){SS<:SearchSpace}(manifold::Function, parameter_space::SS)
+    function Hypersurface(manifold::Function, parameter_space::SS) where {SS<:SearchSpace}
         N = numdims(parameter_space)+1
         int_pt = manifold(0.5*(mins(parameter_space)+maxs(parameter_space)), Val{1})
         length(int_pt) == N || throw(DimensionMismatch())

--- a/src/problems/multi_objective.jl
+++ b/src/problems/multi_objective.jl
@@ -1,7 +1,7 @@
 """
 ``(N-1)``-dimensional manifold in ``N``-dimensional space.
 """
-immutable Hypersurface{N,SS<:SearchSpace}
+struct Hypersurface{N,SS<:SearchSpace}
     manifold::Function
     parameter_space::SS
 

--- a/src/problems/problem_family.jl
+++ b/src/problems/problem_family.jl
@@ -1,16 +1,16 @@
 
 """
-    Base class for problem families.
+Base class for problem families.
 
-    It is an abstraction for problem parameterization (e.g by the
-    number of the search space dimensions) that allows
-    to instantiate `OptimizationProblem` for the concrete parameters.
+It is an abstraction for problem parameterization (e.g by the
+number of the search space dimensions) that allows
+to instantiate `OptimizationProblem` for the concrete parameters.
 """
 abstract type ProblemFamily{FS<:FitnessScheme} end
 
 """
-  Family of `FunctionBasedProblem` optimization problems
-  parameterized by the number of search space dimensions.
+Family of `FunctionBasedProblem` optimization problems
+parameterized by the number of search space dimensions.
 """
 type FunctionBasedProblemFamily{F,FS<:FitnessScheme,FO} <: ProblemFamily{FS}
   objfunc::Function                     # Objective function
@@ -35,7 +35,7 @@ objfunc(family::FunctionBasedProblemFamily) = family.objfunc
 """
     instantiate(family::FunctionBasedProblemFamily, ndim::Int)
 
-    Construct search space for `FunctionBasedProblem` with the given number of dimensions.
+Construct search space for `FunctionBasedProblem` with the given number of dimensions.
 """
 function instantiate_search_space(family::FunctionBasedProblemFamily, ndim::Int)
     ndim >= numdims(family.reserved_ss) ||
@@ -46,7 +46,7 @@ end
 """
     instantiate(family::FunctionBasedProblemFamily, ndim::Int)
 
-    Construct `FunctionBasedProblem` with the given number of dimensions.
+Construct `FunctionBasedProblem` with the given number of dimensions.
 """
 instantiate(family::FunctionBasedProblemFamily, ndim::Int) =
     FunctionBasedProblem(family.objfunc, family.name, family.fitness_scheme,
@@ -77,12 +77,12 @@ minimization_problem(f::Function, name::String, range::ParamBounds, ndim::Int, f
     instantiate(MinimizationProblemFamily(f, name, range, fmin), ndim)
 
 """
-  `problem_set(ps::Dict{Any, FunctionBasedProblemFamily}, dims::Union{Int,Vector{Int}})`
+    problem_set(ps::Dict{Any, FunctionBasedProblemFamily}, dims::Union{Int,Vector{Int}})
 
-  Construct a fixed-dimensional version of each problem from `ps`
-  for each dimension given in `dims`.
+Construct a fixed-dimensional version of each problem from `ps`
+for each dimension given in `dims`.
 
-  Returns a dictionary of problems.
+Returns a dictionary of problems.
 """
 function problem_set(ps::Dict{Any, FunctionBasedProblemFamily}, dims::Vector{Int})
   next_free_index = 1

--- a/src/problems/problem_family.jl
+++ b/src/problems/problem_family.jl
@@ -12,7 +12,7 @@ abstract type ProblemFamily{FS<:FitnessScheme} end
 Family of `FunctionBasedProblem` optimization problems
 parameterized by the number of search space dimensions.
 """
-type FunctionBasedProblemFamily{F,FS<:FitnessScheme,FO} <: ProblemFamily{FS}
+struct FunctionBasedProblemFamily{F,FS<:FitnessScheme,FO} <: ProblemFamily{FS}
     objfunc::Function                     # Objective function
     name::String
     fitness_scheme::FS

--- a/src/problems/problem_family.jl
+++ b/src/problems/problem_family.jl
@@ -20,10 +20,11 @@ struct FunctionBasedProblemFamily{F,FS<:FitnessScheme,FO} <: ProblemFamily{FS}
     range_per_dim::ParamBounds            # Default range per dimension
     opt_value::FO                         # optional optimal value, or nothing
 
-    function (::Type{FunctionBasedProblemFamily}){FS<:FitnessScheme,FO}(
+    function FunctionBasedProblemFamily(
             objfunc::Function, name::String,
             fitness_scheme::FS, range::ParamBounds, opt_value::FO = nothing,
-            reserved_ss::RangePerDimSearchSpace = ZERO_SEARCH_SPACE)
+            reserved_ss::RangePerDimSearchSpace = ZERO_SEARCH_SPACE
+    ) where {FS<:FitnessScheme, FO}
         if FO <: Number
             fitness_type(fitness_scheme) == FO ||
                 throw(ArgumentError("Fitness type ($(fitness_type(fitness_scheme))) and opt_value type ($(FO)) do not match"))

--- a/src/problems/problem_family.jl
+++ b/src/problems/problem_family.jl
@@ -6,7 +6,7 @@
     number of the search space dimensions) that allows
     to instantiate `OptimizationProblem` for the concrete parameters.
 """
-@compat abstract type ProblemFamily{FS<:FitnessScheme} end
+abstract type ProblemFamily{FS<:FitnessScheme} end
 
 """
   Family of `FunctionBasedProblem` optimization problems

--- a/src/problems/single_objective.jl
+++ b/src/problems/single_objective.jl
@@ -85,8 +85,8 @@ Evaluate fitness by first shifting `x` and then biasing the returned function va
 evalfunc(x, i, sp::ShiftedAndBiasedProblem) =
   ofunc(sub_problem(sp), i)(x - sp.xshift) + sp.funcshift
 
-shifted{FS<:FitnessScheme}(p::OptimizationProblem{FS}; funcshift = 0.0) =
-    ShiftedAndBiasedProblem{FS}(p; funcshift = funcshift)
+shifted(p::OptimizationProblem{FS}; funcshift = 0.0) where {FS<:FitnessScheme} =
+    ShiftedAndBiasedProblem(p; funcshift = funcshift)
 
 
 #####################################################################

--- a/src/problems/single_objective.jl
+++ b/src/problems/single_objective.jl
@@ -51,7 +51,7 @@ const JadeFunctionSet = Dict{Int,FunctionBasedProblemFamily}(
 
   The concrete derived types must implement a `sub_problem()` method.
 """
-@compat abstract type TransformedProblem{FS<:FitnessScheme} <: OptimizationProblem{FS} end
+abstract type TransformedProblem{FS<:FitnessScheme} <: OptimizationProblem{FS} end
 
 search_space(tp::TransformedProblem) = search_space(sub_problem(tp))
 is_fixed_dimensional(tp::TransformedProblem) = is_fixed_dimensional(sub_problem(tp))

--- a/src/problems/single_objective.jl
+++ b/src/problems/single_objective.jl
@@ -63,7 +63,7 @@ name(tp::TransformedProblem) = name(sub_problem(tp))
 A `TransformedProblem` subclass that shifts the minimum value and biases the returned
 function values.
 """
-type ShiftedAndBiasedProblem{FS<:FitnessScheme} <: TransformedProblem{FS}
+struct ShiftedAndBiasedProblem{FS<:FitnessScheme} <: TransformedProblem{FS}
     xshift::Vector{Float64}
     funcshift::Float64
     subp::OptimizationProblem{FS}

--- a/src/problems/single_objective.jl
+++ b/src/problems/single_objective.jl
@@ -69,9 +69,9 @@ struct ShiftedAndBiasedProblem{FS<:FitnessScheme} <: TransformedProblem{FS}
     subp::OptimizationProblem{FS}
 
     function ShiftedAndBiasedProblem(sub_problem::OptimizationProblem{FS};
-                                     xshift = false, funcshift = 0.0)
+        xshift = false, funcshift = 0.0) where {FS <: FitnessScheme}
         xshift = (xshift != false) ? xshift : rand_individual(search_space(sub_problem))
-        new(xshift[:], funcshift, sub_problem)
+        new{FS}(xshift[:], funcshift, sub_problem)
     end
 end
 

--- a/src/problems/single_objective.jl
+++ b/src/problems/single_objective.jl
@@ -22,19 +22,18 @@ functions which are quite nonstandard. We also skip `f8` since we are unsure
 about its proper implementation.
 """
 const JadeFunctionSet = Dict{Int,FunctionBasedProblemFamily}(
-  1   => MinimizationProblemFamily(sphere, "Sphere", (-100.0, 100.0), 0.0),
-  2   => MinimizationProblemFamily(schwefel2_22,  "Schwefel2.22",  ( -10.0,  10.0), 0.0),
-  3   => MinimizationProblemFamily(schwefel1_2,   "Schwefel1.2",   (-100.0, 100.0), 0.0),
-  4   => MinimizationProblemFamily(schwefel2_21,  "Schwefel2.21",  (-100.0, 100.0), 0.0),
-  5   => MinimizationProblemFamily(rosenbrock,    "Rosenbrock",    ( -30.0,  30.0), 0.0),
-  6   => MinimizationProblemFamily(s2_step,       "Step",          (-100.0, 100.0), 0.0),
-  7   => MinimizationProblemFamily(noisy_quartic, "Noisy quartic", ( -30.0,  30.0)),
-#  8   => MinimizationProblemFamily(schwefel2_26,  "Schwefel2.26",  (-500.0, 500.0)),
-  9   => MinimizationProblemFamily(rastrigin,     "Rastrigin",     ( -5.12,  5.12), 0.0),
-  10  => MinimizationProblemFamily(ackley,        "Ackley",        ( -32.0,  32.0), 0.0),
-  11  => MinimizationProblemFamily(griewank,      "Griewank",      (-600.0, 600.0), 0.0)
+    1   => MinimizationProblemFamily(sphere, "Sphere", (-100.0, 100.0), 0.0),
+    2   => MinimizationProblemFamily(schwefel2_22,  "Schwefel2.22",  ( -10.0,  10.0), 0.0),
+    3   => MinimizationProblemFamily(schwefel1_2,   "Schwefel1.2",   (-100.0, 100.0), 0.0),
+    4   => MinimizationProblemFamily(schwefel2_21,  "Schwefel2.21",  (-100.0, 100.0), 0.0),
+    5   => MinimizationProblemFamily(rosenbrock,    "Rosenbrock",    ( -30.0,  30.0), 0.0),
+    6   => MinimizationProblemFamily(s2_step,       "Step",          (-100.0, 100.0), 0.0),
+    7   => MinimizationProblemFamily(noisy_quartic, "Noisy quartic", ( -30.0,  30.0)),
+#    8   => MinimizationProblemFamily(schwefel2_26,  "Schwefel2.26",  (-500.0, 500.0)),
+    9   => MinimizationProblemFamily(rastrigin,     "Rastrigin",     ( -5.12,  5.12), 0.0),
+    10  => MinimizationProblemFamily(ackley,        "Ackley",        ( -32.0,  32.0), 0.0),
+    11  => MinimizationProblemFamily(griewank,      "Griewank",      (-600.0, 600.0), 0.0)
 )
-
 
 #####################################################################
 # S3 Base functions.
@@ -65,15 +64,15 @@ A `TransformedProblem` subclass that shifts the minimum value and biases the ret
 function values.
 """
 type ShiftedAndBiasedProblem{FS<:FitnessScheme} <: TransformedProblem{FS}
-  xshift::Vector{Float64}
-  funcshift::Float64
-  subp::OptimizationProblem{FS}
+    xshift::Vector{Float64}
+    funcshift::Float64
+    subp::OptimizationProblem{FS}
 
-  ShiftedAndBiasedProblem(sub_problem::OptimizationProblem{FS};
-    xshift = false, funcshift = 0.0) = begin
-    xshift = (xshift != false) ? xshift : rand_individual(search_space(sub_problem))
-    new(xshift[:], funcshift, sub_problem)
-  end
+    function ShiftedAndBiasedProblem(sub_problem::OptimizationProblem{FS};
+                                     xshift = false, funcshift = 0.0)
+        xshift = (xshift != false) ? xshift : rand_individual(search_space(sub_problem))
+        new(xshift[:], funcshift, sub_problem)
+    end
 end
 
 sub_problem(sp::ShiftedAndBiasedProblem) = sp.subp
@@ -83,12 +82,11 @@ is_fixed_dimensional(p::ShiftedAndBiasedProblem) = is_fixed_dimensional(sub_prob
 """
 Evaluate fitness by first shifting `x` and then biasing the returned function value.
 """
-evalfunc(x, i, sp::ShiftedAndBiasedProblem) = begin
+evalfunc(x, i, sp::ShiftedAndBiasedProblem) =
   ofunc(sub_problem(sp), i)(x - sp.xshift) + sp.funcshift
-end
 
-shifted{FS<:FitnessScheme}(p::OptimizationProblem{FS}; funcshift = 0.0) = ShiftedAndBiasedProblem{FS}(p;
-  funcshift = funcshift)
+shifted{FS<:FitnessScheme}(p::OptimizationProblem{FS}; funcshift = 0.0) =
+    ShiftedAndBiasedProblem{FS}(p; funcshift = funcshift)
 
 
 #####################################################################
@@ -98,23 +96,23 @@ shifted{FS<:FitnessScheme}(p::OptimizationProblem{FS}; funcshift = 0.0) = Shifte
 s1_sphere = sphere
 
 function s1_elliptic(x)
-  xt = t_irreg(x)
-  elliptic(xt)
+    xt = t_irreg(x)
+    elliptic(xt)
 end
 
 function s1_rastrigin(x)
-  xt = t_diag(t_asy(t_irreg(x), 0.2), 10)
-  rastrigin(xt)
+    xt = t_diag(t_asy(t_irreg(x), 0.2), 10)
+    rastrigin(xt)
 end
 
 function s1_ackley(x)
-  xt = t_diag(t_asy(t_irreg(x), 0.2), 10)
-  ackley(xt)
+    xt = t_diag(t_asy(t_irreg(x), 0.2), 10)
+    ackley(xt)
 end
 
 function s1_schwefel(x)
-  xt = t_asy(t_irreg(x), 0.2)
-  schwefel1_2(xt)
+    xt = t_asy(t_irreg(x), 0.2)
+    schwefel1_2(xt)
 end
 
 s1_rosenbrock = rosenbrock
@@ -128,73 +126,73 @@ s1_rosenbrock = rosenbrock
 Transform symmetric `f` into asymmetric objective function.
 """
 function t_asy(f, beta)
-  D = length(f)
-  g = copy(f)
-  temp = beta * linspace(0, 1, D)
-  ind = collect(1:D)[f .> 0]
-  t = f[ind] .^ (1 + temp[ind] .* sqrt(f[ind]))
-  setindex!(g, t, ind)
-  g
+    D = length(f)
+    g = copy(f)
+    temp = beta * linspace(0, 1, D)
+    ind = collect(1:D)[f .> 0]
+    t = f[ind] .^ (1 + temp[ind] .* sqrt(f[ind]))
+    setindex!(g, t, ind)
+    return g
 end
 
 """
 Transform `f` into objective function with ill-conditioning effect.
 """
 function t_diag(f, alpha)
-  D = length(f)
-  scales = sqrt(alpha) .^ linspace(0, 1, D)
-  scales .* f
+    D = length(f)
+    scales = sqrt(alpha) .^ linspace(0, 1, D)
+    return scales .* f
 end
 
 """
 Transform `f` into objective function with smooth local irregularities.
 """
 function t_irreg(f)
-   a = 0.1
-   g = copy(f)
-   indices = collect(1:length(f))
+    a = 0.1
+    g = copy(f)
+    indices = collect(1:length(f))
 
-   idxp = indices[f .> 0]
-   t = log(f[idxp])/a
-   r = exp(t + 0.49*(sin(t) + sin(0.79*t))).^a
-   setindex!(g, r, idxp)
+    idxp = indices[f .> 0]
+    t = log(f[idxp])/a
+    r = exp(t + 0.49*(sin(t) + sin(0.79*t))).^a
+    setindex!(g, r, idxp)
 
-   idxn = indices[f .< 0]
-   t = log(-f[idxn])/a
-   r = -exp(t + 0.49*(sin(0.55*t) + sin(0.31*t))).^a
-   setindex!(g, r, idxn)
+    idxn = indices[f .< 0]
+    t = log(-f[idxn])/a
+    r = -exp(t + 0.49*(sin(0.55*t) + sin(0.31*t))).^a
+    setindex!(g, r, idxn)
 
-   g
+    return g
 end
 
 function xshifted(n, f)
-  move = 10.0 * randn(n, 1)
-  transformed_f(x) = f(x .- move)
+    move = 10.0 * randn(n, 1)
+    transformed_f(x) = f(x .- move)
 end
 
 function xrotatedandshifted(n, f, shiftAmplitude = 1.0, rotateAmplitude = 1.0)
-  shift = shiftAmplitude * randn(n, 1)
-  rotmatrix = rotateAmplitude * rand(n, n)
-  transformed_f(x) = f(rotmatrix * (x .- shift))
+    shift = shiftAmplitude * randn(n, 1)
+    rotmatrix = rotateAmplitude * rand(n, n)
+    transformed_f(x) = f(rotmatrix * (x .- shift))
 end
 
 const example_problems = Dict{String, Union{OptimizationProblem,FunctionBasedProblemFamily}}(
-  "Sphere" => JadeFunctionSet[1],
-  "Rosenbrock" => JadeFunctionSet[5],
-  "Schwefel2.22" => JadeFunctionSet[2],
-  "Schwefel1.2" => JadeFunctionSet[3],
-  "Schwefel2.21" => JadeFunctionSet[4],
-  "Step" => JadeFunctionSet[6],
-  "Rastrigin" => JadeFunctionSet[9],
-  "Ackley" => JadeFunctionSet[10],
-  "Griewank" => JadeFunctionSet[11],
-  "Ellipsoid" => MinimizationProblemFamily(ellipsoid, "Ellipsoid", (-65.536, 65.536), 0.0),
-  "Cigar" => MinimizationProblemFamily(cigar, "Cigar", (-100.0, 100.0), 0.0),
-  "DeceptiveCuccu2011_15_2" => MinimizationProblemFamily(deceptive_cuccu2011_15_2, "DeceptiveCuccu2011_15_2", (-100.0, 100.0), 0.0),
-  "Shekel10" => Shekel10,
-  "Shekel7" => Shekel7,
-  "Shekel5" => Shekel5,
-  "Hartman6" => Hartman6,
-  "Hartman3" => Hartman3,
-  "Tsallis1996" => MinimizationProblemFamily(energy_tsallis1996, "Tsallis1996", (-100.0, 100.0), 0.0),
+    "Sphere" => JadeFunctionSet[1],
+    "Rosenbrock" => JadeFunctionSet[5],
+    "Schwefel2.22" => JadeFunctionSet[2],
+    "Schwefel1.2" => JadeFunctionSet[3],
+    "Schwefel2.21" => JadeFunctionSet[4],
+    "Step" => JadeFunctionSet[6],
+    "Rastrigin" => JadeFunctionSet[9],
+    "Ackley" => JadeFunctionSet[10],
+    "Griewank" => JadeFunctionSet[11],
+    "Ellipsoid" => MinimizationProblemFamily(ellipsoid, "Ellipsoid", (-65.536, 65.536), 0.0),
+    "Cigar" => MinimizationProblemFamily(cigar, "Cigar", (-100.0, 100.0), 0.0),
+    "DeceptiveCuccu2011_15_2" => MinimizationProblemFamily(deceptive_cuccu2011_15_2, "DeceptiveCuccu2011_15_2", (-100.0, 100.0), 0.0),
+    "Shekel10" => Shekel10,
+    "Shekel7" => Shekel7,
+    "Shekel5" => Shekel5,
+    "Hartman6" => Hartman6,
+    "Hartman3" => Hartman3,
+    "Tsallis1996" => MinimizationProblemFamily(energy_tsallis1996, "Tsallis1996", (-100.0, 100.0), 0.0),
 )

--- a/src/problems/single_objective.jl
+++ b/src/problems/single_objective.jl
@@ -15,11 +15,11 @@ Hartman6 = minimization_problem(hartman6, "Hartman6", (0.0, 1.0), 6, -3.32237)
 Hartman3 = minimization_problem(hartman3, "Hartman3", (0.0, 1.0), 3, -3.860038442)
 
 """
-  JADE collection of optimization problems.
+JADE collection of optimization problems.
 
-  We skip (for now) `f12` and `f13` in the JADE paper since they are penalized
-  functions which are quite nonstandard. We also skip `f8` since we are unsure
-  about its proper implementation.
+We skip (for now) `f12` and `f13` in the JADE paper since they are penalized
+functions which are quite nonstandard. We also skip `f8` since we are unsure
+about its proper implementation.
 """
 const JadeFunctionSet = Dict{Int,FunctionBasedProblemFamily}(
   1   => MinimizationProblemFamily(sphere, "Sphere", (-100.0, 100.0), 0.0),
@@ -46,10 +46,10 @@ const JadeFunctionSet = Dict{Int,FunctionBasedProblemFamily}(
 #####################################################################
 
 """
-  A `TransformedProblem` just makes a few changes in an original problem but refers
-  most func calls to it.
+A `TransformedProblem` just makes a few changes in an original problem but refers
+most func calls to it.
 
-  The concrete derived types must implement a `sub_problem()` method.
+The concrete derived types must implement a `sub_problem()` method.
 """
 abstract type TransformedProblem{FS<:FitnessScheme} <: OptimizationProblem{FS} end
 
@@ -61,8 +61,8 @@ fmins(tp::TransformedProblem) = fmins(sub_problem(tp))
 name(tp::TransformedProblem) = name(sub_problem(tp))
 
 """
-  A `TransformedProblem` subclass that shifts the minimum value and biases the returned
-  function values.
+A `TransformedProblem` subclass that shifts the minimum value and biases the returned
+function values.
 """
 type ShiftedAndBiasedProblem{FS<:FitnessScheme} <: TransformedProblem{FS}
   xshift::Vector{Float64}
@@ -81,7 +81,7 @@ sub_problem(sp::ShiftedAndBiasedProblem) = sp.subp
 is_fixed_dimensional(p::ShiftedAndBiasedProblem) = is_fixed_dimensional(sub_problem(p))
 
 """
-  Evaluate fitness by first shifting `x` and then biasing the returned function value.
+Evaluate fitness by first shifting `x` and then biasing the returned function value.
 """
 evalfunc(x, i, sp::ShiftedAndBiasedProblem) = begin
   ofunc(sub_problem(sp), i)(x - sp.xshift) + sp.funcshift
@@ -125,7 +125,7 @@ s1_rosenbrock = rosenbrock
 #####################################################################
 
 """
-  Transform symmetric `f` into asymmetric objective function.
+Transform symmetric `f` into asymmetric objective function.
 """
 function t_asy(f, beta)
   D = length(f)
@@ -138,7 +138,7 @@ function t_asy(f, beta)
 end
 
 """
-  Transform `f` into objective function with ill-conditioning effect.
+Transform `f` into objective function with ill-conditioning effect.
 """
 function t_diag(f, alpha)
   D = length(f)
@@ -147,7 +147,7 @@ function t_diag(f, alpha)
 end
 
 """
-  Transform `f` into objective function with smooth local irregularities.
+Transform `f` into objective function with smooth local irregularities.
 """
 function t_irreg(f)
    a = 0.1

--- a/src/problems/single_objective_base_functions.jl
+++ b/src/problems/single_objective_base_functions.jl
@@ -5,7 +5,7 @@
 sphere(x) = sum(abs2, x)
 
 """
-  Schwefel's ellipsoid.
+Schwefel's ellipsoid.
 """
 function ellipsoid(x)
     res = 0.0
@@ -82,7 +82,7 @@ cigar(x) = x[1]^2 + 1e6 * sum(abs2, view(x, 2:length(x)))
 cigtab(x) = x[1]^2 + 1e8 * x[end]^2 + 1e4 * sum(abs2, view(x, 2:length(x)-1))
 
 """
-  Generic function to define `ShekelN` problems.
+Generic function to define `ShekelN` problems.
 """
 function shekel(x, a, c)
     @assert length(x) == size(a, 2)
@@ -103,9 +103,9 @@ Shekel10_A = [4 4 4 4; 1 1 1 1; 8 8 8 8; 6 6 6 6; 3 7 3 7; 2 9 2 9; 5 5 3 3; 8 1
 Shekel10_C = [0.1, 0.2, 0.2, 0.4, 0.4, 0.6, 0.3, 0.7, 0.5, 0.5]
 
 """
-  `Shekel10` is a 4D, multi-minima, non-separable test problem. Our implementation
-  is based on the C code in:
-    http://www.math.ntu.edu.tw/~wwang/cola_lab/test_problems/multiple_opt/multiopt_prob/Shekel10/Shekel10.c
+`Shekel10` is a 4D, multi-minima, non-separable test problem. Our implementation
+is based on the C code in:
+http://www.math.ntu.edu.tw/~wwang/cola_lab/test_problems/multiple_opt/multiopt_prob/Shekel10/Shekel10.c
 """
 shekel10(x) = shekel(x, Shekel10_A, Shekel10_C)
 
@@ -114,9 +114,9 @@ Shekel7_A = [4 4 4 4; 1 1 1 1; 8 8 8 8; 6 6 6 6; 3 7 3 7; 2 9 2 9; 5 5 3 3]
 Shekel7_C = [0.1, 0.2, 0.2, 0.4, 0.4, 0.6, 0.3]
 
 """
-  `Shekel7` is a 4D, multi-minima, non-separable test problem. Our implementation
-  is based on the C code in:
-    http://www.math.ntu.edu.tw/~wwang/cola_lab/test_problems/multiple_opt/multiopt_prob/Shekel7/Shekel7.c
+`Shekel7` is a 4D, multi-minima, non-separable test problem. Our implementation
+is based on the C code in:
+http://www.math.ntu.edu.tw/~wwang/cola_lab/test_problems/multiple_opt/multiopt_prob/Shekel7/Shekel7.c
 """
 shekel7(x) = shekel(x, Shekel7_A, Shekel7_C)
 
@@ -125,14 +125,14 @@ Shekel5_A = [4 4 4 4; 1 1 1 1; 8 8 8 8; 6 6 6 6; 3 7 3 7]
 Shekel5_C = [0.1, 0.2, 0.2, 0.4, 0.4]
 
 """
-  `Shekel5` is a 4D, multi-minima, non-separable test problem. Our implementation
-  is based on the C code in:
-    http://www.math.ntu.edu.tw/~wwang/cola_lab/test_problems/multiple_opt/multiopt_prob/Shekel5/Shekel5.c
+`Shekel5` is a 4D, multi-minima, non-separable test problem. Our implementation
+is based on the C code in:
+http://www.math.ntu.edu.tw/~wwang/cola_lab/test_problems/multiple_opt/multiopt_prob/Shekel5/Shekel5.c
 """
 shekel5(x) = shekel(x, Shekel5_A, Shekel5_C)
 
 """
-  Generic function for `Hartman N` problem family.
+Generic function for `Hartman N` problem family.
 """
 function hartman(x, alpha, A, P)
     @assert size(A) == size(P)
@@ -155,8 +155,8 @@ Hartman6_A = [10 3 17 3.50 1.7 8; 0.05 10 17 0.1 8 14; 3 3.5 1.7 10 17 8; 17 8 0
 Hartman6_P = 1e-4 * [1312 1696 5569 124 8283 5886; 2329 4135 8307 3736 1004 9991; 2348 1451 3522 2883 3047 6650; 4047 8828 8732 5743 1091 381]
 
 """
-  `Hartman 6D` is a multi-minima, non-separable test problem. Our implementation is based on:
-    http://www.sfu.ca/~ssurjano/hart6.html
+`Hartman 6D` is a multi-minima, non-separable test problem. Our implementation is based on:
+http://www.sfu.ca/~ssurjano/hart6.html
 """
 hartman6(x) = hartman(x, Hartman6_alpha, Hartman6_A, Hartman6_P)
 
@@ -166,10 +166,10 @@ Hartman3_A = [3.0 10 30; 0.1 10 35; 3.0 10 30; 0.1 10 36]
 Hartman3_P = 1e-4 * [3689 1170 2673; 4699 4387 7470; 1091 8732 5547; 381 5743 8828]
 
 """
-  `Hartman 3D` is a multi-minima, non-separable test problem. Our implementation is based on:
-    http://www.sfu.ca/~ssurjano/hart3.html
-  However, we get a different global minima than the one stated on that page.
-  The minima should be -3.86278 but we get a different one so use that in the problem spec:
+`Hartman 3D` is a multi-minima, non-separable test problem. Our implementation is based on:
+http://www.sfu.ca/~ssurjano/hart3.html
+However, we get a different global minima than the one stated on that page.
+The minima should be -3.86278 but we get a different one so use that in the problem spec:
 """
 hartman3(x) = hartman(x, Hartman3_alpha, Hartman3_A, Hartman3_P)
 
@@ -216,15 +216,15 @@ s2_step(x) = sum(xx -> abs2(ceil(xx + 0.5)), x)
 #end
 
 """
-  Generator for the family of deceptive functions from the
-  Cuccu2011 paper on novelty-based restarts. We have vectorized it to allow
-  more than 1D versions. The Cuccu2011 paper uses the following values for
+Generator for the family of deceptive functions from the
+Cuccu2011 paper on novelty-based restarts. We have vectorized it to allow
+more than 1D versions. The Cuccu2011 paper uses the following values for
 ```
-  (l, w) = [(5, 0),  (15, 0),  (30, 0),
-           (5, 2),  (15, 2),  (30, 2),
-           (5, 10), (15, 10), (30, 10)]
+(l, w) = [(5, 0),  (15, 0),  (30, 0),
+          (5, 2),  (15, 2),  (30, 2),
+          (5, 10), (15, 10), (30, 10)]
 ```
-  and notes that `(15, 2)` and `(30, 2)` are the most difficult instances.
+and notes that `(15, 2)` and `(30, 2)` are the most difficult instances.
 """
 function deceptive_cuccu2011(l, w)
   (x) -> begin
@@ -244,9 +244,9 @@ deceptive_cuccu2011_15_2 = deceptive_cuccu2011(15, 2)
 deceptive_cuccu2011_30_2 = deceptive_cuccu2011(30, 2)
 
 """
-  From section 3, page 7, of Tsallis1996 paper:
+From section 3, page 7, of Tsallis1996 paper:
     Tsallis and Stariolo, "Generalized simulated annealing", Physica A, 1996.
-  available from http://www.if.ufrgs.br/~stariolo/publications/TsSt96_PhysA233_395_1996.pdf
- the original paper used this as a 4-dimensional problem but here it is generalized.
+available from http://www.if.ufrgs.br/~stariolo/publications/TsSt96_PhysA233_395_1996.pdf
+the original paper used this as a 4-dimensional problem but here it is generalized.
 """
 energy_tsallis1996(x::AbstractArray) = sum(xx -> abs2(xx^2 - 8.0), x) + 5.0*sum(x) + 57.3276

--- a/src/problems/single_objective_base_functions.jl
+++ b/src/problems/single_objective_base_functions.jl
@@ -14,56 +14,56 @@ function ellipsoid(x)
         cumsum += xx
         res += cumsum^2
     end
-    res
+    return res
 end
 
 function elliptic(x)
-  D = length(x)
-  condition = 1e+6
-  coefficients = condition .^ linspace(0, 1, D)
-  sum(coefficients .* x.^2)
+    D = length(x)
+    condition = 1e+6
+    coefficients = condition .^ linspace(0, 1, D)
+    return sum(coefficients .* x.^2)
 end
 
 function rastrigin(x)
-  D = length(x)
-  10 * D + sum(abs2, x) - 10 * sum(xx -> cos(2π * xx), x)
+    D = length(x)
+    10 * D + sum(abs2, x) - 10 * sum(xx -> cos(2π * xx), x)
 end
 
 function ackley(x)
-  D = length(x)
-  try
-    20 - 20.*exp(-0.2.*sqrt(sum(abs2, x)/D)) - exp(sum(xx -> cos(2π * xx), x)/D) + e
-  catch ex
-    # Sometimes we have gotten a DomainError from the cos function so we protect this call
-    println(ex)
-    println("For input x = ", x)
-    # Return a very large fitness value to indicate that this is NOT the solution we want.
-    # TODO: Fix better way to handle this!
-    9.99e100
-  end
+    D = length(x)
+    try
+        return 20 - 20.*exp(-0.2.*sqrt(sum(abs2, x)/D)) - exp(sum(xx -> cos(2π * xx), x)/D) + e
+    catch ex
+        # Sometimes we have gotten a DomainError from the cos function so we protect this call
+        println(ex)
+        println("For input x = ", x)
+        # Return a very large fitness value to indicate that this is NOT the solution we want.
+        # TODO: Fix better way to handle this!
+        return 9.99e100
+    end
 end
 
 function schwefel1_2(x)
-  D = length(x)
-  partsums = zeros(D)
-  partsum = 0
-  for i in 1:D
-    partsum += x[i]
-    partsums[i] = partsum
-  end
-  sum(abs2, partsums)
+    D = length(x)
+    partsums = zeros(D)
+    partsum = 0
+    for i in 1:D
+        partsum += x[i]
+        partsums[i] = partsum
+    end
+    return sum(abs2, partsums)
 end
 
 function rosenbrock(x)
-  n = length(x)
-  return( sum(100*(view(x, 2:n) - view(x, 1:(n-1)).^2).^2 + (view(x, 1:(n-1)) - 1).^2) )
+    n = length(x)
+    return sum(100*(view(x, 2:n) - view(x, 1:(n-1)).^2).^2 + (view(x, 1:(n-1)) - 1).^2)
 end
 
 step(x) = sum(xx -> ceil(xx + 0.5), x)
 
 function griewank(x)
-  n = length(x)
-  1 + (1/4000)*sum(abs2, x) - prod(cos(x ./ sqrt(1:n)))
+    n = length(x)
+    1 + (1/4000)*sum(abs2, x) - prod(cos(x ./ sqrt(1:n)))
 end
 
 schwefel2_22(x) = sum(abs, x) + prod(abs, x)
@@ -73,8 +73,8 @@ schwefel2_21(x) = maximum(abs, x)
 # I'm unsure about this one since it does not return the expected minima at
 # [1.0, 1.0].
 function schwefel2_26(x)
-  D = length(x)
-  418.98288727243369 * D - sum(xx -> xx * sin(sqrt(abs(xx))), x)
+    D = length(x)
+    418.98288727243369 * D - sum(xx -> xx * sin(sqrt(abs(xx))), x)
 end
 
 cigar(x) = x[1]^2 + 1e6 * sum(abs2, view(x, 2:length(x)))
@@ -178,10 +178,7 @@ hartman3(x) = hartman(x, Hartman3_alpha, Hartman3_A, Hartman3_P)
 # in table II of the JADE paper: http://150.214.190.154/EAMHCO/pdf/JADE.pdf
 #####################################################################
 
-function quartic(x)
-  D = length(x)
-  sum( (1:D) .* x.^4 )
-end
+quartic(x) = sum((i,x) -> i*x^4, enumerate(x))
 
 noisy_quartic(x) = quartic(x) + rand()
 
@@ -227,16 +224,16 @@ more than 1D versions. The Cuccu2011 paper uses the following values for
 and notes that `(15, 2)` and `(30, 2)` are the most difficult instances.
 """
 function deceptive_cuccu2011(l, w)
-  (x) -> begin
-    sumabsx = sum(abs, x)
-    if sumabsx <= 1
-      return sum(abs2, x)
-    elseif sumabsx >= l+1
-      return sum(xx -> abs2(abs(xx) - l), x)
-    else
-      return (1 - 0.5 * sum(xx -> abs2(sin( (π * w * (abs(xx) - 1)) / l )), x))
+    (x) -> begin
+        sumabsx = sum(abs, x)
+        if sumabsx <= 1
+            return sum(abs2, x)
+        elseif sumabsx >= l+1
+            return sum(xx -> abs2(abs(xx) - l), x)
+        else
+            return (1 - 0.5 * sum(xx -> abs2(sin( (π * w * (abs(xx) - 1)) / l )), x))
+        end
     end
-  end
 end
 
 # Deceptive/hardest instances:

--- a/src/random_search.jl
+++ b/src/random_search.jl
@@ -14,7 +14,7 @@ end
 function ask(rs::RandomSearcher)
     # Just randomly generate a new individual and return it with a dummy index
     # (since we do not have a population there are no indices).
-    Candidate{Float64}[Candidate{Float64}(rand_individual(rs.search_space), 1)]
+    [Candidate{Float64}(rand_individual(rs.search_space), 1)]
 end
 
 function tell!{F}(rs::RandomSearcher, rankedCandidates::Vector{Candidate{F}})

--- a/src/random_search.jl
+++ b/src/random_search.jl
@@ -1,5 +1,5 @@
 """
-  Optimize by randomly generating the candidates.
+Optimize by randomly generating the candidates.
 """
 type RandomSearcher{S<:SearchSpace} <: AskTellOptimizer
   name::String

--- a/src/random_search.jl
+++ b/src/random_search.jl
@@ -7,11 +7,9 @@ mutable struct RandomSearcher{S<:SearchSpace} <: AskTellOptimizer
     best_fitness          # FIXME fitness type should be known
     best::Individual
 
-    RandomSearcher(searchSpace::S) =
-        new("Random Search", searchSpace, nothing)
+    RandomSearcher(searchSpace::S) where {S<:SearchSpace} =
+        new{S}("Random Search", searchSpace, nothing)
 end
-
-RandomSearcher{S<:SearchSpace}(searchSpace::S) = RandomSearcher{S}(searchSpace)
 
 function ask(rs::RandomSearcher)
     # Just randomly generate a new individual and return it with a dummy index

--- a/src/random_search.jl
+++ b/src/random_search.jl
@@ -1,7 +1,7 @@
 """
 Optimize by randomly generating the candidates.
 """
-type RandomSearcher{S<:SearchSpace} <: AskTellOptimizer
+mutable struct RandomSearcher{S<:SearchSpace} <: AskTellOptimizer
     name::String
     search_space::S
     best_fitness          # FIXME fitness type should be known

--- a/src/random_search.jl
+++ b/src/random_search.jl
@@ -2,37 +2,36 @@
 Optimize by randomly generating the candidates.
 """
 type RandomSearcher{S<:SearchSpace} <: AskTellOptimizer
-  name::String
-  search_space::S
-  best_fitness          # FIXME fitness type should be known
-  best::Individual
+    name::String
+    search_space::S
+    best_fitness          # FIXME fitness type should be known
+    best::Individual
 
-  RandomSearcher(searchSpace::S) = new("Random Search", searchSpace, nothing)
+    RandomSearcher(searchSpace::S) =
+        new("Random Search", searchSpace, nothing)
 end
 
 RandomSearcher{S<:SearchSpace}(searchSpace::S) = RandomSearcher{S}(searchSpace)
 
 function ask(rs::RandomSearcher)
-  # Just randomly generate a new individual and return it with a dummy index
-  # (since we do not have a population there are no indices).
-  Candidate{Float64}[Candidate{Float64}(rand_individual(rs.search_space), 1)]
+    # Just randomly generate a new individual and return it with a dummy index
+    # (since we do not have a population there are no indices).
+    Candidate{Float64}[Candidate{Float64}(rand_individual(rs.search_space), 1)]
 end
 
 function tell!{F}(rs::RandomSearcher, rankedCandidates::Vector{Candidate{F}})
-  candidate = rankedCandidates[1]
-  if rs.best_fitness == nothing || candidate.fitness < rs.best_fitness
-    rs.best = candidate.params
-    rs.best_fitness = candidate.fitness
-    return 1
-  else
-    return 0
-  end
+    candidate = rankedCandidates[1]
+    if rs.best_fitness == nothing || candidate.fitness < rs.best_fitness
+        rs.best = candidate.params
+        rs.best_fitness = candidate.fitness
+        return 1
+    else
+        return 0
+    end
 end
 
-function random_search(problem::OptimizationProblem, parameters::Parameters)
-  RandomSearcher(search_space(problem))
-end
+random_search(problem::OptimizationProblem, parameters::Parameters) =
+    RandomSearcher(search_space(problem))
 
-function random_search(ss::SearchSpace)
-  RandomSearcher(ss)
-end
+random_search(ss::SearchSpace) =
+    RandomSearcher(ss)

--- a/src/resampling_memetic_search.jl
+++ b/src/resampling_memetic_search.jl
@@ -33,13 +33,13 @@ mutable struct ResamplingMemeticSearcher{E<:Evaluator} <: SteppingOptimizer
 
     # Constructor for RS:
     function ResamplingMemeticSearcher(evaluator::E, parameters::Parameters,
-            resampling_function::Function, name::String) = begin
+            resampling_function::Function, name::String) where {E<:Evaluator}
         params = chain(RSDefaultParameters, parameters)
         elite = rand_individual(search_space(evaluator))
         diams = diameters(search_space(evaluator))
-        new(name, params, evaluator, resampling_function,
-            params[:PrecisionRatio] * diams, diams,
-            elite, fitness(elite, evaluator))
+        new{E}(name, params, evaluator, resampling_function,
+               params[:PrecisionRatio] * diams, diams,
+               elite, fitness(elite, evaluator))
     end
 end
 
@@ -48,11 +48,6 @@ name(rs::ResamplingMemeticSearcher) = rs.name
 const RISDefaultParameters = ParamsDict(
     :InheritanceRatio => 0.30   # On average, 30% of positions are inherited when resampling in RIS
 )
-
-function ResamplingMemeticSearcher{E<:Evaluator}(evaluator::E,
-    params, resampling_function, name)
-    ResamplingMemeticSearcher{E}(evaluator, params, resampling_function, name)
-end
 
 ResamplingMemeticSearcher(problem::OptimizationProblem,
         params::Parameters = EMPTY_PARAMS,

--- a/src/resampling_memetic_search.jl
+++ b/src/resampling_memetic_search.jl
@@ -4,20 +4,20 @@ const RSDefaultParameters = ParamsDict(
 )
 
 """
-  The variants of the memetic search algorithms RS and RIS.
-  However, we have modified them since they did not give very good performance when
-  implemented as described in the papers below. Possibly, the papers are not
-  unambigous and I have misinterpreted something from them...
+The variants of the memetic search algorithms RS and RIS.
+However, we have modified them since they did not give very good performance when
+implemented as described in the papers below. Possibly, the papers are not
+unambigous and I have misinterpreted something from them...
 
-  The "Resampling Search" (RS) memetic algorithm is described in:
+The "Resampling Search" (RS) memetic algorithm is described in:
 
-  F. Caraffini, F. Neri, M. Gongora and B. N. Passow, "Re-sampling Search: A
-  Seriously Simple Memetic Approach with a High Performance", 2013.
+    F. Caraffini, F. Neri, M. Gongora and B. N. Passow, "Re-sampling Search: A
+    Seriously Simple Memetic Approach with a High Performance", 2013.
 
- and its close sibling "Resampling Inheritance Search" (RIS) is described in:
+and its close sibling "Resampling Inheritance Search" (RIS) is described in:
 
-  F. Caraffini, F. Neri, B. N. Passow and G. Iacca, "Re-sampled Inheritance
-  Search: High Performance Despite the Simplicity", 2013.
+    F. Caraffini, F. Neri, B. N. Passow and G. Iacca, "Re-sampled Inheritance
+    Search: High Performance Despite the Simplicity", 2013.
 """
 type ResamplingMemeticSearcher{E<:Evaluator} <: SteppingOptimizer
   name::String

--- a/src/resampling_memetic_search.jl
+++ b/src/resampling_memetic_search.jl
@@ -19,7 +19,7 @@ and its close sibling "Resampling Inheritance Search" (RIS) is described in:
     F. Caraffini, F. Neri, B. N. Passow and G. Iacca, "Re-sampled Inheritance
     Search: High Performance Despite the Simplicity", 2013.
 """
-type ResamplingMemeticSearcher{E<:Evaluator} <: SteppingOptimizer
+mutable struct ResamplingMemeticSearcher{E<:Evaluator} <: SteppingOptimizer
     name::String
     params::Parameters
     evaluator::E

--- a/src/resampling_memetic_search.jl
+++ b/src/resampling_memetic_search.jl
@@ -1,6 +1,6 @@
 const RSDefaultParameters = ParamsDict(
-  :PrecisionRatio    => 0.40, # 40% of the diameter is used as the initial step length
-  :PrecisionTreshold => 1e-6  # They use 1e-6 in the paper.
+    :PrecisionRatio    => 0.40, # 40% of the diameter is used as the initial step length
+    :PrecisionTreshold => 1e-6  # They use 1e-6 in the paper.
 )
 
 """
@@ -20,182 +20,166 @@ and its close sibling "Resampling Inheritance Search" (RIS) is described in:
     Search: High Performance Despite the Simplicity", 2013.
 """
 type ResamplingMemeticSearcher{E<:Evaluator} <: SteppingOptimizer
-  name::String
-  params::Parameters
-  evaluator::E
-  resampling_func::Function
+    name::String
+    params::Parameters
+    evaluator::E
+    resampling_func::Function
 
-  precisions      # Cache the starting precision values so we need not calc them for each step
-  diameters       # Cache the diameters...
+    precisions      # Cache the starting precision values so we need not calc them for each step
+    diameters       # Cache the diameters...
 
-  elite           # Current elite (best) candidate
-  elite_fitness   # Fitness of current elite
+    elite           # Current elite (best) candidate
+    elite_fitness   # Fitness of current elite
 
-  # Constructor for RS:
-  ResamplingMemeticSearcher(evaluator::E, parameters::Parameters,
-    resampling_function::Function, name::String) = begin
-
-    params = chain(RSDefaultParameters, parameters)
-
-    elite = rand_individual(search_space(evaluator))
-
-    diams = diameters(search_space(evaluator))
-
-    new(name, params, evaluator, resampling_function,
-      params[:PrecisionRatio] * diams, diams,
-      elite, fitness(elite, evaluator))
-
-  end
+    # Constructor for RS:
+    function ResamplingMemeticSearcher(evaluator::E, parameters::Parameters,
+            resampling_function::Function, name::String) = begin
+        params = chain(RSDefaultParameters, parameters)
+        elite = rand_individual(search_space(evaluator))
+        diams = diameters(search_space(evaluator))
+        new(name, params, evaluator, resampling_function,
+            params[:PrecisionRatio] * diams, diams,
+            elite, fitness(elite, evaluator))
+    end
 end
 
 name(rs::ResamplingMemeticSearcher) = rs.name
 
 const RISDefaultParameters = ParamsDict(
-  :InheritanceRatio => 0.30   # On average, 30% of positions are inherited when resampling in RIS
+    :InheritanceRatio => 0.30   # On average, 30% of positions are inherited when resampling in RIS
 )
 
 function ResamplingMemeticSearcher{E<:Evaluator}(evaluator::E,
     params, resampling_function, name)
-  ResamplingMemeticSearcher{E}(evaluator, params, resampling_function, name)
+    ResamplingMemeticSearcher{E}(evaluator, params, resampling_function, name)
 end
 
-function ResamplingMemeticSearcher(problem::OptimizationProblem,
-    params::Parameters = EMPTY_PARAMS,
-    resampling_function = random_resample,
-    name = "Resampling Memetic Search (RS)")
-  ResamplingMemeticSearcher(ProblemEvaluator(problem), params, resampling_function, name)
-end
+ResamplingMemeticSearcher(problem::OptimizationProblem,
+        params::Parameters = EMPTY_PARAMS,
+        resampling_function = random_resample,
+        name = "Resampling Memetic Search (RS)") =
+    ResamplingMemeticSearcher(ProblemEvaluator(problem), params, resampling_function, name)
 
 # Constructor for the RIS:
-function ResamplingInheritanceMemeticSearcher(problem::OptimizationProblem, parameters::Parameters = EMPTY_PARAMS)
-  ResamplingMemeticSearcher(problem,
-    chain(RSDefaultParameters, RISDefaultParameters, parameters),
-    random_resample_with_inheritance,
-    "Resampling Inheritance Memetic Search (RIS)")
-end
+ResamplingInheritanceMemeticSearcher(problem::OptimizationProblem, parameters::Parameters = EMPTY_PARAMS) =
+    ResamplingMemeticSearcher(problem,
+            chain(RSDefaultParameters, RISDefaultParameters, parameters),
+            random_resample_with_inheritance,
+            "Resampling Inheritance Memetic Search (RIS)")
 
-function resampling_memetic_searcher(problem::OptimizationProblem, params::Parameters)
-  ResamplingMemeticSearcher(problem, params)
-end
+resampling_memetic_searcher(problem::OptimizationProblem, params::Parameters) =
+    ResamplingMemeticSearcher(problem, params)
 
-function resampling_inheritance_memetic_searcher(problem::OptimizationProblem, params::Parameters)
-  ResamplingInheritanceMemeticSearcher(problem, params)
-end
+resampling_inheritance_memetic_searcher(problem::OptimizationProblem, params::Parameters) =
+    ResamplingInheritanceMemeticSearcher(problem, params)
 
 # For Resampling Search (RS) the resample is purely random.
 random_resample(rms::ResamplingMemeticSearcher) = rand_individual(search_space(rms.evaluator))
 
 # For Resampling Inheritance Search (RIS) the resample has an inheritance component.
 function random_resample_with_inheritance(rms::ResamplingMemeticSearcher)
-  xt = random_resample(rms)
-  n = numdims(rms.evaluator)
-  i = rand(1:n)
-  Cr = 0.5^(1/(rms.params[:InheritanceRatio]*n)) # See equation 3 in the RIS paper
-  k = 1
+    xt = random_resample(rms)
+    n = numdims(rms.evaluator)
+    i = rand(1:n)
+    Cr = 0.5^(1/(rms.params[:InheritanceRatio]*n)) # See equation 3 in the RIS paper
+    k = 1
 
-  while rand() <= Cr && k < n
-    xt[i] = rms.elite[i]
-    i = 1 + mod(i, n)
-    k += 1
-  end
+    while rand() <= Cr && k < n
+        xt[i] = rms.elite[i]
+        i = 1 + mod(i, n)
+        k += 1
+    end
 
-  return xt
+    return xt
 end
 
 function step!(rms::ResamplingMemeticSearcher)
+    # First randomly sample two candidates and select the best one. It seems
+    # RS and RIS might be doing this in two different ways but use the RS way for
+    # now.
+    trial, fitness = best_of(rms.resampling_func(rms), rms.resampling_func(rms), rms.evaluator)
 
-  # First randomly sample two candidates and select the best one. It seems
-  # RS and RIS might be doing this in two different ways but use the RS way for
-  # now.
-  trial, fitness = best_of(rms.resampling_func(rms), rms.resampling_func(rms), rms.evaluator)
+    # Update elite if new trial is better. This is how they write it in the RIS paper
+    # but in the RS paper it seems they always update the elite. Unclear! To me it
+    # seems we should always update since we have already done a local search from
+    # the current elite so it has a "head start" compared to new sampled points
+    # which have not yet gone through local refinement. Since the evaluator/archive
+    # keeps the best candidates anyway there is no risk for us in always overwriting the elite...
+    set_as_elite_if_better(rms, trial, fitness)
 
-  # Update elite if new trial is better. This is how they write it in the RIS paper
-  # but in the RS paper it seems they always update the elite. Unclear! To me it
-  # seems we should always update since we have already done a local search from
-  # the current elite so it has a "head start" compared to new sampled points
-  # which have not yet gone through local refinement. Since the evaluator/archive
-  # keeps the best candidates anyway there is no risk for us in always overwriting the elite...
-  set_as_elite_if_better(rms, trial, fitness)
+    # Then run the local search on the elite one until step length too small.
+    trial, fitness = local_search(rms, trial, fitness)
+    set_as_elite_if_better(rms, trial, fitness)
 
-  # Then run the local search on the elite one until step length too small.
-  trial, fitness = local_search(rms, trial, fitness)
-  set_as_elite_if_better(rms, trial, fitness)
-
-  return trial, fitness
-
+    return trial, fitness
 end
 
 function set_as_elite_if_better(rms::ResamplingMemeticSearcher, candidate, fitness)
-  if is_better(fitness, rms.elite_fitness, rms.evaluator)
-    rms.elite = candidate
-    rms.elite_fitness = fitness
-    return true
-  else
-    return false
-  end
+    if is_better(fitness, rms.elite_fitness, rms.evaluator)
+        rms.elite = candidate
+        rms.elite_fitness = fitness
+        return true
+    else
+        return false
+    end
 end
 
-function stop_due_to_low_precision(rms::ResamplingMemeticSearcher, precisions)
-  norm(precisions ./ rms.diameters) < rms.params[:PrecisionTreshold]
-end
+stop_due_to_low_precision(rms::ResamplingMemeticSearcher, precisions) =
+    norm(precisions ./ rms.diameters) < rms.params[:PrecisionTreshold]
 
 function local_search(rms::ResamplingMemeticSearcher, xstart, fitness)
-  ps = copy(rms.precisions)
-  xt = copy(xstart)
-  tfitness = copy(fitness)
+    ps = copy(rms.precisions)
+    xt = copy(xstart)
+    tfitness = copy(fitness)
 
-  searchSpace = search_space(rms.evaluator)
-  ssmins, ssmaxs = mins(searchSpace), maxs(searchSpace)
-  n = numdims(rms.evaluator)
+    searchSpace = search_space(rms.evaluator)
+    ssmins, ssmaxs = mins(searchSpace), maxs(searchSpace)
+    n = numdims(rms.evaluator)
 
-  indices = collect(1:n)
+    indices = collect(1:n)
 
-  while !stop_due_to_low_precision(rms, ps)
+    while !stop_due_to_low_precision(rms, ps)
+        xs = copy(xt)
+        # We randomize the order that each decision var is changed. This is not done in the orig papers.
+        shuffle!(indices)
 
-    xs = copy(xt)
+        for j in 1:n
+            i = indices[j]
 
-    # We randomize the order that each decision var is changed. This is not done in the orig papers.
-    shuffle!(indices)
+            # This is how it is written in orig papers. To me it seems better to
+            # take the step in a random direction; why prioritize one direction?
+            xs[i] = xt[i] - ps[i]
 
-    for j in 1:n
-      i = indices[j]
+            # rand bound from target if below min
+            if xs[i] < ssmins[i]
+                xs[i] = ssmins[i] + rand() * (xt[i] - ssmins[i])
+            end
 
-      # This is how it is written in orig papers. To me it seems better to
-      # take the step in a random direction; why prioritize one direction?
-      xs[i] = xt[i] - ps[i]
+            if is_better(xs, tfitness, rms.evaluator)
+                xt[i] = xs[i]
+                tfitness = last_fitness(rms.evaluator)
+            else
+                xs[i] = xt[i] + ps[i]/2
 
-      # rand bound from target if below min
-      if xs[i] < ssmins[i]
-        xs[i] = ssmins[i] + rand() * (xt[i] - ssmins[i])
-      end
+                # rand bound from target if above max
+                if xs[i] > ssmaxs[i]
+                    xs[i] = xt[i] + rand() * (ssmaxs[i] - xt[i])
+                end
 
-      if is_better(xs, tfitness, rms.evaluator)
-        xt[i] = xs[i]
-        tfitness = last_fitness(rms.evaluator)
-      else
-        xs[i] = xt[i] + ps[i]/2
-
-        # rand bound from target if above max
-        if xs[i] > ssmaxs[i]
-          xs[i] = xt[i] + rand() * (ssmaxs[i] - xt[i])
+                if is_better(xs, tfitness, rms.evaluator)
+                    xt[i] = xs[i]
+                    tfitness = last_fitness(rms.evaluator)
+                end
+            end
         end
 
-        if is_better(xs, tfitness, rms.evaluator)
-          xt[i] = xs[i]
-          tfitness = last_fitness(rms.evaluator)
+        if is_better(tfitness, fitness, rms.evaluator)
+            fitness = tfitness
+            xstart = xt
+        else
+            ps = ps / 2
         end
-      end
-
     end
 
-    if is_better(tfitness, fitness, rms.evaluator)
-      fitness = tfitness
-      xstart = xt
-    else
-      ps = ps / 2
-    end
-
-  end
-
-  return xstart, fitness
+    return xstart, fitness
 end

--- a/src/search_space.jl
+++ b/src/search_space.jl
@@ -4,18 +4,18 @@
   The base abstract class has very few restrictions
   and can allow varying number of dimensions etc.
 """
-@compat abstract type SearchSpace end
+abstract type SearchSpace end
 
 """
   `SearchSpace` with a fixed finite number of dimensions.
   Applicable to the vast majority of problems.
 """
-@compat abstract type FixedDimensionSearchSpace <: SearchSpace end
+abstract type FixedDimensionSearchSpace <: SearchSpace end
 
 """
   Fixed-dimensional space, each dimension has a continuous range of valid values.
 """
-@compat abstract type ContinuousSearchSpace <: FixedDimensionSearchSpace end
+abstract type ContinuousSearchSpace <: FixedDimensionSearchSpace end
 
 """
     The point of the `SearchSpace`.
@@ -23,19 +23,19 @@
     The abstract type. It allows different actual implementations to be used,
     e.g `Vector` or `SubArray`.
 """
-@compat const AbstractIndividual = AbstractVector{Float64}
+const AbstractIndividual = AbstractVector{Float64}
 
 """
     The point of the `SearchSpace`.
 
     The concrete type that could be used for storage.
 """
-@compat const Individual = Vector{Float64}
+const Individual = Vector{Float64}
 
 """
   The valid range of values for a specific dimension in a `SearchSpace`.
 """
-@compat const ParamBounds = Tuple{Float64,Float64}
+const ParamBounds = Tuple{Float64,Float64}
 
 """
   Get the range of valid values for a specific dimension.

--- a/src/search_space.jl
+++ b/src/search_space.jl
@@ -47,25 +47,21 @@ ranges(css::ContinuousSearchSpace) = collect(zip(mins(css), maxs(css)))
 """
 Generate `numIndividuals` individuals by random sampling in the search space.
 """
-function rand_individuals(css::ContinuousSearchSpace, numIndividuals)
-    # Basically min + delta * rand(), individuals are stored in columns
-    broadcast(+, mins(css), broadcast(*, deltas(css), rand(numdims(css), numIndividuals)))
-end
+rand_individuals(css::ContinuousSearchSpace, numIndividuals) =
+    mins(css) .+ deltas(css) .* rand(numdims(css), numIndividuals)
 
 """
 Generate `numIndividuals` individuals by latin hypercube sampling (LHS).
 This should be the default way to create the initial population.
 """
-function rand_individuals_lhs(css::ContinuousSearchSpace, numIndividuals)
+rand_individuals_lhs(css::ContinuousSearchSpace, numIndividuals) =
     Utils.latin_hypercube_sampling(mins(css), maxs(css), numIndividuals)
-end
 
 """
 Generate one random candidate.
 """
-function rand_individual(css::ContinuousSearchSpace)
-    squeeze(rand_individuals(css, 1), 2)
-end
+rand_individual(css::ContinuousSearchSpace) =
+    mins(css) .+ deltas(css) .* rand(numdims(css))
 
 """
 Check if given individual lies in the given search space.
@@ -116,7 +112,7 @@ feasible(v::AbstractIndividual, ss::RangePerDimSearchSpace) = map(clamp, v, mins
 
 # concatenates two range-based search spaces
 Base.vcat(ss1::RangePerDimSearchSpace, ss2::RangePerDimSearchSpace) =
-  RangePerDimSearchSpace(vcat(mins(ss1), mins(ss2)), vcat(maxs(ss1), maxs(ss2)))
+    RangePerDimSearchSpace(vcat(mins(ss1), mins(ss2)), vcat(maxs(ss1), maxs(ss2)))
 
 """
 0-dimensional search space.

--- a/src/search_space.jl
+++ b/src/search_space.jl
@@ -77,7 +77,7 @@ end
 """
 `SearchSpace` defined by a range of valid values for each dimension.
 """
-immutable RangePerDimSearchSpace <: ContinuousSearchSpace
+struct RangePerDimSearchSpace <: ContinuousSearchSpace
     # We save the ranges as individual mins, maxs and deltas for faster access later.
     mins::Vector{Float64}
     maxs::Vector{Float64}

--- a/src/simultaneous_perturbation_stochastic_approximation.jl
+++ b/src/simultaneous_perturbation_stochastic_approximation.jl
@@ -1,5 +1,5 @@
 """
-  `AskTellOptimizer` that utilizes randomization to generate the candidates.
+`AskTellOptimizer` that utilizes randomization to generate the candidates.
 """
 abstract type StochasticApproximationOptimizer <: AskTellOptimizer end
 

--- a/src/simultaneous_perturbation_stochastic_approximation.jl
+++ b/src/simultaneous_perturbation_stochastic_approximation.jl
@@ -47,7 +47,7 @@ function ask(spsa::SimultaneousPerturbationSA2)
      Candidate{Float64}(theta_minus, 2)]
 end
 
-function tell!{F}(spsa::SimultaneousPerturbationSA2, rankedCandidates::Vector{Candidate{F}})
+function tell!(spsa::SimultaneousPerturbationSA2, rankedCandidates::Vector{<:Candidate})
     # Use index of rank to get right values for yplus and yminus, respectively.
     if rankedCandidates[1].index == 1
         yplus = rankedCandidates[1].fitness

--- a/src/simultaneous_perturbation_stochastic_approximation.jl
+++ b/src/simultaneous_perturbation_stochastic_approximation.jl
@@ -1,7 +1,7 @@
 """
   `AskTellOptimizer` that utilizes randomization to generate the candidates.
 """
-@compat abstract type StochasticApproximationOptimizer <: AskTellOptimizer end
+abstract type StochasticApproximationOptimizer <: AskTellOptimizer end
 
 const SPSADefaultParameters = ParamsDict(
   :Alpha => 0.602,  # The optimal value is 1.0 but values down to 0.602 often can give faster convergence

--- a/src/simultaneous_perturbation_stochastic_approximation.jl
+++ b/src/simultaneous_perturbation_stochastic_approximation.jl
@@ -18,17 +18,18 @@ mutable struct SimultaneousPerturbationSA2{E<:EmbeddingOperator} <: StochasticAp
     n::Int
     theta::Individual
     delta_ck::Individual
-end
 
-function SimultaneousPerturbationSA2{E<:EmbeddingOperator}(problem::OptimizationProblem, embed::E, parameters::Parameters)
-    ss = search_space(problem)
-    n = numdims(ss)
-    SimultaneousPerturbationSA2{E}(embed, chain(SPSADefaultParameters, parameters),
-                                   0, n, rand_individual(ss), zeros(Float64, n))
+    function SimultaneousPerturbationSA2(problem::OptimizationProblem, embed::E, parameters::Parameters) where {E<:EmbeddingOperator}
+        ss = search_space(problem)
+        n = numdims(ss)
+        new{E}(embed, chain(SPSADefaultParameters, parameters),
+               0, n, rand_individual(ss), zeros(Float64, n))
+    end
 end
 
 # by default use RandomBound embedder
-SimultaneousPerturbationSA2(problem::OptimizationProblem, parameters::Parameters) = SimultaneousPerturbationSA2(problem, RandomBound(search_space(problem)), parameters)
+SimultaneousPerturbationSA2(problem::OptimizationProblem, parameters::Parameters) =
+    SimultaneousPerturbationSA2(problem, RandomBound(search_space(problem)), parameters)
 
 name(spsa::SimultaneousPerturbationSA2) = "SPSA2 (Simultaneous Perturbation Stochastic Approximation, 1st order, 2 samples)"
 

--- a/src/simultaneous_perturbation_stochastic_approximation.jl
+++ b/src/simultaneous_perturbation_stochastic_approximation.jl
@@ -11,7 +11,7 @@ const SPSADefaultParameters = ParamsDict(
     :A     => 10
 )
 
-type SimultaneousPerturbationSA2{E<:EmbeddingOperator} <: StochasticApproximationOptimizer
+mutable struct SimultaneousPerturbationSA2{E<:EmbeddingOperator} <: StochasticApproximationOptimizer
     embed::E # embed candidate into search space
     parameters::Parameters
     k::Int

--- a/src/simultaneous_perturbation_stochastic_approximation.jl
+++ b/src/simultaneous_perturbation_stochastic_approximation.jl
@@ -47,7 +47,7 @@ function ask(spsa::SimultaneousPerturbationSA2)
      Candidate{Float64}(theta_minus, 2)]
 end
 
-function tell!(spsa::SimultaneousPerturbationSA2, rankedCandidates::Vector{<:Candidate})
+function tell!(spsa::SimultaneousPerturbationSA2, rankedCandidates::AbstractVector{<:Candidate})
     # Use index of rank to get right values for yplus and yminus, respectively.
     if rankedCandidates[1].index == 1
         yplus = rankedCandidates[1].fitness

--- a/src/utilities/assign_ranks.jl
+++ b/src/utilities/assign_ranks.jl
@@ -1,6 +1,6 @@
 """
-  Assign ranks to the values but keeps the rank the same if the values are within
-  tolerance of each other.
+Assign ranks to the values but keeps the rank the same if the values are within
+tolerance of each other.
 """
 function assign_ranks_within_tolerance(values; by = (x) -> x, tolerance = 1e-5, rev = false)
 

--- a/src/utilities/assign_ranks.jl
+++ b/src/utilities/assign_ranks.jl
@@ -3,26 +3,24 @@ Assign ranks to the values but keeps the rank the same if the values are within
 tolerance of each other.
 """
 function assign_ranks_within_tolerance(values; by = (x) -> x, tolerance = 1e-5, rev = false)
+    perm = sortperm(values, by = by, rev = rev)
+    ranked = Any[]
+    rank = 1
+    prev = by(values[perm[1]])
+    num_of_this_rank = 0
 
-  perm = sortperm(values, by = by, rev = rev)
-  ranked = Any[]
-  rank = 1
-  prev = by(values[perm[1]])
-  num_of_this_rank = 0
-
-  for i in 1:length(perm)
-    r = values[perm[i]]
-    v = by(r)
-    if abs(prev - v) > tolerance
-      rank += num_of_this_rank
-      num_of_this_rank = 1
-    else
-      num_of_this_rank += 1
+    for i in eachindex(perm)
+        r = values[perm[i]]
+        v = by(r)
+        if abs(prev - v) > tolerance
+            rank += num_of_this_rank
+            num_of_this_rank = 1
+        else
+            num_of_this_rank += 1
+        end
+        push!(ranked, (rank, r, v))
+        prev = v
     end
-    push!(ranked, (rank, r, v))
-    prev = v
-  end
 
-  ranked
-
+    return ranked
 end

--- a/src/utilities/halton_sequence.jl
+++ b/src/utilities/halton_sequence.jl
@@ -3,8 +3,7 @@
 
 Generate the first `n` numbers in Halton's sequence with base `b`.
 """
-haltonsequence(b, n) =
-  map(i -> haltonnumber(b, i), 1:n)
+haltonsequence(b, n) = haltonnumber.(b, 1:n)
 
 """
     haltonnumber(base, index)

--- a/src/utilities/halton_sequence.jl
+++ b/src/utilities/halton_sequence.jl
@@ -1,20 +1,20 @@
 """
-  `haltonsequence(b, n)`
+    haltonsequence(b, n)
 
-  Generate the first `n` numbers in Halton's sequence with base `b`.
+Generate the first `n` numbers in Halton's sequence with base `b`.
 """
 function haltonsequence(b, n)
   map((i) -> haltonnumber(b, i), 1:n)
 end
 
 """
-  `haltonnumber(base, index)`
+    haltonnumber(base, index)
 
-  Generate the `n`-th Halton number in the sequence with base `b`.
+Generate the `n`-th Halton number in the sequence with base `b`.
 
 # Note
-  Implementation is based on the psudo code in:
-    http://en.wikipedia.org/wiki/Halton_sequence
+    Implementation is based on the psudo code in:
+        http://en.wikipedia.org/wiki/Halton_sequence
 """
 function haltonnumber(base::Integer, index::Integer)
   res = 0

--- a/src/utilities/halton_sequence.jl
+++ b/src/utilities/halton_sequence.jl
@@ -3,9 +3,8 @@
 
 Generate the first `n` numbers in Halton's sequence with base `b`.
 """
-function haltonsequence(b, n)
-  map((i) -> haltonnumber(b, i), 1:n)
-end
+haltonsequence(b, n) =
+  map(i -> haltonnumber(b, i), 1:n)
 
 """
     haltonnumber(base, index)
@@ -17,15 +16,15 @@ Generate the `n`-th Halton number in the sequence with base `b`.
         http://en.wikipedia.org/wiki/Halton_sequence
 """
 function haltonnumber(base::Integer, index::Integer)
-  res = 0
-  f = 1 / base
-  i = index
+    res = 0
+    f = 1 / base
+    i = index
 
-  while (i > 0)
-    res += f * (i % base)
-    i = floor(Integer, i / base)
-    f = f / base
-  end
+    while (i > 0)
+        res += f * (i % base)
+        i = floor(Integer, i / base)
+        f = f / base
+    end
 
-  return res
+    return res
 end

--- a/src/utilities/latin_hypercube_sampling.jl
+++ b/src/utilities/latin_hypercube_sampling.jl
@@ -4,9 +4,9 @@
 Randomly sample `numSamples` values from the parallelogram defined
 by `mins` and `maxs` using the Latin hypercube algorithm.
 """
-function latin_hypercube_sampling{T}(mins::AbstractVector{T},
-                                     maxs::AbstractVector{T},
-                                     numSamples::Integer)
+function latin_hypercube_sampling(mins::AbstractVector{T},
+                                  maxs::AbstractVector{T},
+                                  numSamples::Integer) where T
     dims = length(mins)
     result = zeros(T, numSamples, dims)
     @inbounds for i in 1:dims

--- a/src/utilities/latin_hypercube_sampling.jl
+++ b/src/utilities/latin_hypercube_sampling.jl
@@ -1,8 +1,8 @@
 """
     latin_hypercube_sampling(mins, maxs, numSamples)
 
-    Randomly sample `numSamples` values from the parallelogram defined
-    by `mins` and `maxs` using the Latin hypercube algorithm.
+Randomly sample `numSamples` values from the parallelogram defined
+by `mins` and `maxs` using the Latin hypercube algorithm.
 """
 function latin_hypercube_sampling{T}(mins::AbstractVector{T}, maxs::AbstractVector{T}, numSamples::Integer)
     dims = length(mins)

--- a/src/utilities/latin_hypercube_sampling.jl
+++ b/src/utilities/latin_hypercube_sampling.jl
@@ -4,7 +4,9 @@
 Randomly sample `numSamples` values from the parallelogram defined
 by `mins` and `maxs` using the Latin hypercube algorithm.
 """
-function latin_hypercube_sampling{T}(mins::AbstractVector{T}, maxs::AbstractVector{T}, numSamples::Integer)
+function latin_hypercube_sampling{T}(mins::AbstractVector{T},
+                                     maxs::AbstractVector{T},
+                                     numSamples::Integer)
     dims = length(mins)
     result = zeros(T, numSamples, dims)
     @inbounds for i in 1:dims

--- a/test/run_autotests.jl
+++ b/test/run_autotests.jl
@@ -4,21 +4,21 @@ Package = "BlackBoxOptim"
 
 using BlackBoxOptim
 
-function run(packagename, srcdir = "src", testdir = "test"; 
-  testfileregexp = r"^test_.*\.jl$", 
-  srcfileregexp = r"^.*\.jl$")
+function run(packagename, srcdir = "src", testdir = "test";
+    testfileregexp = r"^test_.*\.jl$",
+    srcfileregexp = r"^.*\.jl$")
 
-  testfiles = AutoTest.findfiles(testdir, testfileregexp; recursive = true) # in AutoTest this is false
-  srcfiles = AutoTest.findfiles(srcdir, srcfileregexp; recursive = true)
+    testfiles = AutoTest.findfiles(testdir, testfileregexp; recursive = true) # in AutoTest this is false
+    srcfiles = AutoTest.findfiles(srcdir, srcfileregexp; recursive = true)
 
-  ts = AutoTest.TestSuite(testfiles, srcfiles, "$packagename test suite")
+    ts = AutoTest.TestSuite(testfiles, srcfiles, "$packagename test suite")
 
-  AutoTest.runtestsuite(ts)
+    AutoTest.runtestsuite(ts)
 
 end
 
 if length(ARGS) > 0 && ARGS[1] == "continuous"
-  AutoTest.autorun(Package, "src", "test/autotests")
+    AutoTest.autorun(Package, "src", "test/autotests")
 else
-  run(Package, "src", "test/autotests")
+    run(Package, "src", "test/autotests")
 end

--- a/test/runslowtests.jl
+++ b/test/runslowtests.jl
@@ -1,8 +1,8 @@
 include("helper.jl")
 
 my_slow_tests = [
-  "problems/test_optimize_single_objective_problems.jl",
-  "test_bboptimize.jl"
+    "problems/test_optimize_single_objective_problems.jl",
+    "test_bboptimize.jl"
 ]
 
 @testset "BlackBoxOptim long-running test suite" begin

--- a/test/runslowtests.jl
+++ b/test/runslowtests.jl
@@ -5,8 +5,6 @@ my_slow_tests = [
     "test_bboptimize.jl"
 ]
 
-@testset "BlackBoxOptim long-running test suite" begin
-    for t in my_slow_tests
-        include(t)
-    end
+@testset "BlackBoxOptim long-running test suite $t" for t in my_slow_tests
+    include(t)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,5 @@
 if !isdefined(:TimeTestExecution)
-  const TimeTestExecution = false
+    const TimeTestExecution = false
 end
 
 module BlackBoxOptimTests
@@ -11,50 +11,50 @@ import Compat.String
 
 my_tests = [
 
-  "utilities/test_latin_hypercube_sampling.jl",
-  "utilities/test_halton_sequence.jl",
-  "utilities/test_assign_ranks.jl",
+    "utilities/test_latin_hypercube_sampling.jl",
+    "utilities/test_halton_sequence.jl",
+    "utilities/test_assign_ranks.jl",
 
-  "test_parameters.jl",
-  "test_fitness.jl",
-  "test_evaluator.jl",
-  "test_population.jl",
-  "test_bimodal_cauchy_distribution.jl",
-  "test_search_space.jl",
-  "test_mutation_operators.jl",
-  "test_crossover_operators.jl",
-  "test_selectors.jl",
-  "test_embedders.jl",
-  "test_frequency_adaptation.jl",
-  "test_archive.jl",
-  "test_epsbox_archive.jl",
-  "test_optimizationresult.jl",
+    "test_parameters.jl",
+    "test_fitness.jl",
+    "test_evaluator.jl",
+    "test_population.jl",
+    "test_bimodal_cauchy_distribution.jl",
+    "test_search_space.jl",
+    "test_mutation_operators.jl",
+    "test_crossover_operators.jl",
+    "test_selectors.jl",
+    "test_embedders.jl",
+    "test_frequency_adaptation.jl",
+    "test_archive.jl",
+    "test_epsbox_archive.jl",
+    "test_optimizationresult.jl",
 
-  "test_random_search.jl",
-  "test_differential_evolution.jl",
-  "test_adaptive_differential_evolution.jl",
-  "test_natural_evolution_strategies.jl",
+    "test_random_search.jl",
+    "test_differential_evolution.jl",
+    "test_adaptive_differential_evolution.jl",
+    "test_natural_evolution_strategies.jl",
 
-  "test_borg_moea.jl",
+    "test_borg_moea.jl",
 
-  "test_tracing.jl",
-  "test_toplevel_bboptimize.jl",
-  "test_smoketest_bboptimize.jl",
+    "test_tracing.jl",
+    "test_toplevel_bboptimize.jl",
+    "test_smoketest_bboptimize.jl",
 
-  "problems/test_single_objective.jl",
+    "problems/test_single_objective.jl",
 
-  "test_generating_set_search.jl",
-  "test_direct_search_with_probabilistic_descent.jl",
+    "test_generating_set_search.jl",
+    "test_direct_search_with_probabilistic_descent.jl",
 ]
 
 if Main.TimeTestExecution
 
 function get_git_remote_and_branch()
-  lines = split(readstring(`git remote -v show`), "\n")
-  remote = match(r"[a-z0-9]+\s+([^\s]+)", lines[1]).captures[1]
-  branch = strip(readstring(`git rev-parse --abbrev-ref HEAD`))
-  commit = strip(readstring(`git rev-parse HEAD`))
-  return remote, branch, commit
+    lines = split(readstring(`git remote -v show`), "\n")
+    remote = match(r"[a-z0-9]+\s+([^\s]+)", lines[1]).captures[1]
+    branch = strip(readstring(`git rev-parse --abbrev-ref HEAD`))
+    commit = strip(readstring(`git rev-parse HEAD`))
+    return remote, branch, commit
 end
 
 gitremote, gitbranch, gitcommit = get_git_remote_and_branch()
@@ -66,9 +66,13 @@ using DataFrames
 TestTimingFileName = "test/timing_testing.csv"
 
 if isfile("test/timing_testing.csv")
-  timing_data = readtable("test/timing_testing.csv")
+    timing_data = readtable("test/timing_testing.csv")
 else
-  timing_data = DataFrame(TimeStamp = AbstractString[], Julia = AbstractString[], Git = AbstractString[], TestFile = AbstractString[], Elapsed = Float64[])
+    timing_data = DataFrame(TimeStamp = AbstractString[],
+                            Julia = AbstractString[],
+                            Git = AbstractString[],
+                            TestFile = AbstractString[],
+                            Elapsed = Float64[])
 end
 
 end
@@ -80,32 +84,32 @@ starttime = CPUtime_us()
 @testset "BlackBoxOptim test suite" begin
 
 for t in my_tests
-  if Main.TimeTestExecution
-    CPUtic()
+    if Main.TimeTestExecution
+        CPUtic()
 
-    # Including the test file runs the tests in there...
-    include(t)
+        # Including the test file runs the tests in there...
+        include(t)
 
-    elapsed = CPUtoq()
-    datestr = Libc.strftime("%Y%m%d %H:%M.%S", time())
-    push!(timing_data, [datestr, versionstr, gitstr, t, elapsed])
-  else
-    include(t)
-  end
-  numtestfiles += 1
-  print("."); flush(STDOUT);
+        elapsed = CPUtoq()
+        datestr = Libc.strftime("%Y%m%d %H:%M.%S", time())
+        push!(timing_data, [datestr, versionstr, gitstr, t, elapsed])
+    else
+        include(t)
+    end
+    numtestfiles += 1
+    print("."); flush(STDOUT);
 end
 println() # So Base.Test summary is correctly aligned...
 end
 elapsed = float(CPUtime_us() - starttime)/1e6
 
 if Main.TimeTestExecution
-  datestr = Libc.strftime("%Y%m%d %H:%M.%S", time())
-  using SHA
-  hash = bytes2hex(sha512(join(map(fn -> readstring(open(joinpath("test", fn))), my_tests))))[1:16]
-  push!(timing_data, [datestr, versionstr, gitstr, "TOTAL TIME for $(length(my_tests)) test files, $(hash)", elapsed])
-  writetable(TestTimingFileName, timing_data)
-  println("Wrote $(nrow(timing_data)) rows to file $TestTimingFileName")
+    datestr = Libc.strftime("%Y%m%d %H:%M.%S", time())
+    using SHA
+    hash = bytes2hex(sha512(join(map(fn -> readstring(open(joinpath("test", fn))), my_tests))))[1:16]
+    push!(timing_data, [datestr, versionstr, gitstr, "TOTAL TIME for $(length(my_tests)) test files, $(hash)", elapsed])
+    writetable(TestTimingFileName, timing_data)
+    println("Wrote $(nrow(timing_data)) rows to file $TestTimingFileName")
 end
 
 elapsedclock = time() - startclocktime

--- a/test/test_all_problems.jl
+++ b/test/test_all_problems.jl
@@ -1,12 +1,11 @@
-facts("Problems") do
-
-    context("Can create fixed dimensional problem with search space as array") do
+@testset "Problems" begin
+    @testset "Can create fixed dimensional problem with search space as array" begin
         p = BlackBoxOptim.fixeddim_problem((x)->x; search_space = [(0.0, 1.0)])
-        @fact typeof(p) --> BlackBoxOptim.FixedDimProblem
+        @test typeof(p) === BlackBoxOptim.FixedDimProblem
     end
 
-    context("Exception if no valid search space supplied when creating fixed dimensional problem") do
-        @fact_throws BlackBoxOptim.fixeddim_problem((x)->x; search_space = (0.0, 1.0))
+    @testset "Exception if no valid search space supplied when creating fixed dimensional problem" begin
+        @test_throws BlackBoxOptim.fixeddim_problem((x)->x; search_space = (0.0, 1.0))
     end
 
 end

--- a/test/test_all_problems.jl
+++ b/test/test_all_problems.jl
@@ -1,12 +1,12 @@
 facts("Problems") do
 
-  context("Can create fixed dimensional problem with search space as array") do
-    p = BlackBoxOptim.fixeddim_problem((x)->x; search_space = [(0.0, 1.0)])
-    @fact typeof(p) --> BlackBoxOptim.FixedDimProblem
-  end
+    context("Can create fixed dimensional problem with search space as array") do
+        p = BlackBoxOptim.fixeddim_problem((x)->x; search_space = [(0.0, 1.0)])
+        @fact typeof(p) --> BlackBoxOptim.FixedDimProblem
+    end
 
-  context("Exception if no valid search space supplied when creating fixed dimensional problem") do
-    @fact_throws BlackBoxOptim.fixeddim_problem((x)->x; search_space = (0.0, 1.0))
-  end
+    context("Exception if no valid search space supplied when creating fixed dimensional problem") do
+        @fact_throws BlackBoxOptim.fixeddim_problem((x)->x; search_space = (0.0, 1.0))
+    end
 
 end

--- a/test/test_archive.jl
+++ b/test/test_archive.jl
@@ -49,8 +49,8 @@
         @test delta_fitness(a)    == 0.5
 
         expected = ((0.8 - 0.5) / ((1 - 0.05)^(-2/1) - 1))
-        @test width_of_confidence_interval(a, 0.05) == expected
-        @test fitness_improvement_potential(a, 0.05) == (expected / 0.50)
+        @test width_of_confidence_interval(a, 0.05) ≈ expected
+        @test fitness_improvement_potential(a, 0.05) ≈ (expected / 0.50)
 
         BlackBoxOptim.add_candidate!(a, 0.4, [1.9])
         @test capacity(a)       == 3
@@ -61,8 +61,8 @@
         @test isapprox(delta_fitness(a), 0.1)
 
         expected = ((0.5 - 0.4) / ((1 - 0.05)^(-2/1) - 1))
-        @test width_of_confidence_interval(a, 0.05) == expected
-        @test fitness_improvement_potential(a, 0.05) == (expected / 0.40)
+        @test width_of_confidence_interval(a, 0.05) ≈ expected
+        @test fitness_improvement_potential(a, 0.05) ≈ (expected / 0.40)
 
         # identical candidate is not inserted
         BlackBoxOptim.add_candidate!(a, 0.5, [2.0])

--- a/test/test_borg_moea.jl
+++ b/test/test_borg_moea.jl
@@ -1,17 +1,17 @@
 @testset "BorgMOEA" begin
-        @testset "Schaffer1" begin
-            res = bboptimize(BlackBoxOptim.Schaffer1Family; Method=:borg_moea,
-                                            FitnessScheme=ParetoFitnessScheme{2}(is_minimizing=true),
-                                            SearchRange=(-10.0, 10.0), NumDimensions=2, ϵ=0.01,
-                                            MaxSteps=5000, TraceMode=:silent)
-            @test BlackBoxOptim.IGD(BlackBoxOptim.Schaffer1Family.opt_value, pareto_frontier(res),
+    @testset "Schaffer1" begin
+        res = bboptimize(BlackBoxOptim.Schaffer1Family; Method=:borg_moea,
+                         FitnessScheme=ParetoFitnessScheme{2}(is_minimizing=true),
+                         SearchRange=(-10.0, 10.0), NumDimensions=2, ϵ=0.01,
+                         MaxSteps=5000, TraceMode=:silent)
+        @test BlackBoxOptim.IGD(BlackBoxOptim.Schaffer1Family.opt_value, pareto_frontier(res),
                                 fitness_scheme(res), Val{length(best_candidate(res))}) < 0.05
-        end
-        @testset "CEC09_UP8" begin
-            res = bboptimize(BlackBoxOptim.CEC09_Unconstrained_Set[8]; Method=:borg_moea,
-                                            NumDimensions=4, ϵ=0.025,
-                                            MaxSteps=50000, TraceMode=:silent)
-            @test BlackBoxOptim.IGD(BlackBoxOptim.CEC09_Unconstrained_Set[8].opt_value, pareto_frontier(res),
+    end
+    @testset "CEC09_UP8" begin
+        res = bboptimize(BlackBoxOptim.CEC09_Unconstrained_Set[8]; Method=:borg_moea,
+                         NumDimensions=4, ϵ=0.025,
+                         MaxSteps=50000, TraceMode=:silent)
+        @test BlackBoxOptim.IGD(BlackBoxOptim.CEC09_Unconstrained_Set[8].opt_value, pareto_frontier(res),
                                 fitness_scheme(res), Val{length(best_candidate(res))}) < 0.13
-        end
+    end
 end

--- a/test/test_embedders.jl
+++ b/test/test_embedders.jl
@@ -2,39 +2,34 @@
 
 @testset "RandomBound" begin
     @testset "does nothing if within bounds" begin
-        @test BlackBoxOptim.apply!(BlackBoxOptim.RandomBound([(0.0, 1.0)]),
-                                                            [0.0], [0.0]) == [0.0]
+        @test apply!(RandomBound([(0.0, 1.0)]), [0.0], [0.0]) == [0.0]
 
-        @test BlackBoxOptim.apply!(BlackBoxOptim.RandomBound([(0.0, 1.0), (10.0, 15.0)]),
-                                                            [0.0, 11.4], [0.1, 12.3] ) == [0.0, 11.4]
+        @test apply!(RandomBound([(0.0, 1.0), (10.0, 15.0)]),
+                     [0.0, 11.4], [0.1, 12.3] ) == [0.0, 11.4]
     end
 
     @testset "bounds if lower than min bound" begin
-        @test BlackBoxOptim.apply!(BlackBoxOptim.RandomBound([(0.0, 1.0)]),
-                                                            [-0.1], [0.0]) == [0.0]
+        @test apply!(RandomBound([(0.0, 1.0)]), [-0.1], [0.0]) == [0.0]
 
-        res = BlackBoxOptim.apply!(BlackBoxOptim.RandomBound([(0.0, 1.0)]),
-                                                            [-0.1], [0.5])
+        res = apply!(RandomBound([(0.0, 1.0)]), [-0.1], [0.5])
         @test res[1] >= 0.0
         @test res[1] <= 0.5
 
-        res = BlackBoxOptim.apply!(BlackBoxOptim.RandomBound([(-11.0, 1.0), (0.0, 1.0)]),
+        res = apply!(RandomBound([(-11.0, 1.0), (0.0, 1.0)]),
                                                             [-11.1, 0.5], [-10.8, 0.5])
         @test (-10.8 >= res[1] >= -11.0)
         @test res[2] == 0.5
 
-        res = BlackBoxOptim.apply!(BlackBoxOptim.RandomBound([(30.0, 60.0), (-102.0, -1.0)]),
-                                                            [50.4, -103.1], [49.6, -101.4])
+        res = apply!(RandomBound([(30.0, 60.0), (-102.0, -1.0)]),
+                     [50.4, -103.1], [49.6, -101.4])
         @test res[1] == 50.4
         @test (-101.4 >= res[2] >= -102.0)
     end
 
     @testset "bounds if higher than max bound" begin
-        @test BlackBoxOptim.apply!(BlackBoxOptim.RandomBound([(0.0, 1.0)]),
-                                                            [1.1], [1.0]) == [1.0]
+        @test apply!(RandomBound([(0.0, 1.0)]), [1.1], [1.0]) == [1.0]
 
-        res = BlackBoxOptim.apply!(BlackBoxOptim.RandomBound([(-10.0, 96.0)]),
-                                                            [97.0], [95.0])
+        res = apply!(RandomBound([(-10.0, 96.0)]), [97.0], [95.0])
         @test (95.0 <= res[1] <= 96.0)
     end
 end

--- a/test/test_epsbox_archive.jl
+++ b/test/test_epsbox_archive.jl
@@ -1,19 +1,19 @@
 @testset "EpsBoxArchive" begin
-        # check that frontier elements are mutually nondominated and
-        # ther are no epsilon-index duplicates
-        function check_frontier(a::EpsBoxArchive)
-                for (i, el_i) in enumerate(pareto_frontier(a))
-                        for (j, el_j) in enumerate(pareto_frontier(a))
-                                if j > i
-                                        comp, index_match = hat_compare(fitness(el_i), fitness(el_j), fitness_scheme(a))
-                                        if comp != 0 || index_match
-                                                return comp, index_match # return if violating pair is found
-                                        end
-                                end
-                        end
+    # check that frontier elements are mutually nondominated and
+    # ther are no epsilon-index duplicates
+    function check_frontier(a::EpsBoxArchive)
+        for (i, el_i) in enumerate(pareto_frontier(a))
+            for (j, el_j) in enumerate(pareto_frontier(a))
+                if j > i
+                    comp, index_match = hat_compare(fitness(el_i), fitness(el_j), fitness_scheme(a))
+                    if comp != 0 || index_match
+                        return comp, index_match # return if violating pair is found
+                    end
                 end
-                return (0, false) # all non-dominated, no index matches
+            end
         end
+        return (0, false) # all non-dominated, no index matches
+    end
 
     scheme = EpsBoxDominanceFitnessScheme{2}(0.1, is_minimizing=true)
 
@@ -82,62 +82,62 @@
         @test BlackBoxOptim.tagcounts(a) == Dict{Int,Int}(6=>1)
 
         @testset "noprogress_streak(since_restart=0) is reset after restart" begin
-                @test BlackBoxOptim.noprogress_streak(a, since_restart=false) == 1
-                @test BlackBoxOptim.noprogress_streak(a, since_restart=true) == 1
-                BlackBoxOptim.notify!(a, :restart)
-                @test BlackBoxOptim.noprogress_streak(a, since_restart=false) == 1
-                @test BlackBoxOptim.noprogress_streak(a, since_restart=true) == 0
-                BlackBoxOptim.add_candidate!(a, (0.2, 0.2), [1.5, 3.0], 6)
-                @test BlackBoxOptim.noprogress_streak(a, since_restart=false) == 2
-                @test BlackBoxOptim.noprogress_streak(a, since_restart=true) == 1
+            @test BlackBoxOptim.noprogress_streak(a, since_restart=false) == 1
+            @test BlackBoxOptim.noprogress_streak(a, since_restart=true) == 1
+            BlackBoxOptim.notify!(a, :restart)
+            @test BlackBoxOptim.noprogress_streak(a, since_restart=false) == 1
+            @test BlackBoxOptim.noprogress_streak(a, since_restart=true) == 0
+            BlackBoxOptim.add_candidate!(a, (0.2, 0.2), [1.5, 3.0], 6)
+            @test BlackBoxOptim.noprogress_streak(a, since_restart=false) == 2
+            @test BlackBoxOptim.noprogress_streak(a, since_restart=true) == 1
         end
 
         @testset "updating best candidate index if old and new non-dominated" begin
-                a = EpsBoxArchive(scheme, max_size=100)
+            a = EpsBoxArchive(scheme, max_size=100)
 
-                BlackBoxOptim.add_candidate!(a, convert(IndexedTupleFitness, (1.0, 0.0), scheme), [0.0, 1.0], 1)
-                @test a.best_candidate_ix == 1
-                @test length(a)           == 1
-                BlackBoxOptim.add_candidate!(a, convert(IndexedTupleFitness, (0.6, 0.6), scheme), [0.0, 2.0], 2)
-                @test a.best_candidate_ix == 1
-                @test length(a)           == 2
-                BlackBoxOptim.add_candidate!(a, convert(IndexedTupleFitness, (0.0, 1.1), scheme), [0.0, 3.0], 3)
-                @test a.best_candidate_ix == 1
-                @test length(a)           == 3
-                BlackBoxOptim.add_candidate!(a, convert(IndexedTupleFitness, (0.0, 0.9), scheme), [0.0, 4.0], 4)
-                @test a.best_candidate_ix == 3
-                @test length(a)           == 3
+            BlackBoxOptim.add_candidate!(a, convert(IndexedTupleFitness, (1.0, 0.0), scheme), [0.0, 1.0], 1)
+            @test a.best_candidate_ix == 1
+            @test length(a)           == 1
+            BlackBoxOptim.add_candidate!(a, convert(IndexedTupleFitness, (0.6, 0.6), scheme), [0.0, 2.0], 2)
+            @test a.best_candidate_ix == 1
+            @test length(a)           == 2
+            BlackBoxOptim.add_candidate!(a, convert(IndexedTupleFitness, (0.0, 1.1), scheme), [0.0, 3.0], 3)
+            @test a.best_candidate_ix == 1
+            @test length(a)           == 3
+            BlackBoxOptim.add_candidate!(a, convert(IndexedTupleFitness, (0.0, 0.9), scheme), [0.0, 4.0], 4)
+            @test a.best_candidate_ix == 3
+            @test length(a)           == 3
         end
 
         @testset "handling dulicate elements" begin
-                a = EpsBoxArchive(scheme, max_size=100)
+            a = EpsBoxArchive(scheme, max_size=100)
 
-                BlackBoxOptim.add_candidate!(a, convert(IndexedTupleFitness, (1.25, 0.0), scheme), [0.0, 1.0], 1)
-                @test a.best_candidate_ix == 1
-                @test length(a)           == 1
-                BlackBoxOptim.add_candidate!(a, convert(IndexedTupleFitness, (0.6, 0.6), scheme), [0.0, 2.0], 2)
-                @test a.best_candidate_ix == 2
-                @test length(a)           == 2
-                BlackBoxOptim.add_candidate!(a, convert(IndexedTupleFitness, (0.0, 1.3), scheme), [0.0, 3.0], 3)
-                @test a.best_candidate_ix == 2
-                @test length(a)           == 3
-                BlackBoxOptim.add_candidate!(a, convert(IndexedTupleFitness, (0.6, 0.6), scheme), [0.0, 4.0], 4)
-                @test a.best_candidate_ix == 2
-                @test length(a)           == 3
+            BlackBoxOptim.add_candidate!(a, convert(IndexedTupleFitness, (1.25, 0.0), scheme), [0.0, 1.0], 1)
+            @test a.best_candidate_ix == 1
+            @test length(a)           == 1
+            BlackBoxOptim.add_candidate!(a, convert(IndexedTupleFitness, (0.6, 0.6), scheme), [0.0, 2.0], 2)
+            @test a.best_candidate_ix == 2
+            @test length(a)           == 2
+            BlackBoxOptim.add_candidate!(a, convert(IndexedTupleFitness, (0.0, 1.3), scheme), [0.0, 3.0], 3)
+            @test a.best_candidate_ix == 2
+            @test length(a)           == 3
+            BlackBoxOptim.add_candidate!(a, convert(IndexedTupleFitness, (0.6, 0.6), scheme), [0.0, 4.0], 4)
+            @test a.best_candidate_ix == 2
+            @test length(a)           == 3
         end
     end
 
     @testset "shaffer1() Pareto frontier" begin
-            schaffer1(x) = (sum(abs2, x), sum(xx -> abs2(xx - 2.0), x))
-            scheme = EpsBoxDominanceFitnessScheme{2}(0.1, is_minimizing=true)
-            a = EpsBoxArchive(scheme)
+        schaffer1(x) = (sum(abs2, x), sum(xx -> abs2(xx - 2.0), x))
+        scheme = EpsBoxDominanceFitnessScheme{2}(0.1, is_minimizing=true)
+        a = EpsBoxArchive(scheme)
 
-            for t in linspace(0, 2, 1000)
-                    params = [t, t]
-                    BlackBoxOptim.add_candidate!(a, schaffer1(params), params)
-            end
+        for t in linspace(0, 2, 1000)
+            params = [t, t]
+            BlackBoxOptim.add_candidate!(a, schaffer1(params), params)
+        end
 
-            @test length(a) == 40
+        @test length(a) == 40
     end
 
     @testset "archive copies the individuals" begin
@@ -160,27 +160,27 @@
         # generate random fitness from (0..2, 0..2, 0..2)
         # and lying inside the (1.0-r1)^1.5 + (1.0-r2)^1.5 + (1.0-r3)^1.5 <= 8.0
         function rfitness()
-                while true
-                        r1 = rand()
-                        r2 = rand()
-                        r3 = rand()
-                        if (1.0-r1)^1.5 + (1.0-r2)^1.5 + (1.0-r3)^1.5 <= 1.0
-                                return (2.0*r1, 2.0*r2, 2.0*r3)
-                        end
+            while true
+                r1 = rand()
+                r2 = rand()
+                r3 = rand()
+                if (1.0-r1)^1.5 + (1.0-r2)^1.5 + (1.0-r3)^1.5 <= 1.0
+                    return (2.0*r1, 2.0*r2, 2.0*r3)
                 end
+            end
         end
 
         scheme3 = EpsBoxDominanceFitnessScheme{3}(0.1, is_minimizing=true)
         a = EpsBoxArchive(scheme3, max_size=1000)
         indiv = [0.0, 0.0]
         for i in 1:10000
-                BlackBoxOptim.add_candidate!(a, rfitness(), indiv)
-                # periodically check that pareto_frontier(a) is indeed
-                # epsilon-index frontier
-                if mod(i, 100) == 0
-                        @test isposdef(length(a))
-                        @test check_frontier(a) == (0, false)
-                end
+            BlackBoxOptim.add_candidate!(a, rfitness(), indiv)
+            # periodically check that pareto_frontier(a) is indeed
+            # epsilon-index frontier
+            if mod(i, 100) == 0
+                @test isposdef(length(a))
+                @test check_frontier(a) == (0, false)
+            end
         end
     end
 end

--- a/test/test_fitness.jl
+++ b/test/test_fitness.jl
@@ -1,288 +1,286 @@
 @testset "Fitness" begin
-	@testset "hat_compare() Float64" begin
-		@test hat_compare(1.0, 2.0) == -1
-		@test hat_compare(-1.0, 1.0) == -1
+    @testset "hat_compare() Float64" begin
+        @test hat_compare(1.0, 2.0) == -1
+        @test hat_compare(-1.0, 1.0) == -1
 
-		@test hat_compare(2.0, 1.0) == 1
-		@test hat_compare(-2.0, -3.0) == 1
+        @test hat_compare(2.0, 1.0) == 1
+        @test hat_compare(-2.0, -3.0) == 1
 
-		@test hat_compare(1.0, 1.0) == 0
-		@test hat_compare(0.0, 0.0) == 0
-		@test hat_compare(-1.0, -1.0) == 0
+        @test hat_compare(1.0, 1.0) == 0
+        @test hat_compare(0.0, 0.0) == 0
+        @test hat_compare(-1.0, -1.0) == 0
 
-		@test hat_compare(0.0, NaN) == -1
-		@test hat_compare(NaN, 1.0) ==  1
-		@test hat_compare(NaN, NaN) ==  0
-	end
+        @test hat_compare(0.0, NaN) == -1
+        @test hat_compare(NaN, 1.0) ==  1
+        @test hat_compare(NaN, NaN) ==  0
+    end
 
-	@testset "ScalarFitnessScheme" begin
-		@testset "is_minimizing()" begin
-			mins = MinimizingFitnessScheme
-			@test is_minimizing(mins)
+    @testset "ScalarFitnessScheme" begin
+        @testset "is_minimizing()" begin
+            mins = MinimizingFitnessScheme
+            @test is_minimizing(mins)
 
-			maxs = MaximizingFitnessScheme
-			@test is_minimizing(maxs) == false
-		end
+            maxs = MaximizingFitnessScheme
+            @test is_minimizing(maxs) == false
+        end
 
-		@testset "hat_compare(..., MinimizingFitnessScheme)" begin
-			scheme = MinimizingFitnessScheme
+        @testset "hat_compare(..., MinimizingFitnessScheme)" begin
+            scheme = MinimizingFitnessScheme
 
-			@test hat_compare(1.0, 2.0, scheme) == -1
-			@test hat_compare(2.0, 1.0, scheme) == 1
-			@test hat_compare(1.0, 1.0, scheme) == 0
-		end
+            @test hat_compare(1.0, 2.0, scheme) == -1
+            @test hat_compare(2.0, 1.0, scheme) == 1
+            @test hat_compare(1.0, 1.0, scheme) == 0
+        end
 
-		@testset "hat_compare(..., MaximizingFitnessScheme)" begin
-			scheme = MaximizingFitnessScheme
+        @testset "hat_compare(..., MaximizingFitnessScheme)" begin
+            scheme = MaximizingFitnessScheme
 
-			@test hat_compare(1.0, 2.0, scheme) == 1
-			@test hat_compare(2.0, 1.0, scheme) == -1
-			@test hat_compare(1.0, 1.0, scheme) == 0
-		end
+            @test hat_compare(1.0, 2.0, scheme) == 1
+            @test hat_compare(2.0, 1.0, scheme) == -1
+            @test hat_compare(1.0, 1.0, scheme) == 0
+        end
 
-		# FIXME enable tests once v0.5 issue #14919 is fixed
-		@testset "fitness_scheme(x, y)" begin
-			mins = MinimizingFitnessScheme
-			#@test !mins(5.0, 3.0)
-			#@test mins(1.0, 2.0)
+        # FIXME enable tests once v0.5 issue #14919 is fixed
+        @testset "fitness_scheme(x, y)" begin
+            mins = MinimizingFitnessScheme
+            #@test !mins(5.0, 3.0)
+            #@test mins(1.0, 2.0)
 
-			maxs = MaximizingFitnessScheme
-			#@test !maxs(3.0, 5.0)
-			#@test maxs(2.0, 1.0)
-		end
-	end
+            maxs = MaximizingFitnessScheme
+            #@test !maxs(3.0, 5.0)
+            #@test maxs(2.0, 1.0)
+        end
+    end
 
-	@testset "TupleFitnessScheme" begin
-		@testset "general interface" begin
-			@testset "ParetoFitnessScheme{1}" begin
-				scheme = ParetoFitnessScheme{1}()
-				@test numobjectives(scheme) == 1
-				@test is_minimizing(scheme)
-				@test isnafitness(nafitness(scheme), scheme)
-				@test isequal(nafitness(scheme), (NaN,))
-				@test isnafitness((NaN,), scheme)
-				@test isnafitness((1.0,), scheme) == false
-			end
+    @testset "TupleFitnessScheme" begin
+        @testset "general interface" begin
+            @testset "ParetoFitnessScheme{1}" begin
+                scheme = ParetoFitnessScheme{1}()
+                @test numobjectives(scheme) == 1
+                @test is_minimizing(scheme)
+                @test isnafitness(nafitness(scheme), scheme)
+                @test isequal(nafitness(scheme), (NaN,))
+                @test isnafitness((NaN,), scheme)
+                @test isnafitness((1.0,), scheme) == false
+            end
 
-			@testset "ParetoFitnessScheme{1}(is_minimizing=false)" begin
-				scheme = ParetoFitnessScheme{1}(is_minimizing=false)
-				@test numobjectives(scheme) == 1
-				@test is_minimizing(scheme) == false
-				@test isnafitness(nafitness(scheme), scheme)
-				@test isequal(nafitness(scheme), (NaN,))
-				@test isnafitness((NaN,), scheme)
-				@test isnafitness((1.0,), scheme) == false
-			end
+            @testset "ParetoFitnessScheme{1}(is_minimizing=false)" begin
+                scheme = ParetoFitnessScheme{1}(is_minimizing=false)
+                @test numobjectives(scheme) == 1
+                @test is_minimizing(scheme) == false
+                @test isnafitness(nafitness(scheme), scheme)
+                @test isequal(nafitness(scheme), (NaN,))
+                @test isnafitness((NaN,), scheme)
+                @test isnafitness((1.0,), scheme) == false
+            end
 
-			@testset "ParetoFitnessScheme{3}()" begin
-				scheme = ParetoFitnessScheme{3}()
-				@test isequal(nafitness(scheme), (NaN,NaN,NaN))
-				@test numobjectives(scheme) == 3
-				@test is_minimizing(scheme)
-				@test isnafitness(nafitness(scheme), scheme)
-				@test isnafitness((NaN,NaN,NaN), scheme)
-				@test isnafitness((1.0,NaN,2.0), scheme)
-				@test isnafitness((1.0,2.0,2.0), scheme) == false
-			end
-		end
+            @testset "ParetoFitnessScheme{3}()" begin
+                scheme = ParetoFitnessScheme{3}()
+                @test isequal(nafitness(scheme), (NaN,NaN,NaN))
+                @test numobjectives(scheme) == 3
+                @test is_minimizing(scheme)
+                @test isnafitness(nafitness(scheme), scheme)
+                @test isnafitness((NaN,NaN,NaN), scheme)
+                @test isnafitness((1.0,NaN,2.0), scheme)
+                @test isnafitness((1.0,2.0,2.0), scheme) == false
+            end
+        end
 
-		@testset "hat_compare(..., ParetoFitnessScheme{1}())" begin
-			scheme = ParetoFitnessScheme{1}()
+        @testset "hat_compare(..., ParetoFitnessScheme{1}())" begin
+            scheme = ParetoFitnessScheme{1}()
 
-			@test_throws MethodError hat_compare((-1.0,), (1.0, 2.0), scheme)
+            @test_throws MethodError hat_compare((-1.0,), (1.0, 2.0), scheme)
 
-			@test hat_compare((-1.0,), (1.0,), scheme) == -1
-			@test hat_compare((0.0,), (0.3,), scheme) == -1
-			@test hat_compare((11.3,), (354.65,), scheme) == -1
+            @test hat_compare((-1.0,), (1.0,), scheme) == -1
+            @test hat_compare((0.0,), (0.3,), scheme) == -1
+            @test hat_compare((11.3,), (354.65,), scheme) == -1
 
-			@test hat_compare((-1.0,), (-1.0,), scheme) == 0
-			@test hat_compare((0.0,), (0.0,), scheme) == 0
-			@test hat_compare((0.2,), (0.2,), scheme) == 0
+            @test hat_compare((-1.0,), (-1.0,), scheme) == 0
+            @test hat_compare((0.0,), (0.0,), scheme) == 0
+            @test hat_compare((0.2,), (0.2,), scheme) == 0
 
-			@test hat_compare((1.0,), (0.0,), scheme) == 1
-			@test hat_compare((0.0,), (-0.4,), scheme) == 1
-			@test hat_compare((-0.65,), (-34.2,), scheme) == 1
-		end
+            @test hat_compare((1.0,), (0.0,), scheme) == 1
+            @test hat_compare((0.0,), (-0.4,), scheme) == 1
+            @test hat_compare((-0.65,), (-34.2,), scheme) == 1
+        end
 
-		@testset "hat_compare(..., ParetoFitnessScheme{1}(is_minimizing=false))" begin
-			scheme = ParetoFitnessScheme{1}(is_minimizing=false)
-			@test hat_compare((-1.0,), (1.0,), scheme) == 1
-			@test hat_compare((0.0,), (0.3,), scheme) == 1
-			@test hat_compare((11.3,), (354.65,), scheme) == 1
-			@test hat_compare((-1.0,), (-1.0,), scheme) == 0
-			@test hat_compare((0.0,), (0.0,), scheme) == 0
-			@test hat_compare((0.2,), (0.2,), scheme) == 0
-			@test hat_compare((1.0,), (0.0,), scheme) == -1
-			@test hat_compare((0.0,), (-0.4,), scheme) == -1
-			@test hat_compare((-0.65,), (-34.2,), scheme) == -1
-		end
+        @testset "hat_compare(..., ParetoFitnessScheme{1}(is_minimizing=false))" begin
+            scheme = ParetoFitnessScheme{1}(is_minimizing=false)
+            @test hat_compare((-1.0,), (1.0,), scheme) == 1
+            @test hat_compare((0.0,), (0.3,), scheme) == 1
+            @test hat_compare((11.3,), (354.65,), scheme) == 1
+            @test hat_compare((-1.0,), (-1.0,), scheme) == 0
+            @test hat_compare((0.0,), (0.0,), scheme) == 0
+            @test hat_compare((0.2,), (0.2,), scheme) == 0
+            @test hat_compare((1.0,), (0.0,), scheme) == -1
+            @test hat_compare((0.0,), (-0.4,), scheme) == -1
+            @test hat_compare((-0.65,), (-34.2,), scheme) == -1
+        end
 
-		@testset "hat_compare(..., ParetoFitnessScheme{2}(is_minimizing=true))" begin
-			scheme = ParetoFitnessScheme{2}(is_minimizing=true)
-			@test is_minimizing(scheme)
-			@test_throws MethodError hat_compare((-1.0,), (1.0, 2.0), scheme)
-			@test_throws MethodError hat_compare((2.0, -1.0, 3.0), (1.0, 2.0), scheme)
-			@test hat_compare((-1.0, 0.0), (1.0, 0.0), scheme) == -1
-			@test hat_compare((0.0, -1.0), (0.3, 1.0), scheme) == -1
-			@test hat_compare((-1.0, 2.0), (-1.0, 2.0), scheme) == 0
-			@test hat_compare((0.0, 0.0), (0.0, 0.0), scheme) == 0
-			@test hat_compare((0.2, -0.4), (0.2, -0.4), scheme) == 0
-			@test hat_compare((0.4, -0.4), (0.2, -0.2), scheme) == 0
-			@test hat_compare((-0.65, 1.0), (1.0, -34.2), scheme) == 0
-			@test hat_compare((11.3, 100.0), (11.3, 10.0), scheme) == 1
-			@test hat_compare((1.0, 0.0), (0.0, -1.0), scheme) == 1
-			@test hat_compare((0.0, 34.0), (-0.4, 20.0), scheme) == 1
-		end
+        @testset "hat_compare(..., ParetoFitnessScheme{2}(is_minimizing=true))" begin
+            scheme = ParetoFitnessScheme{2}(is_minimizing=true)
+            @test is_minimizing(scheme)
+            @test_throws MethodError hat_compare((-1.0,), (1.0, 2.0), scheme)
+            @test_throws MethodError hat_compare((2.0, -1.0, 3.0), (1.0, 2.0), scheme)
+            @test hat_compare((-1.0, 0.0), (1.0, 0.0), scheme) == -1
+            @test hat_compare((0.0, -1.0), (0.3, 1.0), scheme) == -1
+            @test hat_compare((-1.0, 2.0), (-1.0, 2.0), scheme) == 0
+            @test hat_compare((0.0, 0.0), (0.0, 0.0), scheme) == 0
+            @test hat_compare((0.2, -0.4), (0.2, -0.4), scheme) == 0
+            @test hat_compare((0.4, -0.4), (0.2, -0.2), scheme) == 0
+            @test hat_compare((-0.65, 1.0), (1.0, -34.2), scheme) == 0
+            @test hat_compare((11.3, 100.0), (11.3, 10.0), scheme) == 1
+            @test hat_compare((1.0, 0.0), (0.0, -1.0), scheme) == 1
+            @test hat_compare((0.0, 34.0), (-0.4, 20.0), scheme) == 1
+        end
 
-		@testset "hat_compare(..., ParetoFitnessScheme{2}(is_minimizing=false))" begin
-			scheme = ParetoFitnessScheme{2}(is_minimizing=false)
-			@test is_minimizing(scheme) == false
-			@test hat_compare((-1.0, 0.0), (1.0, 0.0), scheme) == 1
-			@test hat_compare((0.0, -1.0), (0.3, 1.0), scheme) == 1
-			@test hat_compare((-1.0, 2.0), (-1.0, 2.0), scheme) == 0
-			@test hat_compare((0.0, 0.0), (0.0, 0.0), scheme) == 0
-			@test hat_compare((0.2, -0.4), (0.2, -0.4), scheme) == 0
-			@test hat_compare((0.4, -0.4), (0.2, -0.2), scheme) == 0
-			@test hat_compare((-0.65, 1.0), (1.0, -34.2), scheme) == 0
-			@test hat_compare((11.3, 100.0), (11.3, 10.0), scheme) == -1
-			@test hat_compare((1.0, 0.0), (0.0, -1.0), scheme) == -1
-			@test hat_compare((0.0, 34.0), (-0.4, 20.0), scheme) == -1
-		end
+        @testset "hat_compare(..., ParetoFitnessScheme{2}(is_minimizing=false))" begin
+            scheme = ParetoFitnessScheme{2}(is_minimizing=false)
+            @test is_minimizing(scheme) == false
+            @test hat_compare((-1.0, 0.0), (1.0, 0.0), scheme) == 1
+            @test hat_compare((0.0, -1.0), (0.3, 1.0), scheme) == 1
+            @test hat_compare((-1.0, 2.0), (-1.0, 2.0), scheme) == 0
+            @test hat_compare((0.0, 0.0), (0.0, 0.0), scheme) == 0
+            @test hat_compare((0.2, -0.4), (0.2, -0.4), scheme) == 0
+            @test hat_compare((0.4, -0.4), (0.2, -0.2), scheme) == 0
+            @test hat_compare((-0.65, 1.0), (1.0, -34.2), scheme) == 0
+            @test hat_compare((11.3, 100.0), (11.3, 10.0), scheme) == -1
+            @test hat_compare((1.0, 0.0), (0.0, -1.0), scheme) == -1
+            @test hat_compare((0.0, 34.0), (-0.4, 20.0), scheme) == -1
+        end
 
-		@testset "is_better/is_worse/same_fitness(..., ParetoFitnessScheme{2}(is_minimizing=true))" begin
-			scheme = ParetoFitnessScheme{2}()
+        @testset "is_better/is_worse/same_fitness(..., ParetoFitnessScheme{2}(is_minimizing=true))" begin
+            scheme = ParetoFitnessScheme{2}()
 
-			@test is_better((-1.0, 0.0), (1.0, 0.0), scheme)
-			@test is_better((0.0, 0.0), (1.0, 0.0), scheme)
-			@test_throws MethodError is_better((0.0,), (1.0,), scheme)
+            @test is_better((-1.0, 0.0), (1.0, 0.0), scheme)
+            @test is_better((0.0, 0.0), (1.0, 0.0), scheme)
+            @test_throws MethodError is_better((0.0,), (1.0,), scheme)
 
-			@test is_better((1.0, 0.0), (-1.0, 0.0), scheme) == false
-			@test is_better((1.0, 0.0), (0.0, 0.0), scheme) == false
+            @test is_better((1.0, 0.0), (-1.0, 0.0), scheme) == false
+            @test is_better((1.0, 0.0), (0.0, 0.0), scheme) == false
 
-			@test is_worse((-1.0, 0.0), (1.0, 0.0), scheme) == false
-			@test is_worse((0.0, 0.0), (1.0, 0.0), scheme) == false
-			@test_throws MethodError is_worse((0.0, 1.0), (1.0,), scheme)
+            @test is_worse((-1.0, 0.0), (1.0, 0.0), scheme) == false
+            @test is_worse((0.0, 0.0), (1.0, 0.0), scheme) == false
+            @test_throws MethodError is_worse((0.0, 1.0), (1.0,), scheme)
 
-			@test is_worse((1.0, 0.0), (-1.0, 0.0), scheme)
-			@test is_worse((1.0, 0.0), (0.0, 0.0), scheme)
+            @test is_worse((1.0, 0.0), (-1.0, 0.0), scheme)
+            @test is_worse((1.0, 0.0), (0.0, 0.0), scheme)
 
-			@test same_fitness((-1.0, 0.0), (1.0, 0.0), scheme) == false
-			@test same_fitness((0.0, 0.0), (1.0, 0.0), scheme) == false
-			@test_throws MethodError same_fitness((0.0,), (1.0,), scheme)
+            @test same_fitness((-1.0, 0.0), (1.0, 0.0), scheme) == false
+            @test same_fitness((0.0, 0.0), (1.0, 0.0), scheme) == false
+            @test_throws MethodError same_fitness((0.0,), (1.0,), scheme)
 
-			@test same_fitness((-1.0, 0.0), (-1.0, 0.0), scheme)
-			@test same_fitness((0.0, 0.0), (0.0, 0.0), scheme)
-			@test_throws MethodError same_fitness((0.0,), (0.0,), scheme)
-		end
+            @test same_fitness((-1.0, 0.0), (-1.0, 0.0), scheme)
+            @test same_fitness((0.0, 0.0), (0.0, 0.0), scheme)
+            @test_throws MethodError same_fitness((0.0,), (0.0,), scheme)
+        end
 
-		@testset "is_better/is_worse/same_fitness(..., ParetoFitnessScheme{2}(is_minimizing=false))" begin
-			scheme = ParetoFitnessScheme{2}(is_minimizing=false)
+        @testset "is_better/is_worse/same_fitness(..., ParetoFitnessScheme{2}(is_minimizing=false))" begin
+            scheme = ParetoFitnessScheme{2}(is_minimizing=false)
 
-			@test is_better((-1.0, 0.0), (1.0, 0.0), scheme) == false
-			@test is_better((0.0, 0.0), (1.0, 0.0), scheme) == false
+            @test is_better((-1.0, 0.0), (1.0, 0.0), scheme) == false
+            @test is_better((0.0, 0.0), (1.0, 0.0), scheme) == false
 
-			@test is_better((1.0, 0.0), (-1.0, 0.0), scheme)
-			@test is_better((1.0, 0.0), (0.0, 0.0), scheme)
+            @test is_better((1.0, 0.0), (-1.0, 0.0), scheme)
+            @test is_better((1.0, 0.0), (0.0, 0.0), scheme)
 
-			@test is_worse((-1.0, 0.0), (1.0, 0.0), scheme)
-			@test is_worse((0.0, 0.0), (1.0, 0.0), scheme)
+            @test is_worse((-1.0, 0.0), (1.0, 0.0), scheme)
+            @test is_worse((0.0, 0.0), (1.0, 0.0), scheme)
 
-			@test is_worse((1.0, 0.0), (-1.0, 0.0), scheme) == false
-			@test is_worse((1.0, 0.0), (0.0, 0.0), scheme) == false
+            @test is_worse((1.0, 0.0), (-1.0, 0.0), scheme) == false
+            @test is_worse((1.0, 0.0), (0.0, 0.0), scheme) == false
 
-			@test same_fitness((-1.0, 0.0), (1.0, 0.0), scheme) == false
-			@test same_fitness((0.0, 0.0), (1.0, 0.0), scheme) == false
+            @test same_fitness((-1.0, 0.0), (1.0, 0.0), scheme) == false
+            @test same_fitness((0.0, 0.0), (1.0, 0.0), scheme) == false
 
-			@test same_fitness((-1.0, 0.0), (-1.0, 0.0), scheme)
-			@test same_fitness((0.0, 0.0), (0.0, 0.0), scheme)
-		end
-	end
+            @test same_fitness((-1.0, 0.0), (-1.0, 0.0), scheme)
+            @test same_fitness((0.0, 0.0), (0.0, 0.0), scheme)
+        end
+    end
 
-	@testset "ϵ-box FitnessScheme" begin
-		@testset "ϵ-index()" begin
-			for (u, ϵ, is_minim, u_ix, delta) in [
-					(2.3, 1.0, true, 2, 0.3),
-					(2.3, 0.1, true, 23, 0.0),
-					(2.3, 1.0, false, 3, 0.7),
-					(1.0, 1.0, true, 1.0, 0.0),
-					(2.0, 2.0, false, 1.0, 0.0),
-					(-1.1, 1.0, true, -2, 0.9),
-					(-5.4, 1.0, false, -5, 0.4)
-				]
-				res = BlackBoxOptim.ϵ_index(u, ϵ, Val{is_minim})
-				@test res[1] == u_ix
-				@test isapprox(res[2], delta; atol=1E-12)
-			end
-		end
+    @testset "ϵ-box FitnessScheme" begin
+        @testset "ϵ-index()" begin
+            for (u, ϵ, is_minim, u_ix, delta) in [
+                    (2.3, 1.0, true, 2, 0.3),
+                    (2.3, 0.1, true, 23, 0.0),
+                    (2.3, 1.0, false, 3, 0.7),
+                    (1.0, 1.0, true, 1.0, 0.0),
+                    (2.0, 2.0, false, 1.0, 0.0),
+                    (-1.1, 1.0, true, -2, 0.9),
+                    (-5.4, 1.0, false, -5, 0.4)
+                ]
+                res = BlackBoxOptim.ϵ_index(u, ϵ, Val{is_minim})
+                @test res[1] == u_ix
+                @test isapprox(res[2], delta; atol=1E-12)
+            end
+        end
 
-		@testset "IndexedTupleFitness" begin
-			fit = (0.55, 0.3, -0.21)
-			ifit1 = IndexedTupleFitness(fit, sum(fit), 0.1, Val{true})
-			@test ifit1.orig == fit
-			@test ifit1.agg == sum(fit)
-			@test ifit1.index == (5, 3, -3)
-			@test isapprox(ifit1.dist, norm([0.05, 0.09])/0.1)
+        @testset "IndexedTupleFitness" begin
+            fit = (0.55, 0.3, -0.21)
+            ifit1 = IndexedTupleFitness(fit, sum(fit), 0.1, Val{true})
+            @test ifit1.orig == fit
+            @test ifit1.agg == sum(fit)
+            @test ifit1.index == (5, 3, -3)
+            @test isapprox(ifit1.dist, norm([0.05, 0.09])/0.1)
 
-			ifit2 = IndexedTupleFitness(fit, sum(fit), 0.1, Val{false})
-			@test ifit2.orig == fit
-			@test ifit2.agg == sum(fit)
-			@test ifit2.index == (6, 3, -2)
-			@test isapprox(ifit2.dist, norm([0.05, 0.01])/0.1)
+            ifit2 = IndexedTupleFitness(fit, sum(fit), 0.1, Val{false})
+            @test ifit2.orig == fit
+            @test ifit2.agg == sum(fit)
+            @test ifit2.index == (6, 3, -2)
+            @test isapprox(ifit2.dist, norm([0.05, 0.01])/0.1)
 
-			ifit3 = convert(IndexedTupleFitness, fit,
-								EpsBoxDominanceFitnessScheme{3}(0.1))
-			@test ifit3 == ifit1
-			ifit4 = convert(IndexedTupleFitness, fit,
-								EpsBoxDominanceFitnessScheme{3}(0.1, is_minimizing=false))
-			@test ifit4 == ifit2
-		end
+            ifit3 = convert(IndexedTupleFitness, fit, EpsBoxDominanceFitnessScheme{3}(0.1))
+            @test ifit3 == ifit1
+            ifit4 = convert(IndexedTupleFitness, fit, EpsBoxDominanceFitnessScheme{3}(0.1, is_minimizing=false))
+            @test ifit4 == ifit2
+        end
 
-		@testset "hat_compare(..., EpsBoxDominanceFitnessScheme{2}(...))" begin
-			minscheme = EpsBoxDominanceFitnessScheme{2}(0.1, is_minimizing=true)
-			maxscheme = EpsBoxDominanceFitnessScheme{2}(0.1, is_minimizing=false)
+        @testset "hat_compare(..., EpsBoxDominanceFitnessScheme{2}(...))" begin
+            minscheme = EpsBoxDominanceFitnessScheme{2}(0.1, is_minimizing=true)
+            maxscheme = EpsBoxDominanceFitnessScheme{2}(0.1, is_minimizing=false)
 
-			@test isnafitness(nafitness(minscheme), minscheme)
-			@test isnafitness(nafitness(maxscheme), minscheme)
-			@test isnafitness(nafitness(minscheme), maxscheme)
-			@test isnafitness(nafitness(maxscheme), maxscheme)
+            @test isnafitness(nafitness(minscheme), minscheme)
+            @test isnafitness(nafitness(maxscheme), minscheme)
+            @test isnafitness(nafitness(minscheme), maxscheme)
+            @test isnafitness(nafitness(maxscheme), maxscheme)
 
-			@test hat_compare((-1.0, 0.0), (-1.0, 0.0), minscheme) == (0, true)
-			@test hat_compare((-1.0, 0.0), (-1.0, 0.0), maxscheme) == (0, true)
-			@test hat_compare((-1.0, 0.0), (1.0, 0.0), minscheme) == (-1, false)
-			@test hat_compare((-1.0, 0.0), (1.0, 0.0), maxscheme) == (1, false)
-			@test hat_compare((-1.0, 0.0), (-0.99, 0.0), minscheme) == (-1, true)
-			@test hat_compare((-1.0, 0.0), (-0.99, 0.0), maxscheme) == (1, false)
-			@test hat_compare((-1.0, 0.0), (-1.01, 0.0), minscheme) == (1, false)
-			@test hat_compare((-1.0, 0.0), (-1.01, 0.0), maxscheme) == (-1, true)
+            @test hat_compare((-1.0, 0.0), (-1.0, 0.0), minscheme) == (0, true)
+            @test hat_compare((-1.0, 0.0), (-1.0, 0.0), maxscheme) == (0, true)
+            @test hat_compare((-1.0, 0.0), (1.0, 0.0), minscheme) == (-1, false)
+            @test hat_compare((-1.0, 0.0), (1.0, 0.0), maxscheme) == (1, false)
+            @test hat_compare((-1.0, 0.0), (-0.99, 0.0), minscheme) == (-1, true)
+            @test hat_compare((-1.0, 0.0), (-0.99, 0.0), maxscheme) == (1, false)
+            @test hat_compare((-1.0, 0.0), (-1.01, 0.0), minscheme) == (1, false)
+            @test hat_compare((-1.0, 0.0), (-1.01, 0.0), maxscheme) == (-1, true)
 
-			@test hat_compare((-0.97, 0.44), (-0.96, 0.43), minscheme) == (0, true)
-			@test hat_compare((-0.97, 0.44), (-0.96, 0.43), maxscheme) == (0, true)
-			@test hat_compare((-1.0, 0.5), (-1.0, 0.51), minscheme) == (-1, true)
-			@test hat_compare((-1.0, 0.5), (-1.0, 0.51), maxscheme) == (1, false)
+            @test hat_compare((-0.97, 0.44), (-0.96, 0.43), minscheme) == (0, true)
+            @test hat_compare((-0.97, 0.44), (-0.96, 0.43), maxscheme) == (0, true)
+            @test hat_compare((-1.0, 0.5), (-1.0, 0.51), minscheme) == (-1, true)
+            @test hat_compare((-1.0, 0.5), (-1.0, 0.51), maxscheme) == (1, false)
 
-			@test hat_compare((0.9, 0.0), (1.0, 0.0), minscheme) == (-1, false)
-			@test hat_compare((0.9, 0.0), (1.0, 0.0), maxscheme) == (1, false)
-			@test hat_compare((0.95, 0.0), (0.98, 0.0), minscheme) == (-1, true)
-			@test hat_compare((0.95, 0.0), (0.98, 0.0), maxscheme) == (1, true)
+            @test hat_compare((0.9, 0.0), (1.0, 0.0), minscheme) == (-1, false)
+            @test hat_compare((0.9, 0.0), (1.0, 0.0), maxscheme) == (1, false)
+            @test hat_compare((0.95, 0.0), (0.98, 0.0), minscheme) == (-1, true)
+            @test hat_compare((0.95, 0.0), (0.98, 0.0), maxscheme) == (1, true)
 
-			@test hat_compare((-1.0, 0.05), (1.0, 0.0), minscheme) == (-1, false)
-			@test hat_compare((-1.0, 0.05), (1.0, 0.0), maxscheme) == (0, false)
-			@test hat_compare((0.9, 0.05), (1.0, 0.0), minscheme) == (-1, false)
-			@test hat_compare((0.9, 0.05), (1.0, 0.0), maxscheme) == (0, false)
-			@test hat_compare((0.95, 0.05), (0.98, 0.0), minscheme) == (-1, true)
-			@test hat_compare((0.95, 0.05), (0.98, 0.0), maxscheme) == (-1, false)
-			@test hat_compare((0.95, 0.05), (0.98, 0.01), maxscheme) == (-1, true)
-			@test hat_compare((0.95, 0.05), (0.96, 0.0), minscheme) == (1, true)
-			@test hat_compare((0.95, 0.05), (0.96, 0.0), maxscheme) == (-1, false)
-			@test hat_compare((0.95, 0.05), (0.96, 0.04), minscheme) == (-1, true)
-			@test hat_compare((0.95, 0.05), (0.96, 0.04), maxscheme) == (-1, true)
+            @test hat_compare((-1.0, 0.05), (1.0, 0.0), minscheme) == (-1, false)
+            @test hat_compare((-1.0, 0.05), (1.0, 0.0), maxscheme) == (0, false)
+            @test hat_compare((0.9, 0.05), (1.0, 0.0), minscheme) == (-1, false)
+            @test hat_compare((0.9, 0.05), (1.0, 0.0), maxscheme) == (0, false)
+            @test hat_compare((0.95, 0.05), (0.98, 0.0), minscheme) == (-1, true)
+            @test hat_compare((0.95, 0.05), (0.98, 0.0), maxscheme) == (-1, false)
+            @test hat_compare((0.95, 0.05), (0.98, 0.01), maxscheme) == (-1, true)
+            @test hat_compare((0.95, 0.05), (0.96, 0.0), minscheme) == (1, true)
+            @test hat_compare((0.95, 0.05), (0.96, 0.0), maxscheme) == (-1, false)
+            @test hat_compare((0.95, 0.05), (0.96, 0.04), minscheme) == (-1, true)
+            @test hat_compare((0.95, 0.05), (0.96, 0.04), maxscheme) == (-1, true)
 
-			@test hat_compare((6.9928266604943286,0.03386770153536918),
-								(7.007808609410211,0.032833634435236035), minscheme, 0) == (-1, false)
-			@test hat_compare((6.9928266604943286,0.03386770153536918),
-								(7.007808609410211,0.032833634435236035), minscheme, 1) == (-1, false)
-			@test hat_compare((6.9928266604943286,0.03386770153536918),
-								(7.007808609410211,0.032833634435236035), minscheme, -1) == (-1, false)
-		end
-	end
+            @test hat_compare((6.9928266604943286,0.03386770153536918),
+                                (7.007808609410211,0.032833634435236035), minscheme, 0) == (-1, false)
+            @test hat_compare((6.9928266604943286,0.03386770153536918),
+                                (7.007808609410211,0.032833634435236035), minscheme, 1) == (-1, false)
+            @test hat_compare((6.9928266604943286,0.03386770153536918),
+                                (7.007808609410211,0.032833634435236035), minscheme, -1) == (-1, false)
+        end
+    end
 end

--- a/test/test_population.jl
+++ b/test/test_population.jl
@@ -12,7 +12,7 @@
         @test isnafitness(fitness(p1, 4), fs)
 
         @testset "accessing individuals" begin
-    		@test isa(p1[1], Vector{Float64})
+            @test isa(p1[1], Vector{Float64})
             @test length(p1[1]) == numdims(p1)
             @test isa(BlackBoxOptim.viewer(p1, 1), AbstractVector{Float64})
             @test length(BlackBoxOptim.viewer(p1, 1)) == numdims(p1)

--- a/test/test_selectors.jl
+++ b/test/test_selectors.jl
@@ -38,37 +38,37 @@ end
 end
 
 @testset "Tournament" begin
-        sel = BlackBoxOptim.TournamentSelector(MinimizingFitnessScheme, 3)
-        fake_pop = FitPopulation(reshape(collect(1.0:10.0), (1, 10)),
-                                 NaN, collect(1.0:10.0))
+    sel = BlackBoxOptim.TournamentSelector(MinimizingFitnessScheme, 3)
+    fake_pop = FitPopulation(reshape(collect(1.0:10.0), (1, 10)),
+                             NaN, collect(1.0:10.0))
 
-        @testset "tournament()" begin
-                for i in 1:NumTestRepetitions
-                        tourSize = rand(0:popsize(fake_pop))
-                        cand_ixs = find(bitrand(popsize(fake_pop)))
+    @testset "tournament()" begin
+        for i in 1:NumTestRepetitions
+            tourSize = rand(0:popsize(fake_pop))
+            cand_ixs = find(bitrand(popsize(fake_pop)))
 
-                        winner_ix = BlackBoxOptim.tournament(sel, fake_pop, cand_ixs)
+            winner_ix = BlackBoxOptim.tournament(sel, fake_pop, cand_ixs)
 
-                        if isempty(cand_ixs)
-                                @test winner_ix == 0
-                        else
-                                @test in(winner_ix, 1:popsize(fake_pop))
-                                @test fitness(fake_pop, winner_ix) == minimum(fake_pop.fitness[cand_ixs])
-                        end
-                end
+            if isempty(cand_ixs)
+                @test winner_ix == 0
+            else
+                @test in(winner_ix, 1:popsize(fake_pop))
+                @test fitness(fake_pop, winner_ix) == minimum(fake_pop.fitness[cand_ixs])
+            end
         end
+    end
 
-        @testset "select()" begin
-                for i in 1:NumTestRepetitions
-                        numSamples = rand(1:3)
-                        sampled = BlackBoxOptim.select(sel, fake_pop, numSamples)
+    @testset "select()" begin
+        for i in 1:NumTestRepetitions
+            numSamples = rand(1:3)
+            sampled = BlackBoxOptim.select(sel, fake_pop, numSamples)
 
-                        @test length(sampled) == numSamples
+            @test length(sampled) == numSamples
 
-                        # All sampled indices are indices into the population
-                        @test all(index -> in(index, 1:popsize(fake_pop)), sampled)
-                end
+            # All sampled indices are indices into the population
+            @test all(index -> in(index, 1:popsize(fake_pop)), sampled)
         end
+    end
 end
 
 end

--- a/test/test_toplevel_bboptimize.jl
+++ b/test/test_toplevel_bboptimize.jl
@@ -102,7 +102,7 @@
 
     @testset "fitness decrease monotonically if optimizing with same optctrl repeatedly" begin
         # There was a bug in 0.3.0 that did not give monotonically decreasing
-        # fitness with repeated runs. The bug only happened for very short MaxSteps 
+        # fitness with repeated runs. The bug only happened for very short MaxSteps
         # lengths, such as 10. This test ensures it does not resurface.
         optctrl = bbsetup(rosenbrock; SearchRange = (-5.0, 5.0), NumDimensions = 100,
             MaxSteps = 10, TraceMode = :silent)
@@ -114,34 +114,34 @@
     end
 
     @testset "return results after interruption" begin
+        i = 0
+        function rosenbrock_throwing(x)
+            i += 1
+            if i < 50
+                return sum(100*(x[2:end] - x[1:end-1].^2).^2 + (x[1:end-1] - 1).^2)
+            else
+                throw(InterruptException())
+            end
+        end
+        @testset ":RecoverResults on" begin
             i = 0
-            function rosenbrock_throwing(x)
-                    i += 1
-                    if i < 50
-                            return( sum( 100*( x[2:end] - x[1:end-1].^2 ).^2 + ( x[1:end-1] - 1 ).^2 ) )
-                    else
-                            throw(InterruptException())
-                    end
-            end
-            @testset ":RecoverResults on" begin
-                i = 0
-                optctrl = bbsetup(rosenbrock_throwing; SearchRange = (-5.0, 5.0), NumDimensions = 100,
-                        MaxSteps=100, TraceMode=:silent, RecoverResults=true)
-                res = bboptimize(optctrl)
-                @test BlackBoxOptim.stop_reason(res) == (@sprintf "%s" InterruptException())
-            end
+            optctrl = bbsetup(rosenbrock_throwing; SearchRange = (-5.0, 5.0), NumDimensions = 100,
+                              MaxSteps=100, TraceMode=:silent, RecoverResults=true)
+            res = bboptimize(optctrl)
+            @test BlackBoxOptim.stop_reason(res) == (@sprintf "%s" InterruptException())
+        end
 
-            @testset ":RecoverResults off" begin
-                i = 0 # reset the counter, otherwise it will throw in the setup
-                optctrl = bbsetup(rosenbrock_throwing; SearchRange = (-5.0, 5.0), NumDimensions = 100,
-                        MaxSteps=100, TraceMode=:silent, RecoverResults=false)
-                @test_throws InterruptException bboptimize(optctrl)
-            end
+        @testset ":RecoverResults off" begin
+            i = 0 # reset the counter, otherwise it will throw in the setup
+            optctrl = bbsetup(rosenbrock_throwing; SearchRange = (-5.0, 5.0), NumDimensions = 100,
+                              MaxSteps=100, TraceMode=:silent, RecoverResults=false)
+            @test_throws InterruptException bboptimize(optctrl)
+        end
     end
 
     @testset "continue running an optimization after serializing to disc" begin
         optctrl = bbsetup(rosenbrock; SearchRange = (-5.0, 5.0), NumDimensions = 100,
-            MaxTime = 0.5, TraceMode = :silent)
+                          MaxTime = 0.5, TraceMode = :silent)
         res1 = bboptimize(optctrl)
 
         local tempfilename = "./temp" * string(rand(1:10^8)) * ".tmp"
@@ -174,12 +174,12 @@
     @testset "TargetFitness option works" begin
         # FIXME use the same (fixed?) random seed to guarantee reproducibility
         result1 = bboptimize(rosenbrock, SearchRange = (-5.0, 5.0), NumDimensions = 5,
-                                                Method = :de_rand_1_bin, FitnessTolerance = 1e-5,
-                                                MaxSteps = 1000000, TraceMode = :silent,
-                                                TargetFitness = 0.0)
+                             Method = :de_rand_1_bin, FitnessTolerance = 1e-5,
+                             MaxSteps = 1000000, TraceMode = :silent,
+                             TargetFitness = 0.0)
         result2 = bboptimize(rosenbrock, SearchRange = (-5.0, 5.0), NumDimensions = 5,
-                                                Method = :de_rand_1_bin, FitnessTolerance = 1e-5,
-                                                MaxSteps = 1000000, TraceMode = :silent)
+                             Method = :de_rand_1_bin, FitnessTolerance = 1e-5,
+                             MaxSteps = 1000000, TraceMode = :silent)
         @test best_fitness(result1) < 1e-5
         @test result1.iterations < result2.iterations
     end

--- a/test/test_toplevel_bboptimize.jl
+++ b/test/test_toplevel_bboptimize.jl
@@ -118,7 +118,7 @@
         function rosenbrock_throwing(x)
             i += 1
             if i < 50
-                return sum(100*(x[2:end] - x[1:end-1].^2).^2 + (x[1:end-1] - 1).^2)
+                return sum(i -> 100*(x[i+1] - x[i])^2 + (x[i] - 1)^2, 1:(length(x)-1))
             else
                 throw(InterruptException())
             end

--- a/test/test_tracing.jl
+++ b/test/test_tracing.jl
@@ -1,26 +1,26 @@
 @testset "Testing methods diagnostic tracing" begin
-        rosenbrock(x) = 100.0*sum(i -> abs2(x[i+1] - x[i]^2), 1:length(x)-1) + sum(i -> abs2(x[i] - 1.0), 1:length(x)-1)
-        schaffer1(x) = (sum(abs2, x), sum(xx -> abs2(xx - 2.0), x))
+    rosenbrock(x) = 100.0*sum(i -> abs2(x[i+1] - x[i]^2), 1:length(x)-1) + sum(i -> abs2(x[i] - 1.0), 1:length(x)-1)
+    schaffer1(x) = (sum(abs2, x), sum(xx -> abs2(xx - 2.0), x))
 
-        @testset "trace_state()" begin
-                for mode in [:silent, :compact, :verbose]
-                        @testset "$mode" begin
-                                for method in keys(BlackBoxOptim.SingleObjectiveMethods)
-                                        opt = bbsetup(rosenbrock; Method=method,
-                                                                SearchRange = (-5.0, 5.0), NumDimensions = 2,
-                                                                MaxSteps = 1, TraceMode = :silent)
-                                        BlackBoxOptim.run!(opt)
-                                        BlackBoxOptim.trace_state(DevNull, BlackBoxOptim.optimizer(BlackBoxOptim.lastrun(opt)), mode)
-                                end
-                                for method in keys(BlackBoxOptim.MultiObjectiveMethods)
-                                        opt = bbsetup(schaffer1; Method=method,
-                                                                SearchRange = [(-10.0, 10.0), (-10.0, 10.0)],
-                                                                FitnessScheme=ParetoFitnessScheme{2}(is_minimizing=true), ϵ=0.01,
-                                                                MaxSteps = 1, TraceMode = :silent)
-                                        BlackBoxOptim.run!(opt)
-                                        BlackBoxOptim.trace_state(DevNull, BlackBoxOptim.optimizer(BlackBoxOptim.lastrun(opt)), mode)
-                                end
-                        end
+    @testset "trace_state()" begin
+        for mode in [:silent, :compact, :verbose]
+            @testset "$mode" begin
+                for method in keys(BlackBoxOptim.SingleObjectiveMethods)
+                    opt = bbsetup(rosenbrock; Method=method,
+                                            SearchRange = (-5.0, 5.0), NumDimensions = 2,
+                                            MaxSteps = 1, TraceMode = :silent)
+                    BlackBoxOptim.run!(opt)
+                    BlackBoxOptim.trace_state(DevNull, BlackBoxOptim.optimizer(BlackBoxOptim.lastrun(opt)), mode)
                 end
+                for method in keys(BlackBoxOptim.MultiObjectiveMethods)
+                    opt = bbsetup(schaffer1; Method=method,
+                                            SearchRange = [(-10.0, 10.0), (-10.0, 10.0)],
+                                            FitnessScheme=ParetoFitnessScheme{2}(is_minimizing=true), ϵ=0.01,
+                                            MaxSteps = 1, TraceMode = :silent)
+                    BlackBoxOptim.run!(opt)
+                    BlackBoxOptim.trace_state(DevNull, BlackBoxOptim.optimizer(BlackBoxOptim.lastrun(opt)), mode)
+                end
+            end
         end
+    end
 end


### PR DESCRIPTION
With 0.7/1.0 on the horizon, this PR drops Julia 0.5 and switches to Julia 0.6 syntax for constructors (no implicit type parameters), method type parameters (`where`) and changes `type`/`immutable` into `[mutable] struct`.
So most of the warnings go away.
Also it fixes the docstring format (4-space indent for the function signature, no indent for the main body) and code indentation (4 spaces indents in all source files).