### PR TITLE
Fix parallel example

### DIFF
--- a/examples/rosenbrock_parallel.jl
+++ b/examples/rosenbrock_parallel.jl
@@ -1,9 +1,11 @@
+using Distributed
+
 # Now add 2 procs that can exec in parallel (obviously it depends on your CPU
 # what you actually gain from this though)
 addprocs(2)
 
-# note that BlackBoxOptim gets automatically used on all workers
-using BlackBoxOptim
+# BlackBoxOptim does not get automatically used on all workers
+@everywhere using BlackBoxOptim
 
 # define the function to optimize on all workers. Parallel eval only gives a gain
 # if function to optimize is slow. For this example we introduce a fake sleep
@@ -16,17 +18,15 @@ end
 # First run without any parallel procs used in eval
 opt1 = bbsetup(slow_rosenbrock; Method=:xnes, SearchRange = (-5.0, 5.0),
                NumDimensions = 50, MaxFuncEvals = 5000)
-tic()
-res1 = bboptimize(opt1)
-t1 = round(toq(), digits=3)
+el1 = @elapsed res1 = bboptimize(opt1)
+t1 = round(el1, digits=3)
 
 # When Workers= option is given, BlackBoxOptim enables parallel
 # evaluation of fitness using the specified worker processes
 opt2 = bbsetup(slow_rosenbrock; Method=:xnes, SearchRange = (-5.0, 5.0),
                NumDimensions = 50, MaxFuncEvals = 5000, Workers = workers())
-tic()
-res2 = bboptimize(opt2)
-t2 = round(toq(), digits=3)
+el2 = @elapsed res2 = bboptimize(opt2)
+t2 = round(el2, digits=3)
 
 println("Time: serial = $(t1)s, parallel = $(t2)s")
 if t2 < t1

--- a/examples/save_and_load_optimization_state_to_disc.jl
+++ b/examples/save_and_load_optimization_state_to_disc.jl
@@ -1,4 +1,5 @@
 using BlackBoxOptim
+using Serialization
 
 # Lets start an optimization of 2D rosenbrock
 # as in the README, then save its state to disc,


### PR DESCRIPTION
Removes the deprecated `tic()` and `toc()` in favour of `@elapsed`, distributes BlackBoxOptim to all workers, and includes the Distributed package for parallel evaluation (where for example `addprocs()` have been moved).

This example now works on
```
julia> versioninfo()
Julia Version 1.0.1
Commit 0d713926f8
[---]
```