### PR TITLE
Misc (mostly Borg) tweaks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,15 +3,17 @@ os:
   - linux
   - osx
 julia:
-#  - 0.7 uncomment once 0.7 is out
+  - 0.7
+  - 1.0
   - nightly
-#matrix: uncomment once 0.7 is out
-#  allow_failures:
-#    - julia: nightly
+matrix:
+  allow_failures:
+    - julia: nightly
 notifications:
   email: false
-script:
-  - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
-  - julia --check-bounds=yes -e 'Pkg.clone(pwd()); Pkg.build("BlackBoxOptim"); Pkg.test("BlackBoxOptim"; coverage=true)'
+# uncomment the following lines to override the default test script
+#script:
+#  - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
+#  - julia --check-bounds=yes -e 'using Pkg; Pkg.clone(pwd()); Pkg.build("RData"); Pkg.test("RData"; coverage=true)'
 after_success:
-  - julia -e 'cd(Pkg.dir("BlackBoxOptim")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(Coveralls.process_folder())'
+  - julia -e 'using Pkg, BlackBoxOptim; cd(joinpath(dirname(pathof(BlackBoxOptim)), "..")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(Coveralls.process_folder())'

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,4 @@
-julia 0.7.0-beta2.0
+julia 0.7
 StatsBase
 Distributions
 Compat

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,11 +1,21 @@
 environment:
   matrix:
-  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/0.7/julia-0.7-latest-win32.exe"
-  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.7/julia-0.7-latest-win64.exe"
+  - julia_version: 0.7
+  - julia_version: 1.0
+  - julia_version: latest
+
+platform:
+  - x86 # 32-bit
+  - x64 # 64-bit
+
+matrix:
+  allow_failures:
+  - julia_version: latest
 
 branches:
   only:
     - master
+    - /release-.*/
 
 notifications:
   - provider: Email
@@ -14,18 +24,12 @@ notifications:
     on_build_status_changed: false
 
 install:
-  - ps: "[System.Net.ServicePointManager]::SecurityProtocol = [System.Net.SecurityProtocolType]::Tls12"
-# Download most recent Julia Windows binary
-  - ps: (new-object net.webclient).DownloadFile(
-        $env:JULIA_URL,
-        "C:\projects\julia-binary.exe")
-# Run installer silently, output to C:\projects\julia
-  - C:\projects\julia-binary.exe /S /D=C:\projects\julia
+  - ps: iex ((new-object net.webclient).DownloadString("https://raw.githubusercontent.com/JuliaCI/Appveyor.jl/version-1/bin/install.ps1"))
 
 build_script:
-# Need to convert from shallow to complete for Pkg.clone to work
-  - IF EXIST .git\shallow (git fetch --unshallow)
-  - C:\projects\julia\bin\julia -e "Pkg.clone(pwd(), \"BlackBoxOptim\"); versioninfo(); Pkg.build(\"BlackBoxOptim\")"
+  - echo "%JL_BUILD_SCRIPT%"
+  - C:\julia\bin\julia -e "%JL_BUILD_SCRIPT%"
 
 test_script:
-  - C:\projects\julia\bin\julia --check-bounds=yes -e "Pkg.test(\"BlackBoxOptim\")"
+  - echo "%JL_TEST_SCRIPT%"
+  - C:\julia\bin\julia -e "%JL_TEST_SCRIPT%"

--- a/src/BlackBoxOptim.jl
+++ b/src/BlackBoxOptim.jl
@@ -54,6 +54,7 @@ export  Optimizer, AskTellOptimizer, SteppingOptimizer, PopulationOptimizer,
 
         # OptimizationResults
         minimum, f_minimum, iteration_converged, parameters, population, pareto_frontier, params,
+        archived_fitness,
 
         # OptController
         numruns, lastrun, problem,

--- a/src/BlackBoxOptim.jl
+++ b/src/BlackBoxOptim.jl
@@ -37,7 +37,7 @@ export  Optimizer, AskTellOptimizer, SteppingOptimizer, PopulationOptimizer,
         Problems,
         OptimizationProblem, FunctionBasedProblem,
         minimization_problem,
-        name, fitness_scheme, search_space, numdims, opt_value,
+        name, fitness_scheme_type, fitness_scheme, search_space, numdims, opt_value,
         fitness_is_within_ftol, objfunc, fitness,
 
         # Problem factory/family

--- a/src/borg_moea.jl
+++ b/src/borg_moea.jl
@@ -53,7 +53,7 @@ mutable struct BorgMOEA{FS<:FitnessScheme,V<:Evaluator,P<:Population,M<:GeneticO
                 params[:τ], params[:γ], params[:γ_δ], params[:PopulationSize],
                 Categorical(ones(length(recombinate))/length(recombinate)),
                 params[:θ], params[:ζ], params[:OperatorsUpdatePeriod], params[:RestartCheckPeriod],
-                params[:MaxStepsWithoutProgress],
+                params[:MaxStepsWithoutEpsProgress],
                 recombinate,
                 TournamentSelector(fit_scheme, ceil(Int, params[:τ]*popsize(pop))), modify, embed)
     end
@@ -68,7 +68,7 @@ const BorgMOEA_DefaultParameters = chain(EpsBoxArchive_DefaultParameters, Params
     :ζ => 1.0,        # dampening coefficient for recombination operator weights
     :RestartCheckPeriod => 1000,
     :OperatorsUpdatePeriod => 100,
-    :MaxStepsWithoutProgress => 100
+    :MaxStepsWithoutEpsProgress => 100
 ))
 
 function borg_moea(problem::OptimizationProblem, options::Parameters = EMPTY_PARAMS)

--- a/src/dx_nes.jl
+++ b/src/dx_nes.jl
@@ -105,11 +105,7 @@ function tell!(dxnes::DXNESOpt{F}, rankedCandidates::Vector{Candidate{F}}) where
     u = assign_weights!(dxnes.tmp_Utilities, rankedCandidates, dxnes.sortedUtilities)
     dxnes.evol_path *= dxnes.evol_discount
     # We'll take the small perf hit for now just so this can run also on pre rc2 julia 0.7s
-    if VERSION < v"0.7.0-rc2"
-        dxnes.evol_path += dxnes.evol_Zscale * squeeze(wsum(dxnes.Z, u, 2), dims=2)
-    else
-        dxnes.evol_path += dxnes.evol_Zscale * dropdims(wsum(dxnes.Z, u, 2), dims=2)
-    end
+    dxnes.evol_path += dxnes.evol_Zscale * dropdims(wsum(dxnes.Z, u, 2), dims=2)
     evol_speed = norm(dxnes.evol_path)/dxnes.moving_threshold
     if evol_speed > 1.0
         # the center is moving, adjust weights

--- a/src/genetic_operators/embedding/random_bound.jl
+++ b/src/genetic_operators/embedding/random_bound.jl
@@ -14,21 +14,25 @@ RandomBound(dimBounds::Vector{ParamBounds}) = RandomBound(RangePerDimSearchSpace
 
 search_space(rb::RandomBound) = rb.searchSpace
 
-@inline function random_bound(t::Real, r::Real, l::Real, u::Real)
-    if t < l
-        t = l + rand() * (r - l)
-    elseif t > u
-        t = u + rand() * (r - u)
-    end
-    @assert l <= t <= u "target=$(t) is out of [$l, $u]" # if r is out of [l, u]
-    return t
-end
-
 function apply!(eo::RandomBound, target::AbstractIndividual, ref::AbstractIndividual)
     length(target) == length(ref) == numdims(eo.searchSpace) ||
         throw(ArgumentError("Dimensions of problem/individuals do not match"))
     ss = search_space(eo)
-    @inbounds target .= random_bound.(target, ref, mins(ss), maxs(ss))
+    ssmins = mins(eo.searchSpace)
+    ssmaxs = maxs(eo.searchSpace)
+
+    @inbounds for i in eachindex(target)
+        l, u = ssmins[i], ssmaxs[i]
+
+        if target[i] < l
+            target[i] = l + rand() * (ref[i]-l)
+        elseif target[i] > u
+            target[i] = u + rand() * (ref[i]-u)
+        else
+            continue
+        end
+        @assert l <= target[i] <= u "target[$i]=$(target[i]) is out of [$l, $u]"
+    end
     return target
 end
 

--- a/src/ntuple_fitness.jl
+++ b/src/ntuple_fitness.jl
@@ -32,6 +32,12 @@ Always used when printing fitness vectors though.
 struct ParetoFitnessScheme{N,F<:Number,MIN,AGG} <: TupleFitnessScheme{N,F,NTuple{N,F},MIN,AGG}
     aggregator::AGG    # fitness aggregation function
 
+    ParetoFitnessScheme{N,F,MIN,AGG}(; aggregator::AGG=sum) where {N, F<:Number, MIN, AGG} =
+        new{N,F,MIN,AGG}(aggregator)
+
+    ParetoFitnessScheme{N,F,MIN}(; aggregator::AGG=sum) where {N, F<:Number, MIN, AGG} =
+        new{N,F,MIN,AGG}(aggregator)
+
     ParetoFitnessScheme{N,F}(; is_minimizing::Bool=true, aggregator::AGG=sum) where {N, F<:Number, AGG} =
         new{N,F,is_minimizing,AGG}(aggregator)
 

--- a/src/ntuple_fitness.jl
+++ b/src/ntuple_fitness.jl
@@ -291,16 +291,16 @@ hat_compare(u::IndexedTupleFitness{N,F}, v::IndexedTupleFitness{N,F},
 
 hat_compare(u::NTuple{N,F}, v::IndexedTupleFitness{N,F},
             fs::EpsBoxDominanceFitnessScheme{N,F}, expected::Int=0) where {N,F} =
-    hat_compare(convert(IndexedTupleFitness, u, fs), v, fs, expected)
+    hat_compare(convert(IndexedTupleFitness{N,F}, u, fs), v, fs, expected)
 
 hat_compare(u::IndexedTupleFitness{N,F}, v::NTuple{N,F},
             fs::EpsBoxDominanceFitnessScheme{N,F}, expected::Int=0) where {N,F} =
-    hat_compare(u, convert(IndexedTupleFitness, v, fs), fs, expected)
+    hat_compare(u, convert(IndexedTupleFitness{N,F}, v, fs), fs, expected)
 
 hat_compare(u::NTuple{N,F}, v::NTuple{N,F},
             fs::EpsBoxDominanceFitnessScheme{N,F}, expected::Int=0) where {N,F} =
-    hat_compare(convert(IndexedTupleFitness, u, fs),
-                convert(IndexedTupleFitness, v, fs), fs, expected)
+    hat_compare(convert(IndexedTupleFitness{N,F}, u, fs),
+                convert(IndexedTupleFitness{N,F}, v, fs), fs, expected)
 
 # special overload that strips index equality flag
 (hc::HatCompare{FS})(u::IndexedTupleFitness{N,F},

--- a/src/opt_controller.jl
+++ b/src/opt_controller.jl
@@ -395,11 +395,7 @@ end
 function init_rng!(parameters::Parameters)
     if parameters[:RandomizeRngSeed]
         parameters[:RngSeed] = rand(1:1_000_000)
-        if VERSION < v"0.7.0-rc2"
-            srand(parameters[:RngSeed])
-        else
-            Random.seed!(parameters[:RngSeed])
-        end
+        Random.seed!(parameters[:RngSeed])
     end
 end
 

--- a/src/optimization_result.jl
+++ b/src/optimization_result.jl
@@ -81,6 +81,7 @@ Base.minimum(or::OptimizationResults) = best_candidate(or)
 f_minimum(or::OptimizationResults) = best_fitness(or)
 # FIXME lookup stop_reason
 iteration_converged(or::OptimizationResults) = iterations(or) >= parameters(or)[:MaxSteps]
+isinterrupted(or::OptimizationResults) = stop_reason(or) == "InterruptException()"
 
 """
 `TopListArchive`-specific components of the optimization results.

--- a/src/problem.jl
+++ b/src/problem.jl
@@ -7,8 +7,10 @@ abstract type OptimizationProblem{FS<:FitnessScheme} end
 # common definitions for `OptimizationProblem`
 # (enforce field names of subtypes)
 name(p::OptimizationProblem) = p.name
+fitness_scheme_type(::Type{<:OptimizationProblem{FS}}) where FS = FS
+fitness_type(::Type{P}) where P <: OptimizationProblem = fitness_type(fitness_scheme_type(P))
 fitness_scheme(p::OptimizationProblem) = p.fitness_scheme
-fitness_type(p::OptimizationProblem) = fitness_type(fitness_scheme(p))
+fitness_type(p::P) where P <: OptimizationProblem = fitness_type(P)
 numobjectives(p::OptimizationProblem) = numobjectives(fitness_scheme(p))
 search_space(p::OptimizationProblem) = p.ss
 numdims(p::OptimizationProblem) = numdims(search_space(p))

--- a/src/search_space.jl
+++ b/src/search_space.jl
@@ -84,12 +84,12 @@ struct RangePerDimSearchSpace <: ContinuousSearchSpace
     deltas::Vector{Float64}
 
     function RangePerDimSearchSpace(ranges)
-        mins = map(t -> t[1], ranges)
-        maxs = map(t -> t[2], ranges)
-        new(mins, maxs, (maxs - mins))
+        mins = getindex.(ranges, 1)
+        maxs = getindex.(ranges, 2)
+        new(mins, maxs, maxs .- mins)
     end
 
-    RangePerDimSearchSpace(mins, maxs) = new(mins, maxs, (maxs - mins))
+    RangePerDimSearchSpace(mins, maxs) = new(mins, maxs, maxs .- mins)
 end
 
 mins(rss::RangePerDimSearchSpace) = rss.mins
@@ -108,11 +108,12 @@ symmetric_search_space(numdims, range=(0.0, 1.0)) = RangePerDimSearchSpace(fill(
 """
 Projects a given point onto the search space coordinate-wise.
 """
-feasible(v::AbstractIndividual, ss::RangePerDimSearchSpace) = map(clamp, v, mins(ss), maxs(ss))
+feasible(v::AbstractIndividual, ss::RangePerDimSearchSpace) = clamp.(v, mins(ss), maxs(ss))
 
 # concatenates two range-based search spaces
 Base.vcat(ss1::RangePerDimSearchSpace, ss2::RangePerDimSearchSpace) =
-    RangePerDimSearchSpace(vcat(mins(ss1), mins(ss2)), vcat(maxs(ss1), maxs(ss2)))
+    RangePerDimSearchSpace(vcat(mins(ss1), mins(ss2)),
+                           vcat(maxs(ss1), maxs(ss2)))
 
 """
 0-dimensional search space.

--- a/src/search_space.jl
+++ b/src/search_space.jl
@@ -99,6 +99,9 @@ numdims(rss::RangePerDimSearchSpace) = length(mins(rss))
 
 diameters(rss::RangePerDimSearchSpace) = deltas(rss)
 
+Base.:(==)(a::RangePerDimSearchSpace, b::RangePerDimSearchSpace) =
+    numdims(a) == numdims(b) && (a.mins == b.mins) && (a.maxs == b.maxs)
+
 """
 Create `RangePerDimSearchSpace` with given number of dimensions
 and given range of valid values for each dimension.

--- a/test/problems/common.jl
+++ b/test/problems/common.jl
@@ -1,16 +1,15 @@
 using BlackBoxOptim
 
 function fitness_for_opt(problem, numDimensions, populationSize, numSteps, method)
+    problem = instantiate(problem, numDimensions)
 
-  problem = instantiate(problem, numDimensions)
+    println("\n$(problem.name), n = $(numdims(problem)), optimizer = $(string(method))")
 
-  println("\n$(problem.name), n = $(numdims(problem)), optimizer = $(string(method))")
+    res = bboptimize(problem; Method = method,
+        NumDimensions = numDimensions,
+        PopulationSize = populationSize,
+        MaxSteps = numSteps
+    )
 
-  res = bboptimize(problem; Method = method,
-    NumDimensions = numDimensions,
-    PopulationSize = populationSize,
-    MaxSteps = numSteps
-  )
-
-  best_fitness(res)
+    return best_fitness(res)
 end

--- a/test/problems/test_optimize_single_objective_problems.jl
+++ b/test/problems/test_optimize_single_objective_problems.jl
@@ -5,8 +5,8 @@ include("common.jl")
     @testset "Simple problem $pr" for pr in simple_problems
         p = BlackBoxOptim.example_problems[pr]
 
-        @test fitness_for_opt(p, 5, 20, 5e3, :de_rand_1_bin) < 0.01
-        @test fitness_for_opt(p, 5, 20,  5e3, :de_rand_1_bin_radiuslimited) < 0.01
+        @test fitness_for_opt(p,  5, 20, 5e3, :de_rand_1_bin) < 0.01
+        @test fitness_for_opt(p,  5, 20, 5e3, :de_rand_1_bin_radiuslimited) < 0.01
 
         @test fitness_for_opt(p, 10, 20, 1e4, :de_rand_1_bin) < 0.01
         @test fitness_for_opt(p, 10, 20, 1e4, :de_rand_1_bin_radiuslimited) < 0.01
@@ -18,7 +18,7 @@ include("common.jl")
     @testset "Schwefel1.2" begin
         problem = "Schwefel1.2"
         p = BlackBoxOptim.example_problems[problem]
-        @test fitness_for_opt(p, 5, 20,  5e3, :de_rand_1_bin_radiuslimited) < 0.01
+        @test fitness_for_opt(p, 5,  20, 5e3, :de_rand_1_bin_radiuslimited) < 0.01
         @test fitness_for_opt(p, 10, 50, 5e4, :de_rand_1_bin_radiuslimited) < 0.01
 
         #DE/rand/1/bin seems to have troubles...
@@ -30,8 +30,8 @@ include("common.jl")
     @testset "Rosenbrock" begin
         problem = "Rosenbrock"
         p = BlackBoxOptim.example_problems[problem]
-        @test fitness_for_opt(p, 5, 20,   1e4, :de_rand_1_bin_radiuslimited) < 100.0
-        @test fitness_for_opt(p, 10, 20,  5e4, :de_rand_1_bin_radiuslimited) < 100.0
+        @test fitness_for_opt(p, 5,  20, 1e4, :de_rand_1_bin_radiuslimited) < 100.0
+        @test fitness_for_opt(p, 10, 20, 5e4, :de_rand_1_bin_radiuslimited) < 100.0
         @test fitness_for_opt(p, 30, 40, 2e5, :de_rand_1_bin_radiuslimited) < 100.0
 
         @test fitness_for_opt(p, 30, 40, 2e5, :adaptive_de_rand_1_bin) < 100.0

--- a/test/problems/test_problem.jl
+++ b/test/problems/test_problem.jl
@@ -1,125 +1,111 @@
-fsabs(x) = sum(abs(x))
-fsumsq(x) = sum(x.^2)
+fsabs(x) = sum(abs, x)
+fsum_abs_and_sq(x) = (sum(abs, x), sum(abs2, x))
 
-facts("FixedDimProblem") do
-  context("1-dimensional, single-objective sumabs") do
-    ss = symmetric_search_space(1)
-    p = BlackBoxOptim.FixedDimProblem("sumabs", [fsabs], ss, [0.0])
+@testset "minimization_problem()" begin
 
-    @fact is_fixed_dimensional(p)         --> true
-    @fact is_any_dimensional(p)           --> false
-    @fact is_single_objective_problem(p)  --> true
-    @fact is_multi_objective_problem(p)   --> false
-    @fact numdims(p)                      --> 1
-    @fact search_space(p)                 --> ss
+@testset "1-dimensional, single-objective sum(abs, x)" begin
+    p = minimization_problem(fsabs, "sumabs", (-1.0, 1.0), 1, 0.0)
 
-    @fact eval1([0.0], p)                 --> 0.0
-    @fact eval1([1.2], p)                 --> 1.2
-    @fact eval1([-1.9], p)                --> 1.9
-  end
+    @test fitness_scheme(p) == MinimizingFitnessScheme
+    @test numobjectives(p) == 1
+    @test numdims(p) == 1
+    @test search_space(p) == symmetric_search_space(1, (-1.0, 1.0))
 
-  context("3-dimensional, single-objective sumabs") do
-    ss = symmetric_search_space(3)
-    p = BlackBoxOptim.FixedDimProblem("sumabs", [fsabs], ss, [0.0])
-
-    @fact is_fixed_dimensional(p)         --> true
-    @fact is_any_dimensional(p)           --> false
-    @fact is_single_objective_problem(p)  --> true
-    @fact is_multi_objective_problem(p)   --> false
-    @fact numdims(p)                      --> 3
-    @fact search_space(p)                 --> ss
-
-    @fact eval1([0.0, 1.0, 2.0], p)       --> 3.0
-    @fact eval1([-1.0, 1.0, 2.0], p)      --> 4.0
-  end
-
-  context("1-dimensional, multi-objective sumabs_sumsq") do
-    ss = symmetric_search_space(1)
-    p = BlackBoxOptim.FixedDimProblem("sumabs_sumsq", [fsabs, fsumsq], ss, [0.0, 0.0])
-
-    @fact is_fixed_dimensional(p)         --> true
-    @fact is_any_dimensional(p)           --> false
-    @fact is_single_objective_problem(p)  --> false
-    @fact is_multi_objective_problem(p)   --> true
-    @fact numdims(p)                      --> 1
-    @fact search_space(p)                 --> ss
-
-    @fact eval1([0.0], p)                 --> 0.0
-    @fact eval1([1.2], p)                 --> 1.2
-    @fact eval1([-1.9], p)                --> 1.9
-
-    @fact evalall([0.0], p)               --> [0.0, 0.0]
-    @fact evalall([1.2], p)               --> [1.2, 1.2^2]
-    @fact evalall([-1.9], p)              --> [1.9, 1.9^2]
-  end
-
-  context("Fixed dim problem from an anydim one") do
-    ap = anydim_problem("sumabs", fsabs, (0.0, 1.0), 0.0)
-    p1 = as_fixed_dim_problem(ap, 1)
-
-    @fact is_fixed_dimensional(p1)         --> true
-    @fact is_any_dimensional(p1)           --> false
-    @fact is_single_objective_problem(p1)  --> true
-    @fact is_multi_objective_problem(p1)   --> false
-    @fact numdims(p1)                      --> 1
-
-    @fact eval1([0.0], p1)                 --> 0.0
-    @fact eval1([1.2], p1)                 --> 1.2
-    @fact eval1([-1.9], p1)                --> 1.9
-
-    p3 = as_fixed_dim_problem(ap, 3)
-
-    @fact is_fixed_dimensional(p3)         --> true
-    @fact is_any_dimensional(p3)           --> false
-    @fact is_single_objective_problem(p3)  --> true
-    @fact is_multi_objective_problem(p3)   --> false
-    @fact numdims(p3)                      --> 3
-
-    @fact eval1([0.0, 1.0, 2.0], p3)       --> 3.0
-    @fact eval1([-1.0, 1.0, 2.0], p3)      --> 4.0
-  end
+    @test fitness([0.0], p) == 0.0
+    @test fitness([1.2], p) == 1.2
+    @test fitness([-1.9], p) == 1.9
 end
 
-facts("ShiftedAndBiasedProblem") do
-  context("Only x shifted 1-dim") do
+@testset "3-dimensional, single-objective sum(abs, x)" begin
+    p = minimization_problem(fsabs, "sumabs", (-1.0, 1.0), 3, 0.0)
+
+    @test fitness_scheme(p) == MinimizingFitnessScheme
+    @test numobjectives(p) == 1
+    @test numdims(p) == 3
+    @test search_space(p) == symmetric_search_space(3, (-1.0, 1.0))
+
+    @test fitness([0.0, 1.0, 2.0], p) == 3.0
+    @test fitness([-1.0, 1.0, 2.0], p) == 4.0
+end
+
+@testset "1-dimensional, multi-objective sumabs_sumsq" begin
     ss = symmetric_search_space(1)
-    subp = BlackBoxOptim.FixedDimProblem("sumabs", [fsabs], ss, [0.0])
-    sp = BlackBoxOptim.shifted(subp)
+    p = FunctionBasedProblem(fsum_abs_and_sq, "sumabs_sumsq",
+                             ParetoFitnessScheme{2}(), ss, (0.0, 0.0))
 
-    @fact is_fixed_dimensional(sp)         --> true
-    @fact is_any_dimensional(sp)           --> false
-    @fact is_single_objective_problem(sp)  --> true
-    @fact is_multi_objective_problem(sp)   --> false
-    @fact numdims(sp)                      --> 1
+    @test numdims(p) == 1
+    @test numobjectives(p) == 2
+    @test search_space(p) == ss
+
+    @test fitness([0.0], p) == (0.0, 0.0)
+    @test fitness([1.2], p) == (1.2, 1.2^2)
+    @test fitness([-1.9], p) == (1.9, 1.9^2)
+end
+
+@testset "MinimizationProblemFamily" begin
+    pfam = MinimizationProblemFamily(fsabs, "sumabs", (0.0, 1.0), 0.0)
+    p1 = instantiate(pfam, 1)
+
+    @test numobjectives(p1) == 1
+    @test numdims(p1) == 1
+
+    @test fitness([0.0], p1) == 0.0
+    @test fitness([1.2], p1) == 1.2
+    @test fitness([-1.9], p1) == 1.9
+
+    p3 = instantiate(pfam, 3)
+
+    @test numobjectives(p3) == 1
+    @test numdims(p3) == 3
+
+    @test fitness([0.0, 1.0, 2.0], p3) == 3.0
+    @test fitness([-1.0, 1.0, 2.0], p3) == 4.0
+end
+
+end
+
+@testset "ShiftedAndBiasedProblem" begin
+
+@testset "Only x shifted 1-dim" begin
+    p = minimization_problem(fsabs, "sumabs", (-1.0, 1.0), 1, 0.0)
+    sp = BlackBoxOptim.ShiftedAndBiasedProblem(p, xshift=[0.5])
+
+    @test BlackBoxOptim.orig_problem(sp) === p
+    @test numobjectives(sp) == 1
+    @test numdims(sp) == 1
+    @test search_space(sp) == symmetric_search_space(1, (-1.0, 1.0))
+    xs = sp.xshift
+    @test xs == [0.5]
+    @test sp.fitshift == 0.0
+
+    @test fitness([0.0], sp) == 0.5
+    @test fitness([1.2], sp) == 0.7
+    @test fitness([-1.9], sp) == 2.4
+end
+
+@testset "Shifted and biased 2-dim" begin
+    ss = symmetric_search_space(2, (-0.5, 1.0))
+    p = minimization_problem(fsabs, "sumabs", (-0.5, 1.0), 2, 0.0)
+    sp = BlackBoxOptim.ShiftedAndBiasedProblem(p; fitshift = 1.3)
+
+    @test BlackBoxOptim.orig_problem(sp) === p
+    @test numobjectives(sp) == 1
+    @test numdims(sp) == 2
+    @test sp.xshift == [0.0, 0.0]
+    @test sp.fitshift == 1.3
+    @test search_space(sp) == symmetric_search_space(2, (-0.5, 1.0))
 
     xs = sp.xshift
-    @fact eval1(xs + [0.0], sp)                 --> 0.0
-    @fact eval1(xs + [1.2], sp)                 --> 1.2
-    @fact eval1(xs + [-1.9], sp)                --> 1.9
-  end
+    @test fitness([0.0, 1.0], sp) == 1.0 + 1.3
+    @test fitness([1.2, -1.3], sp) == 2.5 + 1.3
+    @test fitness([-1.9, 0.0], sp) == 1.9 + 1.3
+end
 
-  context("Shifted and biased 2-dim") do
-    ss = symmetric_search_space(2)
-    subp = BlackBoxOptim.FixedDimProblem("sumabs", [fsabs], ss, [0.0])
-    sp = BlackBoxOptim.shifted(subp; funcshift = 1.3)
+@testset "Within ftol" begin
+    subp = minimization_problem(fsabs, "sumabs", (-1.0, 1.0), 2, 0.0)
 
-    @fact is_fixed_dimensional(sp)         --> true
-    @fact is_any_dimensional(sp)           --> false
-    @fact is_single_objective_problem(sp)  --> true
-    @fact is_multi_objective_problem(sp)   --> false
-    @fact numdims(sp)                      --> 2
+    @test fitness_is_within_ftol(subp, 0.1, 0.2)
+    @test !fitness_is_within_ftol(subp, 0.1, 0.09)
+end
 
-    xs = sp.xshift
-    @fact eval1(xs + [0.0, 1.0], sp)       --> 1.0 + 1.3
-    @fact eval1(xs + [1.2, -1.3], sp)      --> 2.5 + 1.3
-    @fact eval1(xs + [-1.9, 0.0], sp)      --> 1.9 + 1.3
-  end
-
-  context("Within ftol") do
-    ss = symmetric_search_space(2)
-    subp = BlackBoxOptim.FixedDimProblem("sumabs", [fsabs], ss, [0.0])
-
-    @fact fitness_is_within_ftol(subp, 0.1, 0.2)    --> false
-    @fact fitness_is_within_ftol(subp, 0.1, 0.09)   --> true
-  end
 end

--- a/test/problems/test_snes.jl
+++ b/test/problems/test_snes.jl
@@ -1,41 +1,37 @@
 include("common.jl")
 
-facts("Optimize single objective problems in 5, 10, 30 and 100 dimensions with sNES") do
-  simple_problems = ["Sphere", "Schwefel2.22", "Schwefel2.22"]
-  for problem in simple_problems
-    context(problem) do
-      p = BlackBoxOptim.Problems.examples[problem]
+@testset "Optimize single objective problems in 5, 10, 30 and 100 dimensions with sNES" begin
 
-      @fact fitness_for_opt(p, 5, 20,  1e2, separable_nes) < 0.01 --> true
-      @fact fitness_for_opt(p, 5, 20,  5e2, xnes) < 0.01 --> true
-
-      @fact fitness_for_opt(p, 10, 20, 3e2, separable_nes) < 0.01 --> true
-      @fact fitness_for_opt(p, 10, 20, 1e3, xnes) < 0.01 --> true
-
-      @fact fitness_for_opt(p, 30, 25, 1e3, separable_nes) < 0.01 --> true
-      @fact fitness_for_opt(p, 30, 25, 4e3, xnes) < 0.01 --> true
-
-      @fact fitness_for_opt(p, 100, 25, 5e3, separable_nes) < 0.01 --> true
-      # Cannot run xnes in 100 dimensions since it scales badly.
-    end
-  end
-
-  context("Schwefel1.2") do
-    problem = "Schwefel1.2"
+@testset "$problem" for problem in ["Sphere", "Schwefel2.22", "Schwefel2.22"]
     p = BlackBoxOptim.Problems.examples[problem]
 
-    @fact fitness_for_opt(p, 30, 50, 4e3, separable_nes) < 10.0 --> true
-    @fact fitness_for_opt(p, 30, 50, 8e3, xnes) < 10.0 --> true
-  end
+    @test fitness_for_opt(p, 5, 20,  1e2, separable_nes) < 0.01
+    @test fitness_for_opt(p, 5, 20,  5e2, xnes) < 0.01
 
-  context("Rosenbrock") do
-    problem = "Rosenbrock"
-    p = BlackBoxOptim.Problems.examples[problem]
+    @test fitness_for_opt(p, 10, 20, 3e2, separable_nes) < 0.01
+    @test fitness_for_opt(p, 10, 20, 1e3, xnes) < 0.01
 
-    @fact fitness_for_opt(p, 30, 40, 2e4, separable_nes) < 100.0 --> true
-    @fact fitness_for_opt(p, 30, 40, 5e4, xnes) < 100.0 --> true
+    @test fitness_for_opt(p, 30, 25, 1e3, separable_nes) < 0.01
+    @test fitness_for_opt(p, 30, 25, 4e3, xnes) < 0.01
 
-    @fact fitness_for_opt(p, 50, 40, 3e4, separable_nes) < 100.0 --> true
-  end
+    @test fitness_for_opt(p, 100, 25, 5e3, separable_nes) < 0.01
+    # Cannot run xnes in 100 dimensions since it scales badly.
+end
+
+@testset "Schwefel1.2" begin
+    p = BlackBoxOptim.Problems.examples["Schwefel1.2"]
+
+    @test fitness_for_opt(p, 30, 50, 4e3, separable_nes) < 10.0
+    @test fitness_for_opt(p, 30, 50, 8e3, xnes) < 10.0
+end
+
+@testset "Rosenbrock" begin
+    p = BlackBoxOptim.Problems.examples["Rosenbrock"]
+
+    @test fitness_for_opt(p, 30, 40, 2e4, separable_nes) < 100.0
+    @test fitness_for_opt(p, 30, 40, 5e4, xnes) < 100.0
+
+    @test fitness_for_opt(p, 50, 40, 3e4, separable_nes) < 100.0
+end
 
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -44,6 +44,7 @@ my_tests = [
     "test_toplevel_bboptimize.jl",
     "test_smoketest_bboptimize.jl",
 
+    "problems/test_problem.jl",
     "problems/test_single_objective.jl",
 
     "test_generating_set_search.jl",

--- a/test/test_toplevel_bboptimize.jl
+++ b/test/test_toplevel_bboptimize.jl
@@ -126,7 +126,7 @@
             optctrl = bbsetup(rosenbrock_throwing; SearchRange = (-5.0, 5.0), NumDimensions = 100,
                               MaxSteps=100, TraceMode=:silent, RecoverResults=true)
             res = bboptimize(optctrl)
-            @test BlackBoxOptim.stop_reason(res) == @sprintf("%s", InterruptException())
+            @test BlackBoxOptim.isinterrupted(res)
         end
 
         @testset ":RecoverResults off" begin


### PR DESCRIPTION
- Borg should use its own `MaxStepsWithoutEpsProgress` and not `MaxStepsWithoutProgress`, which defines the generic stopping criterion
- instead of throwing an error immediately if Pareto frontier grows too big, wait for a few iterations and stop (returning the intermediate result and specifying the proper stop reason) if it doesn't shrink back
- add `fitness_scheme_type(::Type{OptProblem})` and `fitness_type(::Type{OptProblem})` to aid in metaprogramming
- `TransformedProblem`: add `P` type parameter which is the type of the original problem; don't assume that the transformed problem keeps the same search space or fitness schema
- `BBO.isinterrupted(result)` to check whether the stop reason is interruption by user