### PR TITLE
Update benchmarking scripts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,15 +3,17 @@ os:
   - linux
   - osx
 julia:
-#  - 0.7 uncomment once 0.7 is out
+  - 0.7
+  - 1.0
   - nightly
-#matrix: uncomment once 0.7 is out
-#  allow_failures:
-#    - julia: nightly
+matrix:
+  allow_failures:
+    - julia: nightly
 notifications:
   email: false
-script:
-  - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
-  - julia --check-bounds=yes -e 'Pkg.clone(pwd()); Pkg.build("BlackBoxOptim"); Pkg.test("BlackBoxOptim"; coverage=true)'
+# uncomment the following lines to override the default test script
+#script:
+#  - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
+#  - julia --check-bounds=yes -e 'using Pkg; Pkg.clone(pwd()); Pkg.build("RData"); Pkg.test("RData"; coverage=true)'
 after_success:
-  - julia -e 'cd(Pkg.dir("BlackBoxOptim")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(Coveralls.process_folder())'
+  - julia -e 'using Pkg, BlackBoxOptim; cd(joinpath(dirname(pathof(BlackBoxOptim)), "..")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(Coveralls.process_folder())'

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ BlackBoxOptim.jl
 [![Coverage Status](https://coveralls.io/repos/robertfeldt/BlackBoxOptim.jl/badge.png?branch=master)](https://coveralls.io/r/robertfeldt/BlackBoxOptim.jl?branch=master)
 [![BlackBoxOptim](http://pkg.julialang.org/badges/BlackBoxOptim_0.6.svg)](http://pkg.julialang.org/?pkg=BlackBoxOptim)
 [![BlackBoxOptim](http://pkg.julialang.org/badges/BlackBoxOptim_0.7.svg)](http://pkg.julialang.org/?pkg=BlackBoxOptim)
+[![BlackBoxOptim](http://pkg.julialang.org/badges/BlackBoxOptim_1.0.svg)](http://pkg.julialang.org/?pkg=BlackBoxOptim)
 
 `BlackBoxOptim` is a global optimization package for Julia (http://julialang.org/). It supports both multi- and single-objective optimization problems and is focused on (meta-)heuristic/stochastic algorithms (DE, NES etc) that do NOT require the function being optimized to be differentiable. This is in contrast to more traditional, deterministic algorithms that are often based on gradients/differentiability. It also supports parallel evaluation to speed up optimization for functions that are slow to evaluate.
 

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,4 @@
-julia 0.7.0-beta2.0
+julia 0.7
 StatsBase
 Distributions
 Compat

--- a/Rakefile
+++ b/Rakefile
@@ -4,7 +4,7 @@ TestDir = "test"
 # General parameters that the user can set from the command line.
 Julia = "julia"
 Julia06 = "julia06"
-Julia07 = "julia07"
+Julia07 = "julia"
 MinReps = (ENV["minreps"] || 30).to_i
 MaxReps = (ENV["maxreps"] || 1000).to_i
 MaxRepTime = (ENV["maxreptime"] || 1.0).to_f
@@ -23,7 +23,7 @@ task :atest do
 end
 
 Command06 = "#{Julia06} --color=yes -L src/BlackBoxOptim.jl"
-Command07 = "#{Julia07} --depwarn=no --color=yes -L src/BlackBoxOptim.jl"
+Command07 = "#{Julia07} --depwarn=no --color=yes"
 Command = Command06
 
 desc "Run normal (fast) tests"
@@ -117,6 +117,16 @@ end
 desc "Benchmark (against latest, saved set of benchmark runs)"
 task :bench do
   cd("./examples/benchmarking")
-  sh("julia runcompare.jl 10")
+  sh("#{Command} runcompare.jl examples/benchmarking 10")
   cd("../..")
+end
+
+desc "Benchmark on 0.7 (against the latest benchmark reference)"
+task :bench07 do
+  sh("#{Command07} ./examples/benchmarking/runcompare.jl examples/benchmarking 10")
+end
+
+desc "Generate benchmark reference"
+task :benchref07 do
+  sh("#{Command07} ./examples/benchmarking/runupdate.jl examples/benchmarking 10")
 end

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,11 +1,21 @@
 environment:
   matrix:
-  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/0.7/julia-0.7-latest-win32.exe"
-  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.7/julia-0.7-latest-win64.exe"
+  - julia_version: 0.7
+  - julia_version: 1.0
+  - julia_version: latest
+
+platform:
+  - x86 # 32-bit
+  - x64 # 64-bit
+
+matrix:
+  allow_failures:
+  - julia_version: latest
 
 branches:
   only:
     - master
+    - /release-.*/
 
 notifications:
   - provider: Email
@@ -14,18 +24,12 @@ notifications:
     on_build_status_changed: false
 
 install:
-  - ps: "[System.Net.ServicePointManager]::SecurityProtocol = [System.Net.SecurityProtocolType]::Tls12"
-# Download most recent Julia Windows binary
-  - ps: (new-object net.webclient).DownloadFile(
-        $env:JULIA_URL,
-        "C:\projects\julia-binary.exe")
-# Run installer silently, output to C:\projects\julia
-  - C:\projects\julia-binary.exe /S /D=C:\projects\julia
+  - ps: iex ((new-object net.webclient).DownloadString("https://raw.githubusercontent.com/JuliaCI/Appveyor.jl/version-1/bin/install.ps1"))
 
 build_script:
-# Need to convert from shallow to complete for Pkg.clone to work
-  - IF EXIST .git\shallow (git fetch --unshallow)
-  - C:\projects\julia\bin\julia -e "Pkg.clone(pwd(), \"BlackBoxOptim\"); versioninfo(); Pkg.build(\"BlackBoxOptim\")"
+  - echo "%JL_BUILD_SCRIPT%"
+  - C:\julia\bin\julia -e "%JL_BUILD_SCRIPT%"
 
 test_script:
-  - C:\projects\julia\bin\julia --check-bounds=yes -e "Pkg.test(\"BlackBoxOptim\")"
+  - echo "%JL_TEST_SCRIPT%"
+  - C:\julia\bin\julia -e "%JL_TEST_SCRIPT%"

--- a/examples/benchmarking/activate_pwd_env.jl
+++ b/examples/benchmarking/activate_pwd_env.jl
@@ -1,0 +1,3 @@
+# activates the Julia environment associated with the working folder
+using Pkg
+Pkg.activate(".")

--- a/examples/benchmarking/compare_optimizers.jl
+++ b/examples/benchmarking/compare_optimizers.jl
@@ -387,7 +387,7 @@ function compare_optimizers_to_benchmarks(benchmarkfile, pset, optimizers, nreps
                 psel = db[:Problem] .== probname
                 dsel = db[:NumDims] .== numdims
                 df = db[optsel .& psel .& dsel, :]
-                benchfitnesses = collect(skipmissing(df[:Fitness]))
+                benchfitnesses = convert(Vector{Float64}, df[:Fitness])
                 newfs = Float64[]
                 prob = BlackBoxOptim.example_problems[probname]
                 for r in 1:nreps
@@ -419,7 +419,7 @@ function compare_optimizers_to_benchmarks(benchmarkfile, pset, optimizers, nreps
 
         # Use Benjamini-Hochberg to judge which pvalues are significant given we did
         # many comparisons.
-        pvs = convert(Array, collect(skipmissing(df[:Pvalue])))
+        pvs = convert(Vector{Float64}, df[:Pvalue])
         df[:SignificantBH001] = benjamini_hochberg(pvs, 0.01)
         df[:SignificantBH005] = benjamini_hochberg(pvs, 0.05)
         df[:SignificantBH010] = benjamini_hochberg(pvs, 0.10)

--- a/examples/benchmarking/compare_optimizers.jl
+++ b/examples/benchmarking/compare_optimizers.jl
@@ -284,6 +284,7 @@ function read_benchmark_db(filename)
     if isfile(filename)
         return CSV.read(filename)
     else
+        @warn "Benchmark results file $filename not found, returning empty frame"
         return DataFrame()
     end
 end

--- a/examples/benchmarking/compare_optimizers.jl
+++ b/examples/benchmarking/compare_optimizers.jl
@@ -456,19 +456,13 @@ function benjamini_hochberg(pvals, alpha = 0.05)
 end
 
 function report_below_pvalue(df, pvalue = 0.05)
-    selection = df[:,:Pvalue] .< pvalue
-    if pvalue >= 1.0
-        log("Num problems (any p-value) = $(sum(selection))\n")
-    else
-        log("Num problems (with p-values < $(pvalue)) = $(sum(selection))\n")
-    end
-    num_new_worse = sum(df[selection, :Order] .== "<")
-    num_new_better = sum(df[selection, :Order] .== ">")
+    selection = df[:Pvalue] .< pvalue
+    log("Num problems (with p-values < $(pvalue)) = $(sum(selection))\n")
+    num_new_worse = sum(x -> x == "<", df[selection, :Order])
+    num_new_better = sum(x -> x == ">", df[selection, :Order])
     log(:green, "  Num where new implementation is better = $(num_new_better)\n")
     log(:red, "  Num where new implementation is worse = $(num_new_worse)\n")
-    if sum(selection) > 0 && pvalue < 1.0
-        println(df[selection,:])
-    end
+    any(selection) && println(df[selection, :])
 end
 
 @CPUtime main(ARGS)

--- a/examples/benchmarking/compare_optimizers.jl
+++ b/examples/benchmarking/compare_optimizers.jl
@@ -420,7 +420,6 @@ function compare_optimizers_to_benchmarks(benchmarkfile, pset, optimizers, nreps
         # Use Benjamini-Hochberg to judge which pvalues are significant given we did
         # many comparisons.
         pvs = convert(Array, collect(skipmissing(df[:Pvalue])))
-        @show pvs
         df[:SignificantBH001] = benjamini_hochberg(pvs, 0.01)
         df[:SignificantBH005] = benjamini_hochberg(pvs, 0.05)
         df[:SignificantBH010] = benjamini_hochberg(pvs, 0.10)

--- a/examples/benchmarking/compare_optimizers.jl
+++ b/examples/benchmarking/compare_optimizers.jl
@@ -1,4 +1,5 @@
 # Run with: julia --color=yes -L ../../src/BlackBoxOptim.jl compare_optimizers.jl ...
+
 using DataFrames
 using BlackBoxOptim
 using ArgParse
@@ -21,186 +22,186 @@ function main(args)
     global logfilehandle
     logfilehandle = open(Libc.strftime("%Y%m%d_%H%M%S.log", start_time), "a+")
 
-  s = ArgParseSettings(description = "comparing optimizers to benchmark runs",
-    commands_are_required = true,
-    version = "0.1.0",
-    add_version = true
-  )
+    s = ArgParseSettings(description = "comparing optimizers to benchmark runs",
+        commands_are_required = true,
+        version = "0.1.0",
+        add_version = true
+    )
 
-  @add_arg_table s begin
-    "update"
-      action = :command
-      help = "update benchmark runs"
+    @add_arg_table s begin
+        "update"
+            action = :command
+            help = "update benchmark runs"
 
-    "list"
-      action = :command
-      help = "list info about benchmark runs"
+        "list"
+            action = :command
+            help = "list info about benchmark runs"
 
-    "compare"
-      action = :command
-      help = "compare current optimizer(s) to benchmark runs"
-  end
-
-  for cmd in ["update", "compare", "list"]
-    @add_arg_table s[cmd] begin
-      "--benchmarkfile", "-b"
-        arg_type = AbstractString
-        default = "benchmark_runs.csv"
-        help = "name of benchmark runs db file"
+        "compare"
+            action = :command
+            help = "compare current optimizer(s) to benchmark runs"
     end
-  end
 
-  for cmd in ["update", "compare"]
-    @add_arg_table s[cmd] begin
-      "--problems"
-        arg_type = AbstractString
-        default = "all"
-        help = "name of problem set"
-
-      "--optimizers"
-        arg_type = AbstractString
-        default = "stable"
-        help = "name of optimizer or optimizer set"
-
-      "--numreps", "-n"
-        arg_type = Int
-        default = 10
-        help = "number of repetitions per problem and optimizer"
-
-      "--adaptive"
-        action = :store_true
-        help = "adaptive number of reps until we can prove there is a difference (with a max of 30 reps)"
+    for cmd in ["update", "compare", "list"]
+        @add_arg_table s[cmd] begin
+            "--benchmarkfile", "-b"
+                arg_type = AbstractString
+                default = "benchmark_runs.csv"
+                help = "name of benchmark runs db file"
+        end
     end
-  end
 
-  @add_arg_table s["compare"] begin
-    "--comparisonfile"
-      arg_type = AbstractString
-      default = ""
-      help = "name of comparison db file"
-  end
+    for cmd in ["update", "compare"]
+        @add_arg_table s[cmd] begin
+           "--problems"
+                arg_type = AbstractString
+                default = "all"
+                help = "name of problem set"
 
-  @add_arg_table s["list"] begin
-    "--outfile", "-o"
-      arg_type = AbstractString
-      default = ""
-      help = "name of csv file where result comparison table is saved"
-  end
+            "--optimizers"
+                arg_type = AbstractString
+                default = "stable"
+                help = "name of optimizer or optimizer set"
 
-  pargs = parse_args(args, s)
+            "--numreps", "-n"
+                arg_type = Int
+                default = 10
+                help = "number of repetitions per problem and optimizer"
 
-  cmd = pargs["%COMMAND%"]
+            "--adaptive"
+                action = :store_true
+                help = "adaptive number of reps until we can prove there is a difference (with a max of 30 reps)"
+        end
+    end
 
-  benchmarkfile = pargs[cmd]["benchmarkfile"]
+    @add_arg_table s["compare"] begin
+        "--comparisonfile"
+            arg_type = AbstractString
+            default = ""
+            help = "name of comparison db file"
+        end
 
-  local pset, optimizers, nreps
+    @add_arg_table s["list"] begin
+        "--outfile", "-o"
+            arg_type = AbstractString
+            default = ""
+            help = "name of csv file where result comparison table is saved"
+        end
 
-  if in(cmd, ["update", "compare"])
-    if haskey(ProblemSets, pargs[cmd]["problems"])
-      pset = ProblemSets[pargs[cmd]["problems"]]
+    pargs = parse_args(args, s)
+
+    cmd = pargs["%COMMAND%"]
+
+    benchmarkfile = pargs[cmd]["benchmarkfile"]
+
+    local pset, optimizers, nreps
+
+    if in(cmd, ["update", "compare"])
+        if haskey(ProblemSets, pargs[cmd]["problems"])
+            pset = ProblemSets[pargs[cmd]["problems"]]
+        else
+            ps = pargs[cmd]["problems"]
+            throw("Unknown problem set $(ps), existing ones are: ", keys(ProblemSets))
+        end
+
+        if haskey(OptimizerSets, pargs[cmd]["optimizers"])
+            optimizers = OptimizerSets[pargs[cmd]["optimizers"]]
+        else
+            os = pargs[cmd]["optimizers"]
+            throw("Unknown optimizer set $(os), existing ones are: ", keys(OptimizerSets))
+        end
+
+        nreps = pargs[cmd]["numreps"]
+    end
+
+    if cmd == "update"
+        db = read_benchmark_db(benchmarkfile)
+        db = update_benchmarks(db, pset, optimizers, nreps)
+        save_result_database(db, benchmarkfile)
+    elseif cmd == "list"
+        db = read_benchmark_db(benchmarkfile)
+        list_benchmark_db(db, pargs[cmd]["outfile"])
+    elseif cmd == "compare"
+        compare_optimizers_to_benchmarks(benchmarkfile, pset, optimizers, nreps, 0.01,
+                pargs[cmd]["comparisonfile"])
     else
-      ps = pargs[cmd]["problems"]
-      throw("Unknown problem set $(ps), existing ones are: ", keys(ProblemSets))
+        raise("Unknown command") # FIXME logfilehandle is not closed
     end
 
-    if haskey(OptimizerSets, pargs[cmd]["optimizers"])
-      optimizers = OptimizerSets[pargs[cmd]["optimizers"]]
-    else
-      os = pargs[cmd]["optimizers"]
-      throw("Unknown optimizer set $(os), existing ones are: ", keys(OptimizerSets))
-    end
+    close(logfilehandle)
 
-    nreps = pargs[cmd]["numreps"]
-  end
-
-  if cmd == "update"
-    db = read_benchmark_db(benchmarkfile)
-    db = update_benchmarks(db, pset, optimizers, nreps)
-    save_result_database(db, benchmarkfile)
-  elseif cmd == "list"
-    db = read_benchmark_db(benchmarkfile)
-    list_benchmark_db(db, pargs[cmd]["outfile"])
-  elseif cmd == "compare"
-    compare_optimizers_to_benchmarks(benchmarkfile, pset, optimizers, nreps, 0.01,
-        pargs[cmd]["comparisonfile"])
-  else
-    raise("Unknown command")
-  end
-
-  close(logfilehandle)
-
-  println("elapsed time:    ", format_time(time() - start_time))
+    println("elapsed time:    ", format_time(time() - start_time))
 end
 
 function format_time(t)
-  if t < 60.0
-    @sprintf("%.1f secs", t)
-  elseif t < 3600.0
-    m = floor(Int, t/60.0)
-    @sprintf("%d min%s ", m, (m>1) ? "s" : "") * format_time(t - 60*m)
-  else
-    h = floor(Int, t/3600.0)
-    @sprintf("%d hour%s ", h, (h>1) ? "s" : "") * format_time(t - 3600*h)
-  end
+    if t < 60.0
+        @sprintf("%.1f secs", t)
+    elseif t < 3600.0
+        m = floor(Int, t/60.0)
+        @sprintf("%d min%s ", m, (m>1) ? "s" : "") * format_time(t - 60*m)
+    else
+        h = floor(Int, t/3600.0)
+        @sprintf("%d hour%s ", h, (h>1) ? "s" : "") * format_time(t - 3600*h)
+    end
 end
 
 ProblemSets = Dict{String,Any}(
-  "easy" => [
-    # ProblemName, NumDims, PopSize, MaxFevals
-    ("Sphere",        5, 20, 5e3),
-    ("Sphere",       10, 20, 1e4),
-    ("Sphere",       30, 20, 3e4),
+    "easy" => [
+        # ProblemName, NumDims, PopSize, MaxFevals
+        ("Sphere",        5, 20, 5e3),
+        ("Sphere",       10, 20, 1e4),
+        ("Sphere",       30, 20, 3e4),
 
-    ("Schwefel2.22",  5, 20, 5e3),
-    ("Schwefel2.22", 10, 20, 1e4),
-    ("Schwefel2.22", 30, 20, 3e4),
+        ("Schwefel2.22",  5, 20, 5e3),
+        ("Schwefel2.22", 10, 20, 1e4),
+        ("Schwefel2.22", 30, 20, 3e4),
 
-    ("Schwefel2.21",  5, 20, 5e3),
-    ("Schwefel2.21", 10, 20, 1e4),
-    ("Schwefel2.21", 30, 20, 3e4)
-  ],
+        ("Schwefel2.21",  5, 20, 5e3),
+        ("Schwefel2.21", 10, 20, 1e4),
+        ("Schwefel2.21", 30, 20, 3e4)
+    ],
 
-  "harder" => [
-    # Harder problems
-    ("Schwefel1.2",   5, 20, 5e3),
-    ("Schwefel1.2",  10, 50, 5e4),
-    ("Schwefel1.2",  30, 50, 2e5),
-    ("Schwefel1.2",  50, 50, 3e5),
+    "harder" => [
+        # Harder problems
+        ("Schwefel1.2",   5, 20, 5e3),
+        ("Schwefel1.2",  10, 50, 5e4),
+        ("Schwefel1.2",  30, 50, 2e5),
+        ("Schwefel1.2",  50, 50, 3e5),
 
-    ("Rosenbrock",    5, 20, 1e4),
-    ("Rosenbrock",   10, 50, 5e4),
-    ("Rosenbrock",   30, 50, 2e5),
-    ("Rosenbrock",   50, 40, 3e5),
+        ("Rosenbrock",    5, 20, 1e4),
+        ("Rosenbrock",   10, 50, 5e4),
+        ("Rosenbrock",   30, 50, 2e5),
+        ("Rosenbrock",   50, 40, 3e5),
 
-    ("Rastrigin",    50, 50, 5e5),
-    ("Rastrigin",   100, 90, 8e5),
+        ("Rastrigin",    50, 50, 5e5),
+        ("Rastrigin",   100, 90, 8e5),
 
-    ("Ackley",       50, 50, 5e5),
-    ("Ackley",      100, 90, 8e5),
+        ("Ackley",       50, 50, 5e5),
+        ("Ackley",      100, 90, 8e5),
 
-    ("Griewank",     50, 50, 5e5),
-    ("Griewank",    100, 90, 8e5),
-  ],
+        ("Griewank",     50, 50, 5e5),
+        ("Griewank",    100, 90, 8e5),
+    ],
 
-  "lowdim" => [
-    ("Schwefel1.2",   2, 25, 1e4),
-    ("Rosenbrock",    2, 25, 1e4),
-    ("Rastrigin",     2, 25, 1e4),
-    ("Ackley",        2, 25, 1e4),
-    ("Griewank",      2, 25, 1e4),
-  ],
+    "lowdim" => [
+        ("Schwefel1.2",   2, 25, 1e4),
+        ("Rosenbrock",    2, 25, 1e4),
+        ("Rastrigin",     2, 25, 1e4),
+        ("Ackley",        2, 25, 1e4),
+        ("Griewank",      2, 25, 1e4),
+    ],
 
-  "test" => [
-    ("Rosenbrock",   30, 50, 2e5),
-  ]
+    "test" => [
+        ("Rosenbrock",   30, 50, 2e5),
+    ]
 )
 ProblemSets["all"] = vcat(ProblemSets["easy"], ProblemSets["harder"])
 
 OptimizerSets = Dict{String,Any}(
-  "de" => [:de_rand_1_bin, :de_rand_1_bin_radiuslimited, :adaptive_de_rand_1_bin, :adaptive_de_rand_1_bin_radiuslimited],
-  "stable_non_de" => [:probabilistic_descent, :generating_set_search, :random_search],
-  "nes" => [:xnes, :separable_nes, :dxnes],
-  "test" => [:de_rand_1_bin],
+    "de" => [:de_rand_1_bin, :de_rand_1_bin_radiuslimited, :adaptive_de_rand_1_bin, :adaptive_de_rand_1_bin_radiuslimited],
+    "stable_non_de" => [:probabilistic_descent, :generating_set_search, :random_search],
+    "nes" => [:xnes, :separable_nes, :dxnes],
+    "test" => [:de_rand_1_bin],
 )
 OptimizerSets["all"] = unique(collect(keys(BlackBoxOptim.SingleObjectiveMethods)))
 OptimizerSets["stable"] = vcat(OptimizerSets["de"], OptimizerSets["stable_non_de"])
@@ -209,77 +210,80 @@ OptimizerSets["stable"] = vcat(OptimizerSets["de"], OptimizerSets["stable_non_de
 # since we should never take time measurements before we have ensured everything has been compiled.
 const RunsPerProblem = Dict{Any,Int}()
 runs_per_problem(problemname, numdims) = get(RunsPerProblem, (problemname, numdims), 0)
-increase_runs_per_problem(problemname, numdims) = begin
-  k = (problemname, numdims)
-  RunsPerProblem[k] = get(RunsPerProblem, k, 0) + 1
+function increase_runs_per_problem(problemname, numdims)
+    k = (problemname, numdims)
+    RunsPerProblem[k] = get(RunsPerProblem, k, 0) + 1
 end
 
-function fitness_for_opt(family::FunctionBasedProblemFamily, NumDimensions::Int, PopulationSize::Int, MaxFuncEvals::Int,
-    Method::Symbol, TraceMode::Symbol = :verbose)
+function fitness_for_opt(family::FunctionBasedProblemFamily, NumDimensions::Int,
+                         PopulationSize::Int, MaxFuncEvals::Int,
+                         Method::Symbol, TraceMode::Symbol = :verbose)
 
-  problem = instantiate(family, NumDimensions)
+    problem = instantiate(family, NumDimensions)
 
-  res = bboptimize(problem; Method = Method,
-    NumDimensions = NumDimensions,
-    PopulationSize = PopulationSize,
-    TraceMode = TraceMode,
-    MaxFuncEvals = MaxFuncEvals
-  )
+    res = bboptimize(problem; Method = Method,
+        NumDimensions = NumDimensions,
+        PopulationSize = PopulationSize,
+        TraceMode = TraceMode,
+        MaxFuncEvals = MaxFuncEvals
+    )
 
-  best_fitness(res)
+    best_fitness(res)
 end
 
 function latest_git_id()
-  strip(readall(`git -C "../.." log --format="%H" -n 1`))
+    strip(readall(`git -C "../.." log --format="%H" -n 1`))
 end
 
 # Test an optimizer on multiple problems and dimensions, return results in dict.
 function multitest_opt(problemDescriptions, method; NumRepetitions = 3)
-  dfs = DataFrame[]
+    dfs = DataFrame[]
 
-  gitid = latest_git_id()
+    gitid = latest_git_id()
 
-  for pd in problemDescriptions
-    log("Running $(NumRepetitions) reps for $(method)\n")
-    for rep in 1:NumRepetitions
-      probname, numdims, popsize, numfevals = pd
+    for pd in problemDescriptions
+        log("Running $(NumRepetitions) reps for $(method)\n")
+        for rep in 1:NumRepetitions
+            probname, numdims, popsize, numfevals = pd
 
-      prob = BlackBoxOptim.example_problems[probname]
+            prob = BlackBoxOptim.example_problems[probname]
 
-      # Ensure everything is compiled before we start measuring the 1st time.
-      if runs_per_problem(probname, numdims) == 0
-        fitness_for_opt(prob, numdims, popsize, 100, method, :silent)
-        increase_runs_per_problem(probname, numdims)
-      end
+            # Ensure everything is compiled before we start measuring the 1st time.
+            if runs_per_problem(probname, numdims) == 0
+                fitness_for_opt(prob, numdims, popsize, 100, method, :silent)
+                increase_runs_per_problem(probname, numdims)
+            end
 
-      df = DataFrame(Problem = probname, NumDims = numdims,
-        Method = string(method), PopulationSize = popsize, NumFevals = numfevals,
-        GitID = gitid)
+            df = DataFrame(Problem = probname, NumDims = numdims,
+                    Method = string(method), PopulationSize = popsize,
+                    NumFevals = numfevals,
+                    GitID = gitid
+            )
 
-      log("\n$(probname), n = $(numdims), optimizer = $(string(method)), run $(rep) of $(NumRepetitions)\n")
+            log("\n$(probname), n = $(numdims), optimizer = $(string(method)), run $(rep) of $(NumRepetitions)\n")
 
-      start_time = time()
-      CPUtic()
-      ftn = fitness_for_opt(prob, numdims, popsize, ceil(Int, numfevals), method)
-      df[:ElapsedTime] = CPUtoc()
-      df[:StartTime] = Libc.strftime("%Y-%m-%d %H:%M:%S", start_time)
-      df[:Fitness] = ftn
+            start_time = time()
+            CPUtic()
+            ftn = fitness_for_opt(prob, numdims, popsize, ceil(Int, numfevals), method)
+            df[:ElapsedTime] = CPUtoc()
+            df[:StartTime] = Libc.strftime("%Y-%m-%d %H:%M:%S", start_time)
+            df[:Fitness] = ftn
 
-      push!(dfs, df)
+            push!(dfs, df)
+        end
     end
-  end
 
-  vcat(dfs)
+    vcat(dfs)
 end
 
 using CSV
 
 function read_benchmark_db(filename)
-  if isfile(filename)
-    return CSV.read(filename)
-  else
-    return DataFrame()
-  end
+    if isfile(filename)
+        return CSV.read(filename)
+    else
+        return DataFrame()
+    end
 end
 
 function add_rank_per_group(df, groupcols, rankcol, resultcol)
@@ -293,71 +297,74 @@ function add_rank_per_group(df, groupcols, rankcol, resultcol)
 end
 
 function list_benchmark_db(db, saveResultCsvFile = nothing)
-  numrows = size(db, 1)
-  println("Number of runs in db: ", numrows)
+    numrows = size(db, 1)
+    println("Number of runs in db: ", numrows)
 
-  if numrows > 1
-    # Find min fitness per problem
-    minfitpp = by(db, [:Problem, :NumDims], df -> DataFrame(
-        MinFitness = minimum(df[:,:Fitness])))
-
-    # Add col with order of magnitude worse than min fitness for each run
-    db = join(db, minfitpp, on = [:Problem, :NumDims])
-    db[:LogTimesWorseFitness] = log10(db[:Fitness] ./ db[:MinFitness])
-
-    # Calc median fitness and time per problem and method.
-    sumdf = by(db, [:Problem, :NumDims, :Method], df ->
-        DataFrame(N = size(df, 1),
-            MedianFitness = median(df[:,:Fitness]),
-            MedianTime = median(df[:,:ElapsedTime])))
-
-    # Rank on median fitness and median time for each problem.
-    sumdf = add_rank_per_group(sumdf, [:Problem, :NumDims], :MedianFitness, :RankFitness)
-    sumdf = add_rank_per_group(sumdf, [:Problem, :NumDims], :MedianTime, :RankTime)
-
-    # Get number of runs and median magnitude worse per method
-    permethod = by(db, [:Method], df -> DataFrame(
-        NumRuns = size(df, 1),
-        MedianLogTimesWorseFitness = round(median(df[:, :LogTimesWorseFitness]), digits=1),
+    if numrows > 1
+        # Find min fitness per problem
+        minfitpp = by(db, [:Problem, :NumDims], df -> DataFrame(
+                MinFitness = minimum(df[:Fitness])
+            )
         )
-    )
 
-    # and merge with table with mean ranks of fitness and time.
-    summarydf = by(sumdf, [:Method], df -> DataFrame(
-        MeanRank = round(mean(df[:,:RankFitness]), digits=3),
-        Num1sFitness = sum(map(r -> (r == 1) ? 1 : 0, df[:,:RankFitness])),
-        MeanRankTime = round(mean(df[:,:RankTime]), digits=3),
-        Num1sTime = sum(map(r -> (r == 1) ? 1 : 0, df[:,:RankTime])),
+        # Add col with order of magnitude worse than min fitness for each run
+        db = join(db, minfitpp, on = [:Problem, :NumDims])
+        db[:LogTimesWorseFitness] = log10.(db[:Fitness] ./ db[:MinFitness])
+
+        # Calc median fitness and time per problem and method.
+        sumdf = by(db, [:Problem, :NumDims, :Method], df ->
+            DataFrame(N = size(df, 1),
+                      MedianFitness = median(df[:,:Fitness]),
+                      MedianTime = median(df[:,:ElapsedTime]))
         )
-    )
-    df = join(summarydf, permethod, on = :Method)
 
-    # Now sort and print
-    sort!(df; [:MeanRank, :MeanRankTime, :Num1sFitness])
-    println(df)
-    if typeof(saveResultCsvFile) <: AbstractString && length(saveResultCsvFile) > 0
-        CSV.write(saveResultCsvFile, df)
-        println("Results written to file: ", saveResultCsvFile)
+        # Rank on median fitness and median time for each problem.
+        sumdf = add_rank_per_group(sumdf, [:Problem, :NumDims], :MedianFitness, :RankFitness)
+        sumdf = add_rank_per_group(sumdf, [:Problem, :NumDims], :MedianTime, :RankTime)
+
+        # Get number of runs and median magnitude worse per method
+        permethod = by(db, [:Method], df -> DataFrame(
+                NumRuns = size(df, 1),
+                MedianLogTimesWorseFitness = round(median(df[:, :LogTimesWorseFitness]), digits=1)
+            )
+        )
+
+        # and merge with table with mean ranks of fitness and time.
+        summarydf = by(sumdf, [:Method], df -> DataFrame(
+                MeanRank = round(mean(df[:RankFitness]), digits=3),
+                Num1sFitness = sum(r -> (r == 1) ? 1 : 0, df[:RankFitness]),
+                MeanRankTime = round(mean(df[:RankTime]), digits=3),
+                Num1sTime = sum(r -> (r == 1) ? 1 : 0, df[:RankTime]),
+            )
+        )
+        df = join(summarydf, permethod, on = :Method)
+
+        # Now sort and print
+        sort!(df, [:MeanRank, :MeanRankTime, :Num1sFitness])
+        println(df)
+        if typeof(saveResultCsvFile) <: AbstractString && length(saveResultCsvFile) > 0
+            CSV.write(saveResultCsvFile, df)
+            println("Results written to file: ", saveResultCsvFile)
+        end
     end
-  end
 end
 
 function save_result_database(db, filename)
-  CSV.write(filename, db)
+    CSV.write(filename, db)
 end
 
 function update_benchmarks(db, pset, optimizers, nreps = 10)
-  for optmethod in optimizers
-    @time res = multitest_opt(pset, optmethod; NumRepetitions = nreps)
-    if size(db, 1) < 1
-      db = res
-    else
-      db = vcat(db, res)
+    for optmethod in optimizers
+        @time res = multitest_opt(pset, optmethod; NumRepetitions = nreps)
+        if size(db, 1) < 1
+            db = res
+        else
+            db = vcat(db, res)
+        end
+        #save_result_database(db, "temp.csv")
+        list_benchmark_db(db)
     end
-    #save_result_database(db, "temp.csv")
-    list_benchmark_db(db)
-  end
-  db
+    return db
 end
 
 using HypothesisTests
@@ -427,27 +434,24 @@ function compare_optimizers_to_benchmarks(benchmarkfile, pset, optimizers, nreps
     # correction.
     color = (sum(df[:SignificantBH005]) > 0) ? :red : :green
     print_with_color(color,
-      "\nNum significant at Benjamini-Hochberg 0.05 level: ", string(sum(df[:SignificantBH005])),
-      "\n")
+        "\nNum significant at Benjamini-Hochberg 0.05 level: ", string(sum(df[:SignificantBH005])),
+        "\n")
 end
 
 function benjamini_hochberg(pvals, alpha = 0.05)
-  n = length(pvals)
-  if n <= 1
-    return pvals
-  end
-  perm = sortperm(pvals)
-  origperm = sortperm(perm)
-  sortedps = pvals[perm]
+    n = length(pvals)
+    (n <= 1) && return pvals # no pvalue correction needed
 
-  tresholds = alpha * collect(1:n) / n
-  khat = n+1 - findfirst(reverse(sortedps .<= tresholds))
-  if khat > n
-    return (ones(n).>10.0) # There were no significant ones so return all false
-  else
+    perm = sortperm(pvals)
+    origperm = sortperm(perm)
+    sortedps = pvals[perm]
+
+    tresholds = alpha .* (collect(1:n) ./ n)
+    khat = n+1 - findfirst(reverse(sortedps .<= tresholds))
+    (khat > n) && return (ones(n).>10.0) # There were no significant ones so return all false
+
     significant = vcat(ones(khat), zeros(n-khat)) .> 0.0
-    significant[origperm]
-  end
+    return significant[origperm]
 end
 
 function report_below_pvalue(df, pvalue = 0.05)

--- a/examples/benchmarking/compare_optimizers.jl
+++ b/examples/benchmarking/compare_optimizers.jl
@@ -381,13 +381,13 @@ function compare_optimizers_to_benchmarks(benchmarkfile, pset, optimizers, nreps
         totalruns = length(optimizers) * nreps * length(pset)
         runnum = 0
         for optmethod in optimizers
-            optsel = db[:,:Method] .== string(optmethod)
+            optsel = db[:Method] .== string(optmethod)
             for pd in pset
                 probname, numdims, popsize, numfevals = pd
-                psel = db[:,:Problem] .== probname
-                dsel = db[:,:NumDims] .== numdims
-                df = db[optsel .& psel .& dsel,:]
-                benchfitnesses = collect(skipmissing(df[:,:Fitness]))
+                psel = db[:Problem] .== probname
+                dsel = db[:NumDims] .== numdims
+                df = db[optsel .& psel .& dsel, :]
+                benchfitnesses = collect(skipmissing(df[:Fitness]))
                 newfs = Float64[]
                 prob = BlackBoxOptim.example_problems[probname]
                 for r in 1:nreps

--- a/examples/benchmarking/runcompare.jl
+++ b/examples/benchmarking/runcompare.jl
@@ -1,11 +1,20 @@
-bfiles = filter(f->typeof(match(r"^benchmark_runs_\d.+\.csv$", f))!=Nothing, readdir("."))
+scripts_dir = @__DIR__
+reports_dir = (length(ARGS) > 0 ? ARGS[1] : "examples/benchmarking")
 
-bf = bfiles[end]
+isdir(reports_dir) || throw(error("Benchmark results folder $reports_dir not found"))
+
+bfiles = filter!(f->ismatch(r"^benchmark_runs_\d.+\.csv$", f), readdir(reports_dir))
+
+isempty(bfiles) && throw(error("No benchmark runs found"))
+bf = joinpath(reports_dir, bfiles[end])
 
 println("Comparing to benchmark: ", bf)
 
-nreps = (length(ARGS) > 0 ? parse(Int, ARGS[1]) : 10)
+nreps = (length(ARGS) > 1 ? parse(Int, ARGS[2]) : 10)
 
-cmd = `julia --color=yes -L ../../src/BlackBoxOptim.jl compare_optimizers.jl compare --benchmarkfile $bf --numreps $nreps`
+
+@info @__DIR__
+
+cmd = `$(Sys.BINDIR)/julia --color=yes -L $scripts_dir/activate_pwd_env.jl -- $scripts_dir/compare_optimizers.jl compare --benchmarkfile $bf --numreps $nreps`
 
 run(cmd)

--- a/examples/benchmarking/runupdate.jl
+++ b/examples/benchmarking/runupdate.jl
@@ -1,12 +1,15 @@
-nbfile = Libc.strftime("benchmark_runs_%y%m%d.csv", time())
+scripts_dir = @__DIR__
+reports_dir = (length(ARGS) > 0 ? ARGS[1] : "examples/benchmarking")
+
+nbfile = joinpath(reports_dir, Libc.strftime("benchmark_runs_%y%m%d.csv", time()))
 
 if isfile(nbfile)
-  println("Deleting existing file: ", nbfile)
-  rm(nbfile)
+    @info("Deleting existing benchmark file: ", nbfile)
+    rm(nbfile)
 end
 
-nreps = (length(ARGS) > 0 ? parse(Int, ARGS[1]) : 10)
+nreps = (length(ARGS) > 0 ? parse(Int, ARGS[2]) : 10)
 
-cmd = `julia --color=yes -L ../../src/BlackBoxOptim.jl compare_optimizers.jl update --benchmarkfile $nbfile --numreps $nreps`
+cmd = `$(Sys.BINDIR)/julia --color=yes -L $scripts_dir/activate_pwd_env.jl -- $scripts_dir/compare_optimizers.jl update --benchmarkfile $nbfile --numreps $nreps`
 
 run(cmd)

--- a/src/BlackBoxOptim.jl
+++ b/src/BlackBoxOptim.jl
@@ -1,5 +1,3 @@
-using Random
-
 module BlackBoxOptim
 
 using Distributions, StatsBase, Random, LinearAlgebra, Printf, Distributed, Compat

--- a/src/dx_nes.jl
+++ b/src/dx_nes.jl
@@ -105,11 +105,7 @@ function tell!(dxnes::DXNESOpt{F}, rankedCandidates::Vector{Candidate{F}}) where
     u = assign_weights!(dxnes.tmp_Utilities, rankedCandidates, dxnes.sortedUtilities)
     dxnes.evol_path *= dxnes.evol_discount
     # We'll take the small perf hit for now just so this can run also on pre rc2 julia 0.7s
-    if VERSION < v"0.7.0-rc2"
-        dxnes.evol_path += dxnes.evol_Zscale * squeeze(wsum(dxnes.Z, u, 2), dims=2)
-    else
-        dxnes.evol_path += dxnes.evol_Zscale * dropdims(wsum(dxnes.Z, u, 2), dims=2)
-    end
+    dxnes.evol_path += dxnes.evol_Zscale * dropdims(wsum(dxnes.Z, u, 2), dims=2)
     evol_speed = norm(dxnes.evol_path)/dxnes.moving_threshold
     if evol_speed > 1.0
         # the center is moving, adjust weights

--- a/src/frequency_adaptation.jl
+++ b/src/frequency_adaptation.jl
@@ -52,7 +52,7 @@ If the block is empty, it is repopulated.
 The methods are randomly shuffled each time the block is regenerated, since we need
 to know their effectiveness at every period of the optimization process.
 """
-function Base.next(fa::FrequencyAdapter)
+function next(fa::FrequencyAdapter)
     if fa.block_pos > length(fa.block)
         fill_block!(fa)
     end

--- a/src/genetic_operators/operators_mixture.jl
+++ b/src/genetic_operators/operators_mixture.jl
@@ -25,7 +25,16 @@ function apply!(opmix::GeneticOperatorsMixture,
     apply!(op, v, target_index)
 end
 
-function Base.next(opmix::FixedGeneticOperatorsMixture)
+"""
+    next(fa::FixedGeneticOperatorsMixture)
+
+Gets the random genetic operator from the mixture.
+
+The probability to select an operator is proportional to its weight.
+
+Returns a tuple of the genetic operator and its index in the mix.
+"""
+function next(opmix::FixedGeneticOperatorsMixture)
     i = sample(1:length(opmix.operators), opmix.weights)
     return opmix.operators[i], i
 end
@@ -47,7 +56,7 @@ end
 
 frequencies(opmix::FAGeneticOperatorsMixture) = frequencies(opmix.fa)
 
-function Base.next(opmix::FAGeneticOperatorsMixture)
+function next(opmix::FAGeneticOperatorsMixture)
     i = next(opmix.fa)
     return opmix.operators[i], i
 end

--- a/src/opt_controller.jl
+++ b/src/opt_controller.jl
@@ -103,7 +103,7 @@ function trace(ctrl::OptRunController, msg::AbstractString, obj = nothing)
             if isa(obj, AbstractString)
                 print(obj)
             else
-                showcompact(obj)
+                show(IOContext(stdout, :compact => true), obj)
             end
         end
     end

--- a/src/opt_controller.jl
+++ b/src/opt_controller.jl
@@ -395,11 +395,7 @@ end
 function init_rng!(parameters::Parameters)
     if parameters[:RandomizeRngSeed]
         parameters[:RngSeed] = rand(1:1_000_000)
-        if VERSION < v"0.7.0-rc2"
-            srand(parameters[:RngSeed])
-        else
-            Random.seed!(parameters[:RngSeed])
-        end
+        Random.seed!(parameters[:RngSeed])
     end
 end
 


### PR DESCRIPTION
While trying to investigate the cause of regressions in #83, I've updated the benchmarking scripts:
 * updated benchmark scripts to 0.7
 * added `ElapsedTime` comparison (it's an ugly copy-paste of the Fitness comparisons, but we anyway may consider rewriting benchmarking to use [BenchmarkTools.jl](https://github.com/JuliaCI/BenchmarkTools.jl))
 * added rake `benchref07` target for generating the reference data for benchmarks (basically calling `benchmarks/runupdate.jl`)
 * also added `bench07` target that calls `benchmarks/runcompare.jl` while using `BlackBoxOptim` `Project.toml` dependencies.

Unfortunately, running the benchmarks in 0.7 is not as straightforward as I have hoped. `Project/Manifest.toml` where supposed to bring much better control and automatization of the dependencies. It already does allow specifying custom dependencies for the benchmark (`[extras]`/`[targets]` in `Project.toml`), but currently the mechanisms to use these custom targets for code execution are not implemented (only the "test" target is supported by `Pkg.test()`). So all benchmarking dependencies would have to be specified in `[deps]`, which we most likely don't want to do. I omitted my .toml files from the commit (otherwise it will bloat BBO deps for all the users), but there's still `activate_pwd_env.jl`, which tells julia to use BBO's `Project.toml`. So some manual fixing of the local julia environment would be needed to run the benchmarks.