### PR TITLE
Misc fixes

### DIFF
--- a/examples/visualize_crossover.jl
+++ b/examples/visualize_crossover.jl
@@ -1,25 +1,25 @@
-using BlackBoxOptim, Gadfly
+using BlackBoxOptim, Plots, Random
 
 """
     plot_crossover(xover::CrossoverOperator, parents::Matrix{Float64};
                    n=5000, shuffle_parents=false)
 
-    Plot the distribution of offsprings for the crossover operator `xover`
-    and given `parents`.
+Plot the distribution of offsprings for the crossover operator `xover`
+and given `parents`.
 """
-function plot_crossover(xover::CrossoverOperator{NP,NC}, parents::Matrix{Float64};
-                 n=5000, shuffle_parents=false) where {NP,NC}
-    @assert size(parents, 2) == NP
+function plot_crossover(xover::CrossoverOperator, parents::Matrix{Float64};
+                        n=5000, shuffle_parents=false)
+    @assert size(parents, 2) == numparents(xover)
     parents_pop = FitPopulation(parents, NaN)
-    parent_ixs = collect(1:NP)
-    children_mtx = hcat([hcat(apply!(xover, [fill!(Individual(undef, size(parents, 1)), NaN) for _ in 1:NC],
-                              zeros(Int, NC), parents_pop,
+    parent_ixs = collect(1:numparents(xover))
+    children_mtx = hcat([hcat(apply!(xover, [fill!(Individual(undef, size(parents, 1)), NaN) for _ in 1:numchildren(xover)],
+                              zeros(Int, numchildren(xover)), parents_pop,
                               shuffle_parents ? shuffle(parent_ixs) : parent_ixs)...) for _ in 1:n]...)
-    plot(layer(x=parents_pop.individuals[1,:], y=parents_pop.individuals[2,:], Geom.point, # parents
-               Theme(default_color=colorant"purple", default_point_size=8.0pt, highlight_width=0pt)),
-         layer(x=children_mtx[1,:], y=children_mtx[2,:], Geom.point,
-               Theme(default_color=colorant"orange", default_point_size=1.5pt, highlight_width=0pt))
-    )
+    plot(view(children_mtx, 1, :), view(children_mtx, 2, :),
+         seriestype=:scatter, title=string(typeof(xover)), label="children",
+         markersize=1.5, markerstrokewidth=0, markercolor=colorant"orange")
+    scatter!(view(parents_pop.individuals, 1, :), view(parents_pop.individuals, 2, :),
+             markersize=5, markercolor=colorant"purple", label="parents")
 end
 
 plot_crossover(SimplexCrossover{3}(1.2),

--- a/src/genetic_operators/genetic_operator.jl
+++ b/src/genetic_operators/genetic_operator.jl
@@ -32,11 +32,11 @@ The concrete implementations must provide `select()` method.
 abstract type IndividualsSelector end
 
 """
-    select(selector<:IndividualsSelector, population, numSamples::Int)
+    select(selector::IndividualsSelector, population, numSamples::Int)
 
 Select `numSamples` random candidates from the `population`.
 """
-function select(::IndividualsSelector, population, numSamples::Int) end
+select
 
 apply(o::MutationOperator, parents::AbstractVector{<:AbstractVector{<:Real}}) =
     map(p -> apply(o, p), parents)

--- a/src/genetic_operators/selector/radius_limited.jl
+++ b/src/genetic_operators/selector/radius_limited.jl
@@ -17,13 +17,13 @@ mutable struct RadiusLimitedSelector <: IndividualsSelector
     radius::Int
 end
 
-function select(sel::RadiusLimitedSelector, population, numSamples::Int)
+function select(sel::RadiusLimitedSelector, population, n::Integer)
     # The radius must be at least as big as the number of samples + 2 so that
     # there is something to sample from.
-    radius = max(sel.radius, numSamples+2)
+    radius = max(sel.radius, n+2)
     psize = popsize(population)
     deme_start = rand(1:psize)
-    ixs = rand_indexes(deme_start:(deme_start+radius-1), numSamples)
+    ixs = sample(deme_start:(deme_start+radius-1), n, replace=false, ordered=false)
     # Ensure they are not out of bounds by wrapping over at the end.
     ixs .= mod1.(ixs, psize)
 end

--- a/src/genetic_operators/selector/simple.jl
+++ b/src/genetic_operators/selector/simple.jl
@@ -6,5 +6,5 @@ The probabilties of all candidates are equal.
 struct SimpleSelector <: IndividualsSelector
 end
 
-select(::SimpleSelector, population, numSamples::Int) =
-    rand_indexes(1:popsize(population), numSamples)
+select(::SimpleSelector, population, n::Integer) =
+    sample(1:popsize(population), n, ordered=false, replace=false)

--- a/src/genetic_operators/selector/tournament.jl
+++ b/src/genetic_operators/selector/tournament.jl
@@ -14,7 +14,7 @@ end
 # selection using `n_tours` tournaments
 function select(sel::TournamentSelector, population, n_tours::Int)
     n_candidates = min(popsize(population), sel.size*n_tours)
-    all_candidates = rand_indexes(1:popsize(population), n_candidates)
+    all_candidates = sample(1:popsize(population), n_candidates, replace=false, ordered=false)
 
     res = Vector{Int}(undef, n_tours)
     tour_candidates = Vector{Int}(undef, sel.size)

--- a/src/opt_controller.jl
+++ b/src/opt_controller.jl
@@ -307,12 +307,12 @@ function run!(ctrl::OptRunController)
             ctrl.last_num_fevals = num_func_evals(ctrl)
 
             # Callback every now and then (if a callback interval has been set)...
-            if ctrl.callback_interval > 0.0 && 
+            if ctrl.callback_interval > 0.0 &&
                 (ctrl.last_callback_time <= 0.0 ||
                     (time() - ctrl.last_callback_time) > ctrl.callback_interval)
                 callback(ctrl)
-            end            
-            
+            end
+
             # Check if we have a reason to stop on next loop
             ctrl.stop_reason = check_stop_condition(ctrl)
         end

--- a/src/opt_controller.jl
+++ b/src/opt_controller.jl
@@ -320,7 +320,7 @@ function run!(ctrl::OptRunController)
     finally
         shutdown_optimizer!(ctrl)
     end
-    trace(ctrl, "\nOptimization stopped after $(ctrl.num_steps) steps and $(elapsed_time(ctrl)) seconds\n")
+    trace(ctrl, @sprintf "\nOptimization stopped after %d steps and %.2f seconds\n" ctrl.num_steps elapsed_time(ctrl))
 
     return ctrl.stop_reason
 end
@@ -328,9 +328,9 @@ end
 function show_report(ctrl::OptRunController, population_stats=false)
     final_elapsed_time = elapsed_time(ctrl)
     trace(ctrl, "Termination reason: $(ctrl.stop_reason)\n")
-    trace(ctrl, "Steps per second = $(num_steps(ctrl)/final_elapsed_time)\n")
-    trace(ctrl, "Function evals per second = $(num_func_evals(ctrl)/final_elapsed_time)\n")
-    trace(ctrl, "Improvements/step = $(ctrl.num_better/ctrl.max_steps)\n")
+    trace(ctrl, @sprintf "Steps per second = %.2f\n" num_steps(ctrl)/final_elapsed_time)
+    trace(ctrl, @sprintf "Function evals per second = %.2f\n" num_func_evals(ctrl)/final_elapsed_time)
+    trace(ctrl, @sprintf "Improvements/step = %.5f\n" ctrl.num_better/ctrl.max_steps)
     trace(ctrl, "Total function evaluations = $(num_func_evals(ctrl))\n")
 
     if population_stats && isa(ctrl.optimizer, PopulationOptimizer)

--- a/src/parameters.jl
+++ b/src/parameters.jl
@@ -112,4 +112,4 @@ The default placeholder value for parameters argument.
 """
 const EMPTY_PARAMS = ParamsDict()
 
-kwargs2dict(kwargs::Iterators.Pairs{Symbol}) = ParamsDict(kwargs)
+kwargs2dict(kwargs...) = ParamsDict(kwargs...)

--- a/src/population.jl
+++ b/src/population.jl
@@ -29,24 +29,6 @@ numdims(pop::AbstractVector{<:Candidate}) = isempty(pop) ? 0 : length(pop[1].par
 
 viewer(pop::PopulationMatrix, indi_ix) = view(pop, :, indi_ix)
 
-# select random indexes
-# FIXME use sample() when Julia keyarg inference problem (https://github.com/JuliaLang/julia/issues/9551) would be solved
-# at the moment it's just an extract from SampleBase.sample!() for ordered=false, replace=false
-function rand_indexes(a::AbstractArray{Int}, k::Int)
-    n = length(a)
-    x = Vector{Int}(undef, k)
-    if k == 1
-        @inbounds x[1] = sample(a)
-    elseif k == 2
-        @inbounds (x[1], x[2]) = StatsBase.samplepair(a)
-    elseif n < k * 24
-        StatsBase.fisher_yates_sample!(a, x)
-    else
-        StatsBase.self_avoid_sample!(a, x)
-    end
-    return x
-end
-
 """
 The default implementation of `PopulationWithFitness{F}`.
 """


### PR DESCRIPTION
Another round of fixes that seemed to me straightforward enough to put in a single PR, in particular:
 * parent-centric crossover implementation was quite inefficient (apparent for large problems), since it contained the computation of ndim X ndim temporary matrix; the updated implementation avoids it
 * updated `visualize_crossover.jl` visual test/example to use `Plots.jl` package
 * logging of optimization progress should be more readable (less digits after comma for performance metrics)
 * BBO's `rand_indexes()` method (which was a wrapper for `StatsBase` internal methods) replaced by `StatsBase.sample()` (since calls with keyword arguments should be properly optimized in 1.0)
 * `kwargs2dict()` should work in more cases now
