### PR TITLE
Fix Latin Hypercube Sampling

### DIFF
--- a/src/utilities/latin_hypercube_sampling.jl
+++ b/src/utilities/latin_hypercube_sampling.jl
@@ -1,18 +1,24 @@
 """
-    latin_hypercube_sampling(mins, maxs, numSamples)
+    latin_hypercube_sampling(mins, maxs, n)
 
-Randomly sample `numSamples` values from the parallelogram defined
+Randomly sample `n` vectors from the parallelogram defined
 by `mins` and `maxs` using the Latin hypercube algorithm.
+
+Returns `dims`×`n` matrix.
 """
 function latin_hypercube_sampling(mins::AbstractVector{T},
                                   maxs::AbstractVector{T},
-                                  numSamples::Integer) where T
+                                  n::Integer) where T<:Number
+    length(mins) == length(maxs) ||
+        throw(DimensionMismatch("mins and maxs should have the same length"))
+    all(xy -> xy[1] <= xy[2], zip(mins, maxs)) ||
+        throw(ArgumentError("mins[i] should not exceed maxs[i]"))
     dims = length(mins)
-    result = zeros(T, numSamples, dims)
+    result = zeros(T, n, dims)
     @inbounds for i in 1:dims
-        interval_len = (maxs[i] - mins[i]) / numSamples
-        result[:,i] = shuffle!(range(mins[i], stop=maxs[i] - interval_len, length=numSamples) +
-                               interval_len*rand(numSamples))
+        interval_len = (maxs[i] - mins[i]) / n
+        result[:,i] = shuffle!(range(mins[i], stop=maxs[i] - interval_len, length=n) +
+                               interval_len*rand(n))
     end
     return result'
 end

--- a/src/utilities/latin_hypercube_sampling.jl
+++ b/src/utilities/latin_hypercube_sampling.jl
@@ -14,11 +14,15 @@ function latin_hypercube_sampling(mins::AbstractVector{T},
     all(xy -> xy[1] <= xy[2], zip(mins, maxs)) ||
         throw(ArgumentError("mins[i] should not exceed maxs[i]"))
     dims = length(mins)
-    result = zeros(T, n, dims)
+    result = zeros(T, dims, n)
+    cubedim = Vector{T}(undef, n)
     @inbounds for i in 1:dims
-        interval_len = (maxs[i] - mins[i]) / n
-        result[:,i] = shuffle!(range(mins[i], stop=maxs[i] - interval_len, length=n) +
-                               interval_len*rand(n))
+        imin = mins[i]
+        dimstep = (maxs[i] - imin) / n
+        for j in 1:n
+            cubedim[j] = imin + dimstep * (j - 1 + rand(T))
+        end
+        result[i, :] .= shuffle!(cubedim)
     end
-    return result'
+    return result
 end

--- a/test/utilities/test_latin_hypercube_sampling.jl
+++ b/test/utilities/test_latin_hypercube_sampling.jl
@@ -1,4 +1,8 @@
 @testset "Latin hypercube sampling" begin
+    @test_throws DimensionMismatch BlackBoxOptim.Utils.latin_hypercube_sampling(Float64[], [1.0], 1)
+    @test_throws DimensionMismatch BlackBoxOptim.Utils.latin_hypercube_sampling([1.0, 2.0], [1.0], 1)
+    @test_throws ArgumentError BlackBoxOptim.Utils.latin_hypercube_sampling([2.0], [1.0], 1)
+
     samples = BlackBoxOptim.Utils.latin_hypercube_sampling([0.0], [1.0], 1)
     @test size(samples, 1) == 1
     @test (0.0 <= samples[1,1] <= 1.0)

--- a/test/utilities/test_latin_hypercube_sampling.jl
+++ b/test/utilities/test_latin_hypercube_sampling.jl
@@ -3,27 +3,35 @@
     @test_throws DimensionMismatch BlackBoxOptim.Utils.latin_hypercube_sampling([1.0, 2.0], [1.0], 1)
     @test_throws ArgumentError BlackBoxOptim.Utils.latin_hypercube_sampling([2.0], [1.0], 1)
 
-    samples = BlackBoxOptim.Utils.latin_hypercube_sampling([0.0], [1.0], 1)
-    @test size(samples, 1) == 1
-    @test (0.0 <= samples[1,1] <= 1.0)
+    samples0 = BlackBoxOptim.Utils.latin_hypercube_sampling([2.0], [2.0], 1)
+    @test samples0 isa Matrix{Float64}
+    @test size(samples0) == (1, 1)
+    @test samples0[1,1] == 2.0
 
-    samples = BlackBoxOptim.Utils.latin_hypercube_sampling([0.0], [1.0], 2)
-    @test size(samples, 2) == 2
-    sorted = sort(samples, dims=2)
-    @test (0.0 <= sorted[1,1] <= 0.5)
-    @test (0.5 <= sorted[1,2] <= 1.0)
+    samples1 = BlackBoxOptim.Utils.latin_hypercube_sampling([0.0], [1.0], 1)
+    # since the output of latin_hypercube_sampling() would be used as population matrix
+    # it should be of Matrix type, not just AbstractMatrix
+    @test samples1 isa Matrix{Float64}
+    @test size(samples1) == (1, 1)
+    @test 0.0 <= samples1[1,1] <= 1.0
 
-    samples = BlackBoxOptim.Utils.latin_hypercube_sampling([0.0, 2.0], [1.0, 3.0], 4)
-    @test size(samples, 1) == 2
-    @test size(samples, 2) == 4
-    sorted = sort(samples[[1],:], dims=2)
-    @test (0.0 <= sorted[1,1] <= 0.25)
-    @test (0.25 <= sorted[1,2] <= 0.5)
-    @test (0.5 <= sorted[1,3] <= 0.75)
-    @test (0.75 <= sorted[1,4] <= 1.0)
-    s2 = sort(samples[[2],:], dims=2)
-    @test (2.0 <= s2[1,1] <= 2.25)
-    @test (2.25 <= s2[1,2] <= 2.5)
-    @test (2.5 <= s2[1,3] <= 2.75)
-    @test (2.75 <= s2[1,4] <= 3.0)
+    samples2 = BlackBoxOptim.Utils.latin_hypercube_sampling([0.0], [1.0], 2)
+    @test samples2 isa Matrix{Float64}
+    @test size(samples2) == (1, 2)
+    samples2 = sort(samples2, dims=2)
+    @test 0.0 <= samples2[1,1] <= 0.5
+    @test 0.5 <= samples2[1,2] <= 1.0
+
+    samples3 = BlackBoxOptim.Utils.latin_hypercube_sampling([0.0, 2.0], [1.0, 3.0], 4)
+    @test samples3 isa Matrix{Float64}
+    @test size(samples3) == (2, 4)
+    samples3 = sort(samples3, dims=2)
+    @test 0.0 <= samples3[1,1] <= 0.25
+    @test 0.25 <= samples3[1,2] <= 0.5
+    @test 0.5 <= samples3[1,3] <= 0.75
+    @test 0.75 <= samples3[1,4] <= 1.0
+    @test 2.0 <= samples3[2,1] <= 2.25
+    @test 2.25 <= samples3[2,2] <= 2.5
+    @test 2.5 <= samples3[2,3] <= 2.75
+    @test 2.75 <= samples3[2,4] <= 3.0
 end


### PR DESCRIPTION
In Julia v0.7/v1.0 transpose operations are lazy, so the output of `latin_hypercube_sampling()` was not `Matrix{Float64}` (we directly use the result as population container, so we need it to be a `Matrix`), but `Adjoint{...}`.
I've slightly changed the code so that the transpose is not required.

Also added some parameter checks + updated the tests.