### PR TITLE
use R*-Tree for Pareto frontier

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ os:
   - linux
   - osx
 julia:
-  - 0.7
   - 1.0
   - nightly
 matrix:

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,6 +1,6 @@
-julia 0.7
+julia 1.0.3
 StatsBase
 Distributions
-SpatialIndexing
+SpatialIndexing 0.1
 Compat
 CPUTime

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,5 +1,6 @@
 julia 0.7
 StatsBase
 Distributions
+SpatialIndexing
 Compat
 CPUTime

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,5 @@
 environment:
   matrix:
-  - julia_version: 0.7
   - julia_version: 1.0
   - julia_version: latest
 

--- a/src/BlackBoxOptim.jl
+++ b/src/BlackBoxOptim.jl
@@ -1,6 +1,7 @@
 module BlackBoxOptim
 
 using Distributions, StatsBase, Random, LinearAlgebra, Printf, Distributed, Compat
+using SpatialIndexing
 using Printf: @printf, @sprintf
 using Compat: String, view
 
@@ -91,6 +92,8 @@ module Utils
     include("utilities/halton_sequence.jl")
 end
 
+const SI = SpatialIndexing
+
 include("search_space.jl")
 include("parameters.jl")
 include("fitness.jl")
@@ -102,6 +105,7 @@ include("frequency_adaptation.jl")
 
 include("fit_individual.jl")
 include("archive.jl")
+include("archives/dominance_cone.jl")
 include("archives/epsbox_archive.jl")
 
 include("genetic_operators/genetic_operator.jl")

--- a/src/archives/dominance_cone.jl
+++ b/src/archives/dominance_cone.jl
@@ -1,0 +1,47 @@
+"""
+Set of points in fitness space that Pareto-dominate (`MIN` is `true`) or
+are dominated by (`MIN` is `false`) the given point `pt`.
+
+The point `pt` itself is not part of its `DominanceCone`.
+
+If the goal is to maximize each individual fitness component
+(i.e. `is_minimizing(fs::FitnessScheme) == false`), the cone of
+Pareto-dominating points should use `MIN = false` and Pareto-dominated points
+should use `MIN = true`.
+"""
+struct DominanceCone{F,N,MIN} <: SI.Region{F,N}
+    pt::NTuple{N,F}
+
+    function DominanceCone{MIN}(pt::NTuple{N,F}) where {F,N,MIN}
+        (MIN isa Bool) || throw(ArgumentError("MIN should be true or false (got $MIN)"))
+        new{F,N,MIN}(pt)
+    end
+end
+
+is_minimizing(a::DominanceCone{<:Any,<:Any,MIN}) where MIN = MIN
+
+# function to help define contains/intersects for all MIN values
+# rely on constant propagation of lt for efficient compilation
+isordered(lt::Bool, a::Number, b::Number) = lt ? a < b : a > b
+
+@generated SI.contains(a::DominanceCone{F,N,MIN}, b::NTuple{N,F}) where {F,N,MIN} =
+    quote
+        isordered(MIN, a.pt[1], b[1]) && return false
+        anylt = isordered(MIN, b[1], a.pt[1])
+        @inbounds Base.Cartesian.@nall $(N-1) i -> begin
+            isordered(MIN, a.pt[i+1], b[i+1]) && return false
+            anylt || (anylt = isordered(MIN, b[i+1], a.pt[i+1]))
+        end
+        return anylt
+    end
+
+SI.contains(a::DominanceCone, b::SI.Point) = SI.contains(a, b.coord)
+SI.intersects(a::DominanceCone, b::SI.Point) = SI.contains(a, b)
+
+SI.contains(a::DominanceCone, b::SI.Rect) =
+    SI.contains(a, is_minimizing(a) ? b.high : b.low)
+Base.in(a::SI.Region, b::DominanceCone) = SI.contains(b, a)
+
+SI.intersects(a::DominanceCone, b::SI.Rect) =
+    SI.contains(a, is_minimizing(a) ? b.low : b.high)
+SI.intersects(a::SI.Rect, b::DominanceCone) = SI.intersects(b, a)

--- a/src/archives/dominance_cone.jl
+++ b/src/archives/dominance_cone.jl
@@ -28,7 +28,7 @@ isordered(lt::Bool, a::Number, b::Number) = lt ? a < b : a > b
     quote
         isordered(MIN, a.pt[1], b[1]) && return false
         anylt = isordered(MIN, b[1], a.pt[1])
-        @inbounds Base.Cartesian.@nall $(N-1) i -> begin
+        @inbounds Base.Cartesian.@nexprs $(N-1) i -> begin
             isordered(MIN, a.pt[i+1], b[i+1]) && return false
             anylt || (anylt = isordered(MIN, b[i+1], a.pt[i+1]))
         end

--- a/src/archives/epsbox_archive.jl
+++ b/src/archives/epsbox_archive.jl
@@ -24,6 +24,14 @@ tag(indi::FrontierIndividual) = indi.tag
 Individual stored in `EpsBoxArchive`.
 """
 const EpsBoxFrontierIndividual{N,F<:Number} = FrontierIndividual{IndexedTupleFitness{N,F}}
+const FrontierSpatialIndex{N,F<:Number} = SI.SpatialIndex{Int,N,EpsBoxFrontierIndividual{N,F}}
+const FrontierRTree{N,F<:Number} = SI.RTree{Int,N,EpsBoxFrontierIndividual{N,F}}
+
+# traits for spatial indexing
+SI.mbrtrait(::Type{EpsBoxFrontierIndividual{N,F}}) where {N,F} = SI.HasMBR{SI.Rect{Int,N}}
+SI.mbr(indi::EpsBoxFrontierIndividual{N,F}) where {N,F} = SI.Rect(indi.fitness.index, indi.fitness.index)
+SI.idtrait(::Type{<:EpsBoxFrontierIndividual}) = SI.HasID{Int}
+SI.id(indi::EpsBoxFrontierIndividual) = indi.num_fevals
 
 EpsBoxFrontierIndividual(fitness::IndexedTupleFitness{N,F},
                params, tag, num_fevals, n_restarts, timestamp=time()) where {N,F} =
@@ -41,37 +49,43 @@ mutable struct EpsBoxArchive{N,F,FS<:EpsBoxDominanceFitnessScheme} <: Archive{In
     start_time::Float64   # Time when archive created, we use this to approximate the starting time for the opt...
 
     num_candidates::Int               # Number of calls to add_candidate!()
-    best_candidate_ix::Int            # the index of the candidate with the best aggregated fitness
+    best_candidate::EpsBoxFrontierIndividual{N,F} # the candidate with the best aggregated fitness
     last_progress::Int                # when (wrt num_candidates) last ϵ-progress has occured
     last_restart::Int                 # when (wrt num_dlast) last restart has occured
     n_restarts::Int                   # the counter of the method restarts
     n_oversize_inserts::Int           # how many times the candidates were inserted into oversized archive
 
-    len::Int              # current frontier size
     max_size::Int         # maximal frontier size
     # TODO allow different frontier containers?
     # see e.g. Altwaijry & Menai "Data Structures in Multi-Objective Evolutionary Algorithms", 2012
-    frontier::Vector{EpsBoxFrontierIndividual{N,F}}  # candidates along the fitness Pareto frontier
-    frontier_isoccupied::BitVector # true if given frontier element is occupied
+    frontier::FrontierRTree{N,F}  # candidates along the fitness Pareto frontier
 
     EpsBoxArchive(fit_scheme::EpsBoxDominanceFitnessScheme{N,F};
-                  max_size::Integer = 1_000_000) where {N,F} =
-        new{N,F,typeof(fit_scheme)}(fit_scheme, time(), 0, 0, 0, 0, 0, 0, 0, max_size,
-                                    sizehint!(Vector{EpsBoxFrontierIndividual{N,F}}(), 64),
-                                    sizehint!(BitVector(), 64))
+                  max_size::Integer = 1_000_000,
+                  leaf_capacity::Integer = 10,
+                  branch_capacity::Integer = 10) where {N,F} =
+        new{N,F,typeof(fit_scheme)}(fit_scheme, time(), 0,
+                                    EpsBoxFrontierIndividual{N,F}(nafitness(fit_scheme), Individual(), 0, 0, 0, NaN),
+                                    0, 0, 0, 0, max_size,
+                                    FrontierRTree{N,F}(leaf_capacity=leaf_capacity,
+                                                       branch_capacity=branch_capacity))
 end
 
-EpsBoxArchive(fit_scheme::EpsBoxDominanceFitnessScheme{N,F}, params::Parameters) where {N,F} =
-    EpsBoxArchive(fit_scheme, max_size=params[:MaxArchiveSize])
+EpsBoxArchive(fit_scheme::EpsBoxDominanceFitnessScheme, params::Parameters) =
+    EpsBoxArchive(fit_scheme, max_size=params[:MaxArchiveSize],
+                  leaf_capacity=params[:LeafCapacity],
+                  branch_capacity=params[:BranchCapacity])
 
 const EpsBoxArchive_DefaultParameters = ParamsDict(
     :MaxArchiveSize => 10_000,
+    :LeafCapacity => 10,
+    :BranchCapacity => 10
 )
 
 Base.eltype(::Type{EpsBoxArchive{N,F}}) where {N,F} = EpsBoxFrontierIndividual{N,F}
 
-Base.length(a::EpsBoxArchive) = a.len
-Base.isempty(a::EpsBoxArchive) = a.len == 0
+Base.length(a::EpsBoxArchive) = length(a.frontier)
+Base.isempty(a::EpsBoxArchive) = isempty(a.frontier)
 capacity(a::EpsBoxArchive) = a.max_size
 numdims(a::EpsBoxArchive) = !isempty(a.frontier) ? length(a.frontier[1].params) : 0
 
@@ -84,53 +98,64 @@ struct EpsBoxArchiveFrontierIterator{A<:EpsBoxArchive}
 end
 
 Base.eltype(::Type{EpsBoxArchiveFrontierIterator{A}}) where A = eltype(A)
+Base.length(it::EpsBoxArchiveFrontierIterator) = length(it.archive.frontier)
 
 @inline function Base.iterate(it::EpsBoxArchiveFrontierIterator)
-    ix = findfirst(it.archive.frontier_isoccupied)
-    return ix !== nothing ? (it.archive.frontier[ix], ix) : nothing
+    isempty(it.archive.frontier) && return nothing
+    node = it.archive.frontier.root
+    # get the first leaf of the frontier
+    while SI.level(node) > 0
+        node = node[1]
+    end
+    first_leaf = node::SI.leaftype(it.archive.frontier)
+    return (first_leaf[1], (first_leaf, 1)) # first element of the first leaf
 end
 
-@inline function Base.iterate(it::EpsBoxArchiveFrontierIterator, state::Int)
-    ix = findnext(it.archive.frontier_isoccupied, state+1)
-    return ix !== nothing ? (it.archive.frontier[ix], ix) : nothing
+@inline function Base.iterate(it::EpsBoxArchiveFrontierIterator,
+                              state::Tuple{SI.Leaf, Int})
+    leaf, ix = state
+    (ix < length(leaf)) && return leaf[ix+1], (leaf, ix+1)
+    # leaf iterations is done, go up until the first non-visited branch
+    node = leaf
+    while ix >= length(node)
+        SI.hasparent(node) || return nothing # returned to root, iteration finished
+        ix = SI.pos_in_parent(node)
+        node = SI.parent(node)
+    end
+    # go down into the first leaf
+    node = node[ix+1]
+    while SI.level(node) > 0
+        node = node[1]
+    end
+    leaf = node::SI.leaftype(it.archive.frontier)
+    return (leaf[1], (leaf, 1)) # first element of the leaf
 end
-
-Base.length(it::EpsBoxArchiveFrontierIterator) = sum(it.archive.frontier_isoccupied)
 
 """
+    pareto_frontier(a::EpsBoxArchive)
+
 Get the iterator to the individuals on the Pareto frontier.
 """
 pareto_frontier(a::EpsBoxArchive) = EpsBoxArchiveFrontierIterator(a)
 
-function occupied_frontier_indices(a::EpsBoxArchive)
-    ixs = sizehint!(Vector{Int}(), a.len)
-    i = findfirst(a.frontier_isoccupied)
-    while i !== nothing
-        push!(ixs, i)
-        i = findnext(a.frontier_isoccupied, i+1)
-    end
-    @assert length(ixs) == a.len
-    return ixs
-end
+occupied_frontier_indices(a::EpsBoxArchive) = findall(a.frontier_isoccupied)
 
 """
-Get random occupied Pareto frontier index.
-Returns 0 if frontier is empty.
+    rand_frontier_elem(a::EpsBoxArchive)
+
+Get random Pareto frontier element.
+
+Returns `nothing` if frontier is empty.
 """
-function rand_frontier_index(a::EpsBoxArchive)
-    if a.len == 0
-        return 0
+function rand_frontier_elem(a::EpsBoxArchive)
+    isempty(a) && return nothing
+
+    node = a.frontier.parent
+    while level(node) > 0
+        # descend to a random child
+        node = node[rand(eachindex(children(node)))]
     end
-    # narrow the range of random indices
-    il = findfirst(a.frontier_isoccupied)
-    iu = findlast(a.frontier_isoccupied)
-    # generate random indices until occupied one found
-    # FIXME any better scheme to get uniform samples from occupied indices?
-    i = rand(il:iu)
-    while !a.frontier_isoccupied[i]
-        i = rand(il:iu)
-    end
-    return i
+    return node[rand(eachindex(children(node)))]
 end
 
 """
@@ -145,8 +170,8 @@ noprogress_streak(a::EpsBoxArchive; since_restart::Bool=false) =
         a.num_candidates - max(a.last_progress, a.last_restart) :
         a.num_candidates - a.last_progress
 
-best_candidate(a::EpsBoxArchive) = a.frontier[a.best_candidate_ix].params
-best_fitness(a::EpsBoxArchive) = a.best_candidate_ix > 0 ? fitness(a.frontier[a.best_candidate_ix]) : nafitness(fitness_scheme(a))
+best_candidate(a::EpsBoxArchive) = isfinite(a.best_candidate.timestamp) ? a.best_candidate : nothing
+best_fitness(a::EpsBoxArchive) = best_candidate(a) !== nothing ? fitness(best_candidate(a)) : nafitness(a.fit_scheme)
 
 function notify!(a::EpsBoxArchive, event::Symbol)
     if event == :restart
@@ -168,14 +193,12 @@ Returns the `tag`→`count` dictionary.
 function tagcounts(a::EpsBoxArchive, θ::Number = 1.0)
     (0.0 < θ <= 1.0) || throw(ArgumentError("θ ($θ) should be in (0.0, 1.0] range"))
     res = Dict{Int,Float64}()
-    i = findfirst(a.frontier_isoccupied)
-    while i !== nothing
-        curtag = tag(a.frontier[i])
+    for indi in pareto_frontier(a)
+        curtag = tag(indi)
         if curtag > 0
             curcounts = get!(res, curtag, 0.0)
-            res[curtag] = curcounts+θ^(a.n_restarts-a.frontier[i].n_restarts)
+            res[curtag] = curcounts+θ^(a.n_restarts-indi.n_restarts)
         end
-        i = findnext(a.frontier_isoccupied, i+1)
     end
     return res
 end
@@ -186,85 +209,49 @@ function add_candidate!(a::EpsBoxArchive{N,F}, cand_fitness::IndexedTupleFitness
     if num_fevals == -1
         num_fevals = a.num_candidates
     end
-    #info("New fitness: ", cand_fitness.orig, " agg=", cand_fitness.agg)
-    #info("Params: ", candidate)
-
-    has_progress = false
-    updated_frontier_ix = nothing
-    i = findfirst(a.frontier_isoccupied)
-    while i !== nothing
-        front_fitness = fitness(a.frontier[i])
-        hat, index_match = hat_compare(cand_fitness, front_fitness, a.fit_scheme)
-        if hat < 0
-            # new fitness dominates the one in the archive
-            if updated_frontier_ix === nothing
-                #info("Replaced the dominated element $i on the frontier")
-                # replace the fitness to minimize memory operations
-                # note - if i was the best candidate index, it stays
-                new_params = copyto!(a.frontier[i].params, candidate)
-                a.frontier[i] = EpsBoxFrontierIndividual(cand_fitness, new_params, tag, num_fevals, a.n_restarts)
-                updated_frontier_ix = i
-                if index_match # we replace the element with the same index, so the domination pattern to the other elements should not change
-                    break
-                else
-                    has_progress = true
-                end
-            else
-                # already replaced the other dominated fitness, exclude this one from the frontier
-                #info("Removed the dominated element $i from the frontier")
-                @assert !index_match # if matching, it means that the old frontier[updated_frontier_ix] _was_ dominated by frontier[i]
-                a.frontier_isoccupied[i] = false
-                a.len -= 1
-                if a.best_candidate_ix == i
-                    #info("New best candidate")
-                    a.best_candidate_ix = updated_frontier_ix
-                end
-            end
-        elseif hat > 0 || (hat == 0 && index_match)
-            # the candidate fitness is worse or just the same as in the frontier, don't insert it
-            @assert updated_frontier_ix === nothing # should not have been inserted into the frontier before
-            updated_frontier_ix = -1 # non-valid integer to prevent appending
-            break
+    #@debug "New fitness: $(cand_fitness.orig) agg=$(cand_fitness.agg)"
+    #@debug "Params: $candidate"
+    if !isempty(a.frontier, DominanceCone{!is_minimizing(a.fit_scheme)}(cand_fitness.index)) # candidate is dominated by frontier
+        if length(a.frontier) <= a.max_size
+            a.n_oversize_inserts = 0 # reset the counter since the size is ok
         end
-        i = findnext(a.frontier_isoccupied, i+1)
+        return a
     end
-    if updated_frontier_ix === nothing # non-dominated candidate, append to the frontier
-        updated_frontier_ix = findfirst(isequal(false), a.frontier_isoccupied) # first unoccupied
-        if updated_frontier_ix !== nothing
-            # replace the deactivated frontier element and activate it
-            new_params = copyto!(a.frontier[updated_frontier_ix].params, candidate)
-            a.frontier[updated_frontier_ix] = EpsBoxFrontierIndividual(cand_fitness, new_params, tag, num_fevals, a.n_restarts)
-            a.frontier_isoccupied[updated_frontier_ix] = true
-        else
-            # all frontier elements are occupied, append another one
-            push!(a.frontier, EpsBoxFrontierIndividual(cand_fitness, deepcopy(candidate), tag, num_fevals, a.n_restarts))
-            push!(a.frontier_isoccupied, true)
-            updated_frontier_ix = length(a.frontier)
+    front_ix = SI.findleaf(a.frontier, SI.Point(cand_fitness.index))
+    if front_ix !== nothing # indexed fitness the same as on frontier, no eps-progress
+        front_node, front_el_pos = front_ix
+        front_elem = front_node[front_el_pos]
+        front_fitness = fitness(front_elem)
+        hat, index_match = hat_compare(cand_fitness, front_fitness, a.fit_scheme)
+        @assert index_match # should have the same indexed fitness since that's how it was found
+        if hat < 0 # new fitness dominates (but not eps-dominates) the one in archive
+            front_node[front_ix] = front_elem =
+                EpsBoxFrontierIndividual(cand_fitness, copyto!(front_elem.params, candidate), tag, num_fevals, a.n_restarts)
         end
-        a.len += 1
-        has_progress = true # no existing element with the same index, otherwise it would have been replaced
-        #info("Appended non-dominated element to the frontier")
+    else # eps-progress: non-dominated solution that has some eps-indices different from the existing ones
+        a.last_progress = a.num_candidates
+        hat = -1
+        # remove all dominated frontier elements
+        SI.subtract!(a.frontier, DominanceCone{is_minimizing(a.fit_scheme)}(cand_fitness.index))
+        #@debug "Appended non-dominated element to the frontier"
+        front_elem = EpsBoxFrontierIndividual(cand_fitness, copy(candidate), tag, num_fevals, a.n_restarts)
+        insert!(a.frontier, front_elem)
         if length(a.frontier) > a.max_size
             a.n_oversize_inserts += 1 # throw(error("Pareto frontier exceeds maximum size"))
         end
     end
-    if updated_frontier_ix > 0
-        # check if the new candidate has better aggregate score
-        if a.best_candidate_ix==0
-            a.best_candidate_ix = updated_frontier_ix
-        elseif a.best_candidate_ix != updated_frontier_ix
-            d = a.frontier[a.best_candidate_ix].fitness.agg - cand_fitness.agg
-            if (d > zero(d) && is_minimizing(a.fit_scheme)) || (d < zero(d) && !is_minimizing(a.fit_scheme))
-                #info("New best candidate")
-                a.best_candidate_ix = updated_frontier_ix
-            end
+    # check if the new candidate has better aggregate score
+    if isnan(a.best_candidate.timestamp) # best candidate is not set yet
+        a.best_candidate = front_elem
+    elseif hat < 0 # only if the candidate was dominating some old frontier element
+        d = best_candidate(a).fitness.agg - cand_fitness.agg
+        if (d > zero(d) && is_minimizing(a.fit_scheme)) || (d < zero(d) && !is_minimizing(a.fit_scheme))
+            #@debug "New best candidate"
+            a.best_candidate = front_elem
         end
     end
     if length(a.frontier) <= a.max_size
         a.n_oversize_inserts = 0 # reset the counter since the size is ok
-    end
-    if has_progress # non-dominated solution that has some eps-indices different from the existing ones
-        a.last_progress = a.num_candidates
     end
     return a
 end

--- a/src/archives/epsbox_archive.jl
+++ b/src/archives/epsbox_archive.jl
@@ -206,11 +206,16 @@ function add_candidate!(a::EpsBoxArchive{N,F}, cand_fitness::IndexedTupleFitness
         end
     end
     # check if the new candidate has better aggregate score
-    if !has_best_front_elem(a)
+    if !has_best_front_elem(a) # initialize best element
         a.best_front_elem = frontel
-    elseif hat < 0 # only if the candidate was dominating some old frontier element
+    elseif hat < 0 # candidate replaced frontier element
+        # update best_front_elem if it was replaced or if the new aggscore is better
+        # NOTE: when the old best element is replaced, the new aggscore might be
+        #       worse due to differences in aggscore and eps-progress metrics
         d = a.best_front_elem.fitness.agg - frontel.fitness.agg
-        if (d > zero(d) && is_minimizing(a.fit_scheme)) || (d < zero(d) && !is_minimizing(a.fit_scheme))
+        if  a.best_front_elem.fitness.index == frontel.fitness.index ||
+           (d > zero(d) && is_minimizing(a.fit_scheme)) ||
+           (d < zero(d) && !is_minimizing(a.fit_scheme))
             #@debug "New best candidate"
             a.best_front_elem = frontel
         end

--- a/src/archives/epsbox_archive.jl
+++ b/src/archives/epsbox_archive.jl
@@ -49,7 +49,7 @@ mutable struct EpsBoxArchive{N,F,FS<:EpsBoxDominanceFitnessScheme} <: Archive{In
     start_time::Float64   # Time when archive created, we use this to approximate the starting time for the opt...
 
     num_candidates::Int               # Number of calls to add_candidate!()
-    best_candidate::EpsBoxFrontierIndividual{N,F} # the candidate with the best aggregated fitness
+    best_frontel::EpsBoxFrontierIndividual{N,F} # best frontier element: the candidate with the best aggregated fitness
     last_progress::Int                # when (wrt num_candidates) last ϵ-progress has occured
     last_restart::Int                 # when (wrt num_dlast) last restart has occured
     n_restarts::Int                   # the counter of the method restarts
@@ -106,12 +106,12 @@ Returns `nothing` if frontier is empty.
 function rand_frontier_elem(a::EpsBoxArchive)
     isempty(a) && return nothing
 
-    node = a.frontier.parent
-    while level(node) > 0
+    node = a.frontier.root
+    while SI.level(node) > 1
         # descend to a random child
-        node = node[rand(eachindex(children(node)))]
+        node = node[rand(eachindex(SI.children(node)))]
     end
-    return node[rand(eachindex(children(node)))]
+    return node[rand(eachindex(SI.children(node)))]
 end
 
 """
@@ -126,8 +126,10 @@ noprogress_streak(a::EpsBoxArchive; since_restart::Bool=false) =
         a.num_candidates - max(a.last_progress, a.last_restart) :
         a.num_candidates - a.last_progress
 
-best_candidate(a::EpsBoxArchive) = isfinite(a.best_candidate.timestamp) ? a.best_candidate : nothing
-best_fitness(a::EpsBoxArchive) = best_candidate(a) !== nothing ? fitness(best_candidate(a)) : nafitness(a.fit_scheme)
+has_best_frontel(a::EpsBoxArchive) = isfinite(a.best_frontel.timestamp)
+best_frontel(a::EpsBoxArchive) = has_best_frontel(a) ? a.best_frontel : nothing
+best_candidate(a::EpsBoxArchive) = has_best_frontel(a) ? params(a.best_frontel) : nothing
+best_fitness(a::EpsBoxArchive) = has_best_frontel(a) ? fitness(a.best_frontel) : nafitness(a.fit_scheme)
 
 function notify!(a::EpsBoxArchive, event::Symbol)
     if event == :restart
@@ -135,7 +137,7 @@ function notify!(a::EpsBoxArchive, event::Symbol)
         a.last_restart = a.num_candidates
         # TODO check if the pareto frontier needs to be compactified
     end
-    a
+    return a
 end
 
 """
@@ -167,43 +169,43 @@ function add_candidate!(a::EpsBoxArchive{N,F}, cand_fitness::IndexedTupleFitness
     end
     #@debug "New fitness: $(cand_fitness.orig) agg=$(cand_fitness.agg)"
     #@debug "Params: $candidate"
-    if !isempty(a.frontier, DominanceCone{!is_minimizing(a.fit_scheme)}(cand_fitness.index)) # candidate is dominated by frontier
+    if !isempty(a.frontier, DominanceCone{is_minimizing(a.fit_scheme)}(cand_fitness.index)) # candidate is dominated by frontier
         if length(a.frontier) <= a.max_size
             a.n_oversize_inserts = 0 # reset the counter since the size is ok
         end
         return a
     end
-    front_ix = SI.findleaf(a.frontier, SI.Point(cand_fitness.index))
-    if front_ix !== nothing # indexed fitness the same as on frontier, no eps-progress
-        front_node, front_el_pos = front_ix
-        front_elem = front_node[front_el_pos]
-        front_fitness = fitness(front_elem)
+    frontix = findfirst(a.frontier, SI.Point(cand_fitness.index))
+    if frontix !== nothing # indexed fitness the same as on frontier, no eps-progress
+        front_leaf, frontel_pos = frontix
+        frontel = front_leaf[frontel_pos]
+        front_fitness = fitness(frontel)
         hat, index_match = hat_compare(cand_fitness, front_fitness, a.fit_scheme)
         @assert index_match # should have the same indexed fitness since that's how it was found
-        if hat < 0 # new fitness dominates (but not eps-dominates) the one in archive
-            front_node[front_ix] = front_elem =
-                EpsBoxFrontierIndividual(cand_fitness, copyto!(front_elem.params, candidate), tag, num_fevals, a.n_restarts)
+        if hat < 0 # new fitness dominates (but not eps-dominates) the one in archive, replace the element
+            SI.children(front_leaf)[frontel_pos] = frontel =
+                EpsBoxFrontierIndividual(cand_fitness, copyto!(frontel.params, candidate), tag, num_fevals, a.n_restarts)
         end
     else # eps-progress: non-dominated solution that has some eps-indices different from the existing ones
         a.last_progress = a.num_candidates
         hat = -1
         # remove all dominated frontier elements
-        SI.subtract!(a.frontier, DominanceCone{is_minimizing(a.fit_scheme)}(cand_fitness.index))
+        SI.subtract!(a.frontier, DominanceCone{!is_minimizing(a.fit_scheme)}(cand_fitness.index))
         #@debug "Appended non-dominated element to the frontier"
-        front_elem = EpsBoxFrontierIndividual(cand_fitness, copy(candidate), tag, num_fevals, a.n_restarts)
-        insert!(a.frontier, front_elem)
+        frontel = EpsBoxFrontierIndividual(cand_fitness, copy(candidate), tag, num_fevals, a.n_restarts)
+        insert!(a.frontier, frontel)
         if length(a.frontier) > a.max_size
             a.n_oversize_inserts += 1 # throw(error("Pareto frontier exceeds maximum size"))
         end
     end
     # check if the new candidate has better aggregate score
-    if isnan(a.best_candidate.timestamp) # best candidate is not set yet
-        a.best_candidate = front_elem
+    if !has_best_frontel(a)
+        a.best_frontel = frontel
     elseif hat < 0 # only if the candidate was dominating some old frontier element
-        d = best_candidate(a).fitness.agg - cand_fitness.agg
+        d = a.best_frontel.fitness.agg - frontel.fitness.agg
         if (d > zero(d) && is_minimizing(a.fit_scheme)) || (d < zero(d) && !is_minimizing(a.fit_scheme))
             #@debug "New best candidate"
-            a.best_candidate = front_elem
+            a.best_frontel = frontel
         end
     end
     if length(a.frontier) <= a.max_size

--- a/src/archives/epsbox_archive.jl
+++ b/src/archives/epsbox_archive.jl
@@ -77,7 +77,7 @@ EpsBoxArchive(fit_scheme::EpsBoxDominanceFitnessScheme, params::Parameters) =
                   branch_capacity=params[:BranchCapacity])
 
 const EpsBoxArchive_DefaultParameters = ParamsDict(
-    :MaxArchiveSize => 10_000,
+    :MaxArchiveSize => 100_000,
     :LeafCapacity => 10,
     :BranchCapacity => 10
 )

--- a/src/borg_moea.jl
+++ b/src/borg_moea.jl
@@ -130,7 +130,7 @@ function recombinate!(alg::BorgMOEA, recomb_op_ix::Int, recomb_op::CrossoverOper
     if !isempty(archive(alg))
         # get one parent from the archive and copy it to the fitrst transient member
         arch_ix = transient_range(alg.population)[1]
-        alg.population[arch_ix] = rand_frontier_elem(archive(alg))
+        alg.population[arch_ix] = rand_front_elem(archive(alg))
         push!(parent_indices, arch_ix)
     end
     # Crossover parents and target

--- a/src/borg_moea.jl
+++ b/src/borg_moea.jl
@@ -130,7 +130,7 @@ function recombinate!(alg::BorgMOEA, recomb_op_ix::Int, recomb_op::CrossoverOper
     if !isempty(archive(alg))
         # get one parent from the archive and copy it to the fitrst transient member
         arch_ix = transient_range(alg.population)[1]
-        alg.population[arch_ix] = archive(alg).frontier[rand_frontier_index(archive(alg))]
+        alg.population[arch_ix] = rand_frontier_elem(archive(alg))
         push!(parent_indices, arch_ix)
     end
     # Crossover parents and target

--- a/src/borg_moea.jl
+++ b/src/borg_moea.jl
@@ -261,17 +261,23 @@ Resize and refills the population from the archive.
 """
 function restart!(alg::BorgMOEA)
     notify!(archive(alg), :restart)
-    frontier_ixs = occupied_frontier_indices(archive(alg))
-    narchived = length(frontier_ixs)
+    narchived = length(archive(alg))
     new_popsize = max(alg.min_popsize, ceil(Int, alg.γ * narchived))
     # fill populations with the solutions from the archive
     resize!(alg.population, new_popsize)
-    last_archived = min(narchived, new_popsize)
-    @inbounds for i in 1:last_archived
-        alg.population[i] = archive(alg).frontier[frontier_ixs[i]]
+    ndelegates = min(narchived, new_popsize)
+    # get the indexes of the frontier elements to put into the population
+    delegate_ixs = sort!(sample(1:narchived, ndelegates, replace=false))
+    delegate_pos = 1 # position of the current delegate index
+    for (candi_ix, candi) in enumerate(pareto_frontier(archive(alg)))
+        delegate_pos > length(delegate_ixs) && break
+        @inbounds if delegate_ixs[delegate_pos] == candi_ix
+            alg.population[delegate_pos] = candi
+            delegate_pos += 1 # move to the next delegate
+        end
     end
     # inject mutated archive members
-    populate_by_mutants(alg, last_archived)
+    populate_by_mutants(alg, ndelegates)
     alg.select.size = min(new_popsize, max(3, ceil(Int, alg.τ * new_popsize)))
     alg.last_restart = alg.n_steps
     alg.n_restarts+=1

--- a/src/optimization_result.jl
+++ b/src/optimization_result.jl
@@ -103,7 +103,7 @@ struct FrontierIndividualWrapper{F,FA} <: FitIndividual{F}
     inner::FrontierIndividual{FA}
     fitness::F
 
-    FrontierIndividualWrapper{F}(
+    FrontierIndividualWrapper{F,FA}(
             indi::FrontierIndividual{FA},
             fit_scheme::FitnessScheme{FA}) where {F, FA} =
         new{F, FA}(indi, convert(F, fitness(indi), fit_scheme))
@@ -123,10 +123,10 @@ struct EpsBoxArchiveOutput{N,F,FS<:EpsBoxDominanceFitnessScheme} <: ArchiveOutpu
 
     function EpsBoxArchiveOutput(archive::EpsBoxArchive{N,F}) where {N,F}
         fit_scheme = fitness_scheme(archive)
+        FIW = FrontierIndividualWrapper{NTuple{N,F}, IndexedTupleFitness{N,F}}
         new{N,F,typeof(fit_scheme)}(convert(NTuple{N,F}, best_fitness(archive), fit_scheme),
                                     best_candidate(archive),
-                                    FrontierIndividualWrapper{NTuple{N,F}, IndexedTupleFitness{N,F}}[FrontierIndividualWrapper{NTuple{N,F}}(archive.frontier[i], fit_scheme)
-                                                                                                     for i in findall(archive.frontier_isoccupied)],
+                                    FIW[FIW(frontel, fit_scheme) for frontel in pareto_frontier(archive)],
                                     fit_scheme)
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -17,7 +17,7 @@ TestDir = first(splitdir(@__FILE__()))
 if length(ARGS) == 2 && isfile(ARGS[2])
     test_file_list = ARGS[2]
 else
-    test_file_list = joinpath(TestDir, "testset_borg.txt")
+    test_file_list = joinpath(TestDir, "testset_normal.txt")
 end
 
 TestFiles = filter(fn -> isfile(joinpath(TestDir, fn)), 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -6,6 +6,9 @@ module BlackBoxOptimTests
 
 using LinearAlgebra, Random
 using Printf: @printf, @sprintf
+using SpatialIndexing
+
+const SI = SpatialIndexing
 
 TestDir = first(splitdir(@__FILE__()))
 
@@ -14,7 +17,7 @@ TestDir = first(splitdir(@__FILE__()))
 if length(ARGS) == 2 && isfile(ARGS[2])
     test_file_list = ARGS[2]
 else
-    test_file_list = joinpath(TestDir, "testset_normal.txt")
+    test_file_list = joinpath(TestDir, "testset_borg.txt")
 end
 
 TestFiles = filter(fn -> isfile(joinpath(TestDir, fn)), 

--- a/test/test_epsbox_archive.jl
+++ b/test/test_epsbox_archive.jl
@@ -46,7 +46,7 @@
         @test !isempty(a)
         @test best_fitness(a) == fitness(first(pareto_frontier(a)))
         @test best_candidate(a) === params(first(pareto_frontier(a)))
-        @test a.best_frontel == first(pareto_frontier(a))
+        @test BlackBoxOptim.best_front_elem(a) == first(pareto_frontier(a))
         @test first(pareto_frontier(a)).num_fevals == 8
         @test BlackBoxOptim.noprogress_streak(a) == 0
         @test BlackBoxOptim.tagcounts(a) == Dict(1=>1)
@@ -55,7 +55,7 @@
         BlackBoxOptim.add_candidate!(a, (3.21, 1.12), [1.0, 5.0], 2)
         @test capacity(a)         == 100
         @test length(a)           == 1
-        @test a.best_frontel == first(pareto_frontier(a))
+        @test BlackBoxOptim.best_front_elem(a) == first(pareto_frontier(a))
         @test first(pareto_frontier(a)).num_fevals == 8
         @test BlackBoxOptim.noprogress_streak(a) == 1
         @test BlackBoxOptim.tagcounts(a) == Dict(1=>1)
@@ -69,7 +69,7 @@
         @test candi_leaf[candi_ix].num_fevals == 3
         @test best_fitness(a).orig == (1.21, 2.11)
         @test best_candidate(a) == [1.2, 3.0]
-        @test a.best_frontel == candi_leaf[candi_ix]
+        @test BlackBoxOptim.best_front_elem(a) == candi_leaf[candi_ix]
         @test BlackBoxOptim.noprogress_streak(a) == 0
         @test BlackBoxOptim.tagcounts(a) == Dict(1=>1, 3=>1)
 
@@ -130,7 +130,7 @@
             a = EpsBoxArchive(scheme, max_size=100)
 
             BlackBoxOptim.add_candidate!(a, convert(IndexedTupleFitness, (1.25, 0.0), scheme), [0.0, 1.0], 1)
-            @test a.best_frontel == first(pareto_frontier(a))
+            @test BlackBoxOptim.best_front_elem(a) == first(pareto_frontier(a))
             @test length(a)         == 1
             BlackBoxOptim.add_candidate!(a, convert(IndexedTupleFitness, (0.6, 0.6), scheme), [0.0, 2.0], 2)
             @test best_fitness(a).orig == (0.6, 0.6)

--- a/test/test_epsbox_archive.jl
+++ b/test/test_epsbox_archive.jl
@@ -33,30 +33,35 @@
 
         @test capacity(a) == 100
         @test length(a)   == 0
+        @test isempty(a)
+        @test best_candidate(a) === nothing
         @test BlackBoxOptim.noprogress_streak(a) == 0
         @test BlackBoxOptim.tagcounts(a) == Dict{Int,Int}()
 
         BlackBoxOptim.add_candidate!(a, convert(IndexedTupleFitness, (2.21, 1.12), scheme), [0.0, 5.0], 1, 8)
         @test capacity(a)         == 100
         @test length(a)           == 1
-        @test a.best_candidate_ix == 1
-        @test a.frontier[1].num_fevals == 8
+        @test !isempty(a)
+        @test best_candidate(a) == first(pareto_frontier(a))
+        @test first(pareto_frontier(a)).num_fevals == 8
         @test BlackBoxOptim.noprogress_streak(a) == 0
         @test BlackBoxOptim.tagcounts(a) == Dict{Int,Int}(1=>1)
 
         BlackBoxOptim.add_candidate!(a, (3.21, 1.12), [1.0, 5.0], 2)
         @test capacity(a)         == 100
         @test length(a)           == 1
-        @test a.best_candidate_ix == 1
-        @test a.frontier[1].num_fevals == 8
+        @test best_candidate(a) == first(pareto_frontier(a))
+        @test first(pareto_frontier(a)).num_fevals == 8
         @test BlackBoxOptim.noprogress_streak(a) == 1
         @test BlackBoxOptim.tagcounts(a) == Dict{Int,Int}(1=>1)
 
         BlackBoxOptim.add_candidate!(a, (1.21, 2.11), [1.2, 3.0], 3)
         @test capacity(a)         == 100
         @test length(a)           == 2
-        @test a.frontier[2].num_fevals == 3
-        @test a.best_candidate_ix == 2
+        @test SI.findleaf(a.frontier, SI.Point((12,21))) !== nothing
+        candi_leaf, candi_ix = SI.findleaf(a.frontier, SI.Point((12,21)))
+        @test candi_leaf[candi_ix].num_fevals == 3
+        @test best_candidate(a) == candi_leaf[candi_ix]
         @test BlackBoxOptim.noprogress_streak(a) == 0
         @test BlackBoxOptim.tagcounts(a) == Dict{Int,Int}(1=>1, 3=>1)
 

--- a/test/test_epsbox_archive.jl
+++ b/test/test_epsbox_archive.jl
@@ -7,6 +7,7 @@
                 if j > i
                     comp, index_match = hat_compare(fitness(el_i), fitness(el_j), fitness_scheme(a))
                     if comp != 0 || index_match
+                        @warn "Dominated pair: fitness($i)=$(fitness(el_i)) fitness($j)=$(fitness(el_j))"
                         return comp, index_match # return if violating pair is found
                     end
                 end
@@ -35,6 +36,7 @@
         @test length(a)   == 0
         @test isempty(a)
         @test best_candidate(a) === nothing
+        @test isnafitness(best_fitness(a), fitness_scheme(a))
         @test BlackBoxOptim.noprogress_streak(a) == 0
         @test BlackBoxOptim.tagcounts(a) == Dict{Int,Int}()
 
@@ -42,49 +44,57 @@
         @test capacity(a)         == 100
         @test length(a)           == 1
         @test !isempty(a)
-        @test best_candidate(a) == first(pareto_frontier(a))
+        @test best_fitness(a) == fitness(first(pareto_frontier(a)))
+        @test best_candidate(a) === params(first(pareto_frontier(a)))
+        @test a.best_frontel == first(pareto_frontier(a))
         @test first(pareto_frontier(a)).num_fevals == 8
         @test BlackBoxOptim.noprogress_streak(a) == 0
-        @test BlackBoxOptim.tagcounts(a) == Dict{Int,Int}(1=>1)
+        @test BlackBoxOptim.tagcounts(a) == Dict(1=>1)
 
+        # dominated candidate is ignored and best candidate unchanged
         BlackBoxOptim.add_candidate!(a, (3.21, 1.12), [1.0, 5.0], 2)
         @test capacity(a)         == 100
         @test length(a)           == 1
-        @test best_candidate(a) == first(pareto_frontier(a))
+        @test a.best_frontel == first(pareto_frontier(a))
         @test first(pareto_frontier(a)).num_fevals == 8
         @test BlackBoxOptim.noprogress_streak(a) == 1
-        @test BlackBoxOptim.tagcounts(a) == Dict{Int,Int}(1=>1)
+        @test BlackBoxOptim.tagcounts(a) == Dict(1=>1)
 
+        # non-dominated candidate is appended and best candidate updated
         BlackBoxOptim.add_candidate!(a, (1.21, 2.11), [1.2, 3.0], 3)
         @test capacity(a)         == 100
         @test length(a)           == 2
-        @test SI.findleaf(a.frontier, SI.Point((12,21))) !== nothing
-        candi_leaf, candi_ix = SI.findleaf(a.frontier, SI.Point((12,21)))
+        @test findfirst(a.frontier, SI.Point((12,21))) !== nothing
+        candi_leaf, candi_ix = findfirst(a.frontier, SI.Point((12,21)))
         @test candi_leaf[candi_ix].num_fevals == 3
-        @test best_candidate(a) == candi_leaf[candi_ix]
+        @test best_fitness(a).orig == (1.21, 2.11)
+        @test best_candidate(a) == [1.2, 3.0]
+        @test a.best_frontel == candi_leaf[candi_ix]
         @test BlackBoxOptim.noprogress_streak(a) == 0
-        @test BlackBoxOptim.tagcounts(a) == Dict{Int,Int}(1=>1, 3=>1)
+        @test BlackBoxOptim.tagcounts(a) == Dict(1=>1, 3=>1)
 
+        # another non-dominated candidate (no best update)
         BlackBoxOptim.add_candidate!(a, (0.52, 3.15), [1.5, 3.0], 3)
         @test capacity(a)         == 100
         @test length(a)           == 3
-        @test a.best_candidate_ix == 2
+        @test best_fitness(a).orig == (1.21, 2.11)
         @test BlackBoxOptim.noprogress_streak(a) == 0
-        @test BlackBoxOptim.tagcounts(a) == Dict{Int,Int}(1=>1, 3=>2)
+        @test BlackBoxOptim.tagcounts(a) == Dict(1=>1, 3=>2)
 
+        # the candidate that dominates all current frontier
         BlackBoxOptim.add_candidate!(a, (0.22, 0.22), [1.5, 3.0], 5)
         @test capacity(a)         == 100
         @test length(a)           == 1
-        @test a.best_candidate_ix == 1
+        @test best_fitness(a).orig == (0.22, 0.22)
         @test BlackBoxOptim.noprogress_streak(a) == 0
-        @test BlackBoxOptim.tagcounts(a) == Dict{Int,Int}(5=>1)
+        @test BlackBoxOptim.tagcounts(a) == Dict(5=>1)
 
         BlackBoxOptim.add_candidate!(a, (0.21, 0.21), [1.5, 3.0], 6)
         @test capacity(a)         == 100
         @test length(a)           == 1
-        @test a.best_candidate_ix == 1
+        @test best_fitness(a).orig == (0.21, 0.21)
         @test BlackBoxOptim.noprogress_streak(a) == 1
-        @test BlackBoxOptim.tagcounts(a) == Dict{Int,Int}(6=>1)
+        @test BlackBoxOptim.tagcounts(a) == Dict(6=>1)
 
         @testset "noprogress_streak(since_restart=0) is reset after restart" begin
             @test BlackBoxOptim.noprogress_streak(a, since_restart=false) == 1
@@ -101,16 +111,18 @@
             a = EpsBoxArchive(scheme, max_size=100)
 
             BlackBoxOptim.add_candidate!(a, convert(IndexedTupleFitness, (1.0, 0.0), scheme), [0.0, 1.0], 1)
-            @test a.best_candidate_ix == 1
+            @test best_fitness(a).orig == (1.0, 0.0)
             @test length(a)           == 1
             BlackBoxOptim.add_candidate!(a, convert(IndexedTupleFitness, (0.6, 0.6), scheme), [0.0, 2.0], 2)
-            @test a.best_candidate_ix == 1
+            @test best_fitness(a).orig == (1.0, 0.0)
+            @test best_candidate(a) == [0.0, 1.0]
             @test length(a)           == 2
             BlackBoxOptim.add_candidate!(a, convert(IndexedTupleFitness, (0.0, 1.1), scheme), [0.0, 3.0], 3)
-            @test a.best_candidate_ix == 1
+            @test best_fitness(a).orig == (1.0, 0.0)
             @test length(a)           == 3
             BlackBoxOptim.add_candidate!(a, convert(IndexedTupleFitness, (0.0, 0.9), scheme), [0.0, 4.0], 4)
-            @test a.best_candidate_ix == 3
+            @test best_fitness(a).orig == (0.0, 0.9)
+            @test best_candidate(a) == [0.0, 4.0]
             @test length(a)           == 3
         end
 
@@ -118,17 +130,19 @@
             a = EpsBoxArchive(scheme, max_size=100)
 
             BlackBoxOptim.add_candidate!(a, convert(IndexedTupleFitness, (1.25, 0.0), scheme), [0.0, 1.0], 1)
-            @test a.best_candidate_ix == 1
-            @test length(a)           == 1
+            @test a.best_frontel == first(pareto_frontier(a))
+            @test length(a)         == 1
             BlackBoxOptim.add_candidate!(a, convert(IndexedTupleFitness, (0.6, 0.6), scheme), [0.0, 2.0], 2)
-            @test a.best_candidate_ix == 2
-            @test length(a)           == 2
+            @test best_fitness(a).orig == (0.6, 0.6)
+            @test length(a)         == 2
             BlackBoxOptim.add_candidate!(a, convert(IndexedTupleFitness, (0.0, 1.3), scheme), [0.0, 3.0], 3)
-            @test a.best_candidate_ix == 2
-            @test length(a)           == 3
+            @test best_fitness(a).orig == (0.6, 0.6)
+            @test best_candidate(a) == [0.0, 2.0] # no change
+            @test length(a)         == 3
             BlackBoxOptim.add_candidate!(a, convert(IndexedTupleFitness, (0.6, 0.6), scheme), [0.0, 4.0], 4)
-            @test a.best_candidate_ix == 2
-            @test length(a)           == 3
+            @test best_fitness(a).orig == (0.6, 0.6)
+            @test best_candidate(a) == [0.0, 2.0] # same fitness, so no change
+            @test length(a)         == 3
         end
     end
 
@@ -152,13 +166,13 @@
         indiv = [1.5, 2.0]
         BlackBoxOptim.add_candidate!(a, (1.5, 2.0), indiv)
         # equal but not identical
-        @test a.frontier[1].params == indiv
-        @test !(a.frontier[1].params === indiv)
+        @test first(a.frontier).params == indiv
+        @test first(a.frontier).params !== indiv
 
         # modify the vector
         indiv[1] = 5.0
         # test that archived version is still the same
-        @test a.frontier[1].params == [1.5, 2.0]
+        @test first(a.frontier).params == [1.5, 2.0]
     end
 
     @testset "simulate optimization" begin
@@ -166,11 +180,9 @@
         # and lying inside the (1.0-r1)^1.5 + (1.0-r2)^1.5 + (1.0-r3)^1.5 <= 8.0
         function rfitness()
             while true
-                r1 = rand()
-                r2 = rand()
-                r3 = rand()
-                if (1.0-r1)^1.5 + (1.0-r2)^1.5 + (1.0-r3)^1.5 <= 1.0
-                    return (2.0*r1, 2.0*r2, 2.0*r3)
+                r = ntuple(_ -> rand(), 3)
+                if sum(x -> (1 - x)^1.5, r) <= 1.0
+                    return 2.0 .* r
                 end
             end
         end
@@ -183,7 +195,7 @@
             # periodically check that pareto_frontier(a) is indeed
             # epsilon-index frontier
             if mod(i, 100) == 0
-                @test isposdef(length(a))
+                @test length(a) > 0
                 @test check_frontier(a) == (0, false)
             end
         end

--- a/test/testset_borg.txt
+++ b/test/testset_borg.txt
@@ -1,0 +1,2 @@
+test_epsbox_archive.jl
+test_borg_moea.jl


### PR DESCRIPTION
I've started [SpatialIndexing.jl](https://github.com/alyst/SpatialIndexing.jl) package (implements [R*-tree](https://en.wikipedia.org/wiki/R*_tree)), and this PR uses R*-tree as the container for the Pareto frontier in `EpsBoxArchive` as discussed in #82. Unfortunately, at the moment I'm hitting some internal Julia error JuliaLang/julia#30122. So either that would be fixed or I'll find some workaround to proceed further.