### PR TITLE
SearchSpace: API cleanup + discrete dimensions support

### DIFF
--- a/examples/multiobjective.jl
+++ b/examples/multiobjective.jl
@@ -11,7 +11,7 @@ res = bboptimize(schaffer1; Method=:borg_moea,
 # N is the number of the problem (not fitness) dimensions
 pareto_curve_func(t, ::Type{Val{N}}) where {N} = (N*t[1]^2, N*(2-t[1])^2)
 pareto_curve = BlackBoxOptim.Hypersurface(pareto_curve_func,
-                                          symmetric_search_space(1, (0.0, 2.0)))
+                                          RectSearchSpace(1, (0.0, 2.0)))
 
 # generate the set of ϵ-indexed points on the exact Pareto frontier
 pareto_pts = BlackBoxOptim.generate(pareto_curve,

--- a/src/BlackBoxOptim.jl
+++ b/src/BlackBoxOptim.jl
@@ -62,7 +62,7 @@ export  Optimizer, AskTellOptimizer, SteppingOptimizer, PopulationOptimizer,
         ParamBounds, Individual, SearchSpace, FixedDimensionSearchSpace,
         RectSearchSpace, ContinuousRectSearchSpace,
         numdims, dimmin, dimmax, dimdelta, dimrange,
-        rand_individual, rand_individuals, rand_individuals_lhs,
+        rand_individual, rand_individuals,
 
         # Population
         FitPopulation,

--- a/src/BlackBoxOptim.jl
+++ b/src/BlackBoxOptim.jl
@@ -60,8 +60,8 @@ export  Optimizer, AskTellOptimizer, SteppingOptimizer, PopulationOptimizer,
 
         # Search spaces
         ParamBounds, Individual, SearchSpace, FixedDimensionSearchSpace,
-        RectSearchSpace, ContinuousRectSearchSpace,
-        numdims, dimmin, dimmax, dimdelta, dimrange,
+        RectSearchSpace, ContinuousRectSearchSpace, MixedPrecisionRectSearchSpace,
+        numdims, dimmin, dimmax, dimdelta, dimrange, dimdigits,
         rand_individual, rand_individuals,
 
         # Population

--- a/src/BlackBoxOptim.jl
+++ b/src/BlackBoxOptim.jl
@@ -61,7 +61,7 @@ export  Optimizer, AskTellOptimizer, SteppingOptimizer, PopulationOptimizer,
         # Search spaces
         ParamBounds, Individual, SearchSpace, FixedDimensionSearchSpace,
         RectSearchSpace, ContinuousRectSearchSpace, symmetric_search_space,
-        numdims, mins, maxs, deltas, ranges, range_for_dim, diameters,
+        numdims, dimmin, dimmax, dimdelta, dimrange,
         rand_individual, rand_individuals, rand_individuals_lhs,
 
         # Population

--- a/src/BlackBoxOptim.jl
+++ b/src/BlackBoxOptim.jl
@@ -60,7 +60,7 @@ export  Optimizer, AskTellOptimizer, SteppingOptimizer, PopulationOptimizer,
 
         # Search spaces
         ParamBounds, Individual, SearchSpace, FixedDimensionSearchSpace,
-        RectSearchSpace, ContinuousRectSearchSpace, symmetric_search_space,
+        RectSearchSpace, ContinuousRectSearchSpace,
         numdims, dimmin, dimmax, dimdelta, dimrange,
         rand_individual, rand_individuals, rand_individuals_lhs,
 

--- a/src/BlackBoxOptim.jl
+++ b/src/BlackBoxOptim.jl
@@ -59,8 +59,8 @@ export  Optimizer, AskTellOptimizer, SteppingOptimizer, PopulationOptimizer,
         numruns, lastrun, problem,
 
         # Search spaces
-        ParamBounds, Individual, SearchSpace, FixedDimensionSearchSpace, ContinuousSearchSpace,
-        RangePerDimSearchSpace, symmetric_search_space,
+        ParamBounds, Individual, SearchSpace, FixedDimensionSearchSpace,
+        RectSearchSpace, ContinuousRectSearchSpace, symmetric_search_space,
         numdims, mins, maxs, deltas, ranges, range_for_dim, diameters,
         rand_individual, rand_individuals, rand_individuals_lhs,
 

--- a/src/adaptive_differential_evolution.jl
+++ b/src/adaptive_differential_evolution.jl
@@ -4,7 +4,7 @@ const ADE_DefaultOptions = chain(DE_DefaultOptions, ParamsDict(
     # Distributions we will use to generate new F and CR values.
     :fdistr => BimodalCauchy(0.65, 0.1, 1.0, 0.1, clampBelow0 = false),
     :crdistr => BimodalCauchy(0.1, 0.1, 0.95, 0.1, clampBelow0 = false),
-    :SearchSpace => symmetric_search_space(1)
+    :SearchSpace => RectSearchSpace(1)
 ))
 
 """

--- a/src/default_parameters.jl
+++ b/src/default_parameters.jl
@@ -64,7 +64,7 @@ function check_and_create_search_space(params::Parameters)
             if ndim == :NotSpecified
                 throw(ArgumentError("You MUST specify NumDimensions= in a solution when giving a SearchRange=$(sr)"))
             end
-            return symmetric_search_space(params[:NumDimensions], sr)
+            return RectSearchSpace(params[:NumDimensions], sr)
         elseif isa(sr, typeof([(0.0, 1.0)]))
             return RectSearchSpace(sr)
         else

--- a/src/default_parameters.jl
+++ b/src/default_parameters.jl
@@ -45,7 +45,7 @@ function check_and_create_search_space(params::Parameters)
         if isa(ss, SearchSpace)
             return ss
         elseif isa(ss, typeof([(0.0, 1.0)]))
-            return RangePerDimSearchSpace(ss)
+            return RectSearchSpace(ss)
         elseif ss == false
             # silently fallthrough to the other means of search space specification
         else
@@ -66,7 +66,7 @@ function check_and_create_search_space(params::Parameters)
             end
             return symmetric_search_space(params[:NumDimensions], sr)
         elseif isa(sr, typeof([(0.0, 1.0)]))
-            return RangePerDimSearchSpace(sr)
+            return RectSearchSpace(sr)
         else
             throw(ArgumentError("Using $(typeof(sr)) for SearchRange is not supported."))
         end

--- a/src/fitness.jl
+++ b/src/fitness.jl
@@ -17,11 +17,10 @@ abstract type FitnessScheme{F} end
 
 Get the type of fitness values for fitness scheme `fs`.
 """
-fitness_type(::Type{FitnessScheme{F}}) where F = F
-fitness_type(::FitnessScheme{F}) where F = F
-fitness_type(::Type{FS}) where {FS<:FitnessScheme} = fitness_type(supertype(FS))
-fitness_eltype(::Type{FitnessScheme{F}}) where {F<:Number} = F
-fitness_eltype(::FitnessScheme{F}) where {F<:Number} = F
+fitness_type(::Type{<:FitnessScheme{F}}) where F = F
+fitness_type(fs::FitnessScheme) = fitness_type(typeof(fs))
+fitness_eltype(::Type{<:FitnessScheme{F}}) where {F<:Number} = F
+fitness_eltype(fs::FitnessScheme) = fitness_eltype(typeof(fs))
 
 # trivial convert() between calculated and archived fitness
 Base.convert(::Type{F}, fit::F, fit_scheme::FitnessScheme{F}) where F = fit
@@ -54,7 +53,7 @@ is_minimizing(::ScalarFitnessScheme{MIN}) where {MIN} = MIN
 nafitness(::Type{F}) where {F<:Number} = convert(F, NaN)
 @inline nafitness(fs::FitnessScheme) = nafitness(fitness_type(fs))
 isnafitness(f::F, ::RatioFitnessScheme{F}) where {F<:Number} = isnan(f)
-numobjectives(::RatioFitnessScheme{F}) where {F<:Number} = 1
+numobjectives(::RatioFitnessScheme) = 1
 
 """
 Aggregation is just the identity function for scalar fitness.

--- a/src/generating_set_search.jl
+++ b/src/generating_set_search.jl
@@ -37,7 +37,7 @@ const GSSDefaultParameters = ParamsDict(
     :StepSizeMax => prevfloat(typemax(Float64)) # A limit on the step size can be set but is typically not => Inf.
 )
 
-calc_initial_step_size(ss, stepSizeFactor = 0.5) = stepSizeFactor * minimum(diameters(ss))
+calc_initial_step_size(ss, stepSizeFactor = 0.5) = stepSizeFactor * minimum(dimdelta(ss))
 
 """
 Generating Set Search as described in Kolda2003:

--- a/src/genetic_operators/embedding/random_bound.jl
+++ b/src/genetic_operators/embedding/random_bound.jl
@@ -9,9 +9,6 @@ struct RandomBound{S<:RectSearchSpace} <: EmbeddingOperator
     RandomBound(search_space::S) where {S<:RectSearchSpace} = new{S}(search_space)
 end
 
-# outer ctors
-RandomBound(dimBounds::Vector{ParamBounds}) = RandomBound(RectSearchSpace(dimBounds))
-
 search_space(rb::RandomBound) = rb.search_space
 
 function apply!(eo::RandomBound, target::AbstractIndividual, ref::AbstractIndividual)

--- a/src/genetic_operators/embedding/random_bound.jl
+++ b/src/genetic_operators/embedding/random_bound.jl
@@ -25,8 +25,11 @@ function apply!(eo::RandomBound, target::AbstractIndividual, ref::AbstractIndivi
             target[i] = l + rand() * (ref[i]-l)
         elseif target[i] > u
             target[i] = u + rand() * (ref[i]-u)
-        else
-            continue
+        else # continuous range doesn't need further checks
+            (ss isa MixedPrecisionRectSearchSpace) || continue
+        end
+        if (ss isa MixedPrecisionRectSearchSpace) && (dimdigits(ss, i) >= 0)
+            target[i] = round(target[i], digits=dimdigits(ss, i))
         end
         @assert l <= target[i] <= u "target[$i]=$(target[i]) is out of [$l, $u]"
     end

--- a/src/genetic_operators/embedding/random_bound.jl
+++ b/src/genetic_operators/embedding/random_bound.jl
@@ -3,23 +3,23 @@ Embedding operator that randomly samples
 between parent's value and the nearest parameter boundary
 to get the new valid value if target's parameter is out-of-bounds.
 """
-struct RandomBound{S<:SearchSpace} <: EmbeddingOperator
-    searchSpace::S
+struct RandomBound{S<:RangePerDimSearchSpace} <: EmbeddingOperator
+    search_space::S
 
-    RandomBound(searchSpace::S) where {S<:SearchSpace} = new{S}(searchSpace)
+    RandomBound(search_space::S) where {S<:RangePerDimSearchSpace} = new{S}(search_space)
 end
 
 # outer ctors
 RandomBound(dimBounds::Vector{ParamBounds}) = RandomBound(RangePerDimSearchSpace(dimBounds))
 
-search_space(rb::RandomBound) = rb.searchSpace
+search_space(rb::RandomBound) = rb.search_space
 
 function apply!(eo::RandomBound, target::AbstractIndividual, ref::AbstractIndividual)
-    length(target) == length(ref) == numdims(eo.searchSpace) ||
+    length(target) == length(ref) == numdims(eo.search_space) ||
         throw(ArgumentError("Dimensions of problem/individuals do not match"))
     ss = search_space(eo)
-    ssmins = mins(eo.searchSpace)
-    ssmaxs = maxs(eo.searchSpace)
+    ssmins = mins(ss)
+    ssmaxs = maxs(ss)
 
     @inbounds for i in eachindex(target)
         l, u = ssmins[i], ssmaxs[i]

--- a/src/genetic_operators/embedding/random_bound.jl
+++ b/src/genetic_operators/embedding/random_bound.jl
@@ -18,8 +18,8 @@ function apply!(eo::RandomBound, target::AbstractIndividual, ref::AbstractIndivi
     length(target) == length(ref) == numdims(eo.search_space) ||
         throw(ArgumentError("Dimensions of problem/individuals do not match"))
     ss = search_space(eo)
-    ssmins = mins(ss)
-    ssmaxs = maxs(ss)
+    ssmins = dimmin(ss)
+    ssmaxs = dimmax(ss)
 
     @inbounds for i in eachindex(target)
         l, u = ssmins[i], ssmaxs[i]

--- a/src/genetic_operators/embedding/random_bound.jl
+++ b/src/genetic_operators/embedding/random_bound.jl
@@ -3,14 +3,14 @@ Embedding operator that randomly samples
 between parent's value and the nearest parameter boundary
 to get the new valid value if target's parameter is out-of-bounds.
 """
-struct RandomBound{S<:RangePerDimSearchSpace} <: EmbeddingOperator
+struct RandomBound{S<:RectSearchSpace} <: EmbeddingOperator
     search_space::S
 
-    RandomBound(search_space::S) where {S<:RangePerDimSearchSpace} = new{S}(search_space)
+    RandomBound(search_space::S) where {S<:RectSearchSpace} = new{S}(search_space)
 end
 
 # outer ctors
-RandomBound(dimBounds::Vector{ParamBounds}) = RandomBound(RangePerDimSearchSpace(dimBounds))
+RandomBound(dimBounds::Vector{ParamBounds}) = RandomBound(RectSearchSpace(dimBounds))
 
 search_space(rb::RandomBound) = rb.search_space
 

--- a/src/genetic_operators/mutation/mutation_clock.jl
+++ b/src/genetic_operators/mutation/mutation_clock.jl
@@ -26,7 +26,7 @@ end
 search_space(m::UniformMutation) = m.search_space
 
 apply(m::UniformMutation, v::Number, dim::Int, target_index::Int) =
-    dimmin(search_space(m))[dim] + rand() * dimdelta(search_space(m))[dim]
+    dimmin(search_space(m), dim) + rand() * dimdelta(search_space(m), dim)
 
 """
 Mutation clock operator is a more efficient way to mutate vectors than to generate

--- a/src/genetic_operators/mutation/mutation_clock.jl
+++ b/src/genetic_operators/mutation/mutation_clock.jl
@@ -26,7 +26,7 @@ end
 search_space(m::UniformMutation) = m.search_space
 
 apply(m::UniformMutation, v::Number, dim::Int, target_index::Int) =
-    mins(search_space(m))[dim] + rand() * deltas(search_space(m))[dim]
+    dimmin(search_space(m))[dim] + rand() * dimdelta(search_space(m))[dim]
 
 """
 Mutation clock operator is a more efficient way to mutate vectors than to generate

--- a/src/genetic_operators/mutation/mutation_clock.jl
+++ b/src/genetic_operators/mutation/mutation_clock.jl
@@ -1,4 +1,4 @@
-num_vars_to_next_mutation_point(probMutation) = ceil( Int, (-log(rand())) / probMutation)
+num_vars_to_next_mutation_point(probMutation) = ceil(Int, (-log(rand())) / probMutation)
 
 """
 Provides `apply()` operator that mutates one specified dimension of a parameter
@@ -18,15 +18,15 @@ end
 Uniform mutation of a parameter vector.
 """
 struct UniformMutation{SS<:SearchSpace} <: GibbsMutationOperator
-    ss::SS
+    search_space::SS
 
     UniformMutation(ss::SS) where {SS<:SearchSpace} = new{SS}(ss)
 end
 
-search_space(m::UniformMutation) = m.ss
+search_space(m::UniformMutation) = m.search_space
 
-@inline apply(m::UniformMutation, v::Number, dim::Int, target_index::Int) =
-    return (mins(m.ss)[dim] + rand() * deltas(m.ss)[dim])
+apply(m::UniformMutation, v::Number, dim::Int, target_index::Int) =
+    mins(search_space(m))[dim] + rand() * deltas(search_space(m))[dim]
 
 """
 Mutation clock operator is a more efficient way to mutate vectors than to generate

--- a/src/genetic_operators/mutation/polynomial_mutation.jl
+++ b/src/genetic_operators/mutation/polynomial_mutation.jl
@@ -3,13 +3,15 @@ Polynomial mutation as presented in the paper:
     Deb and Deb (2012), "Analyzing Mutation Schemes for Real-Parameter Genetic Algorithms"
 """
 struct PolynomialMutation{SS<:SearchSpace} <: GibbsMutationOperator
-    ss::SS
+    search_space::SS
     η::Float64
 
     PolynomialMutation(ss::SS, η = 50.0) where {SS<:SearchSpace} = new{SS}(ss, η)
     PolynomialMutation(ss::SS, options::Parameters) where {SS<:SearchSpace} =
         new{SS}(ss, options[:PM_η])
 end
+
+search_space(m::PolynomialMutation) = m.search_space
 
 """
 Default parameters for `PolynomialMutation`.
@@ -22,9 +24,9 @@ function apply(m::PolynomialMutation, v::Number, dim::Int, target_index::Int)
     u = 2.0*rand()
     if u <= 1.0
         ΔL = u^(1.0/(1.0+m.η)) - 1.0
-        return (v + ΔL * (v - mins(m.ss)[dim]))
+        return (v + ΔL * (v - mins(search_space(m))[dim]))
     else
         ΔR = 1.0 - (2.0-u)^(1.0/(1.0+m.η))
-        return (v + ΔR * (maxs(m.ss)[dim] - v))
+        return (v + ΔR * (maxs(search_space(m))[dim] - v))
     end
 end

--- a/src/genetic_operators/mutation/polynomial_mutation.jl
+++ b/src/genetic_operators/mutation/polynomial_mutation.jl
@@ -24,9 +24,9 @@ function apply(m::PolynomialMutation, v::Number, dim::Int, target_index::Int)
     u = 2.0*rand()
     if u <= 1.0
         ΔL = u^(1.0/(1.0+m.η)) - 1.0
-        return (v + ΔL * (v - dimmin(search_space(m))[dim]))
+        return v + ΔL * (v - dimmin(search_space(m), dim))
     else
         ΔR = 1.0 - (2.0-u)^(1.0/(1.0+m.η))
-        return (v + ΔR * (dimmax(search_space(m))[dim] - v))
+        return v + ΔR * (dimmax(search_space(m), dim) - v)
     end
 end

--- a/src/genetic_operators/mutation/polynomial_mutation.jl
+++ b/src/genetic_operators/mutation/polynomial_mutation.jl
@@ -24,9 +24,9 @@ function apply(m::PolynomialMutation, v::Number, dim::Int, target_index::Int)
     u = 2.0*rand()
     if u <= 1.0
         ΔL = u^(1.0/(1.0+m.η)) - 1.0
-        return (v + ΔL * (v - mins(search_space(m))[dim]))
+        return (v + ΔL * (v - dimmin(search_space(m))[dim]))
     else
         ΔR = 1.0 - (2.0-u)^(1.0/(1.0+m.η))
-        return (v + ΔR * (maxs(search_space(m))[dim] - v))
+        return (v + ΔR * (dimmax(search_space(m))[dim] - v))
     end
 end

--- a/src/natural_evolution_strategies.jl
+++ b/src/natural_evolution_strategies.jl
@@ -202,7 +202,7 @@ ini_xnes_B(ss::SearchSpace) = Matrix{Float64}(I, numdims(ss), numdims(ss))
 Calculates the initial ``log B`` matrix for `xNES` based on the deltas of each dimension.
 """
 function ini_xnes_B(ss::RectSearchSpace)
-    diag = log.(deltas(ss))
+    diag = log.(dimdelta(ss))
     diag .-= mean(diag)
     return Matrix{Float64}(Diagonal(diag))
 end

--- a/src/natural_evolution_strategies.jl
+++ b/src/natural_evolution_strategies.jl
@@ -201,7 +201,7 @@ ini_xnes_B(ss::SearchSpace) = Matrix{Float64}(I, numdims(ss), numdims(ss))
 """
 Calculates the initial ``log B`` matrix for `xNES` based on the deltas of each dimension.
 """
-function ini_xnes_B(ss::RangePerDimSearchSpace)
+function ini_xnes_B(ss::RectSearchSpace)
     diag = log.(deltas(ss))
     diag .-= mean(diag)
     return Matrix{Float64}(Diagonal(diag))

--- a/src/ntuple_fitness.jl
+++ b/src/ntuple_fitness.jl
@@ -10,9 +10,9 @@ Type parameters:
 """
 abstract type TupleFitnessScheme{N,F<:Number,FA,MIN,AGG} <: FitnessScheme{FA} end
 
-@inline numobjectives(::TupleFitnessScheme{N}) where {N} = N
-@inline fitness_eltype(::TupleFitnessScheme{N,F}) where {N,F} = F
-@inline is_minimizing(::TupleFitnessScheme{N,F,FA,MIN}) where {N,F,FA,MIN} = MIN
+numobjectives(::TupleFitnessScheme{N}) where {N} = N
+fitness_eltype(::Type{<:TupleFitnessScheme{N,F}}) where {N,F} = F
+is_minimizing(::TupleFitnessScheme{N,F,FA,MIN}) where {N,F,FA,MIN} = MIN
 
 @generated nafitness(::TupleFitnessScheme{N,F,NTuple{N,F}}) where {N,F} = ntuple(_ -> convert(F, NaN), N)
 isnafitness(f::NTuple{N,F}, ::TupleFitnessScheme{N,F}) where {N,F} = any(isnan, f)

--- a/src/population.jl
+++ b/src/population.jl
@@ -189,16 +189,17 @@ end
 candi_pool_size(pop::FitPopulation) = length(pop.candi_pool)
 
 """
-Generate a population for a given problem.
+Generate a population for a given optimization `problem`.
 
-The default method to generate a population, uses Latin Hypercube Sampling.
+`method` specifies a method for sampling random individuals, defaults to `:latin_hypercube`.
 """
 function population(problem::OptimizationProblem,
                     options::Parameters = EMPTY_PARAMS,
                     nafitness::F = nafitness(fitness_scheme(problem));
-                    ntransient::Integer = 0) where F
+                    ntransient::Integer = 0,
+                    method::Symbol = :latin_hypercube) where F
     if !haskey(options, :Population)
-        pop = rand_individuals_lhs(search_space(problem), get(options, :PopulationSize, 50) + ntransient)
+        pop = rand_individuals(search_space(problem), get(options, :PopulationSize, 50) + ntransient, method=method)
     else
         pop = options[:Population]
     end

--- a/src/problem.jl
+++ b/src/problem.jl
@@ -12,7 +12,7 @@ fitness_type(::Type{P}) where P <: OptimizationProblem = fitness_type(fitness_sc
 fitness_scheme(p::OptimizationProblem) = p.fitness_scheme
 fitness_type(p::P) where P <: OptimizationProblem = fitness_type(P)
 numobjectives(p::OptimizationProblem) = numobjectives(fitness_scheme(p))
-search_space(p::OptimizationProblem) = p.ss
+search_space(p::OptimizationProblem) = p.search_space
 numdims(p::OptimizationProblem) = numdims(search_space(p))
 
 """
@@ -33,11 +33,11 @@ mutable struct FunctionBasedProblem{FS<:FitnessScheme,SS<:SearchSpace,FO} <: Opt
     objfunc::Function     # Objective function
     name::String
     fitness_scheme::FS
-    ss::SS                # search space
+    search_space::SS      # search space
     opt_value::FO         # known optimal value or nothing
 
     function FunctionBasedProblem(objfunc::Function, name::String,
-                                  fitness_scheme::FS, ss::SS,
+                                  fitness_scheme::FS, search_space::SS,
                                   opt_value::FO = nothing) where {FS<:FitnessScheme,SS<:SearchSpace,FO}
         if FO <: Number
             fitness_type(fitness_scheme) == FO ||
@@ -47,7 +47,7 @@ mutable struct FunctionBasedProblem{FS<:FitnessScheme,SS<:SearchSpace,FO} <: Opt
                 #throw(ArgumentError("Known optimal value cannot be NA"))
             end
         end
-        new{FS,SS,typeof(opt_value)}(objfunc, name, fitness_scheme, ss, opt_value)
+        new{FS,SS,typeof(opt_value)}(objfunc, name, fitness_scheme, search_space, opt_value)
     end
 end
 
@@ -62,7 +62,7 @@ fitness(x, p::FunctionBasedProblem) = objfunc(p)(x)
 
 Base.copy(p::FunctionBasedProblem) =
     FunctionBasedProblem(deepcopy(p.objfunc), deepcopy(p.name),
-                         p.fitness_scheme, p.ss, p.opt_value)
+                         p.fitness_scheme, p.search_space, p.opt_value)
 
 opt_value(p::FunctionBasedProblem) = p.opt_value
 

--- a/src/problems/multi_objective.jl
+++ b/src/problems/multi_objective.jl
@@ -7,7 +7,7 @@ struct Hypersurface{N,SS<:SearchSpace}
 
     function Hypersurface(manifold::Function, parameter_space::SS) where {SS<:SearchSpace}
         N = numdims(parameter_space)+1
-        int_pt = manifold(0.5*(mins(parameter_space)+maxs(parameter_space)), Val{1})
+        int_pt = manifold(0.5*(dimmin(parameter_space)+dimmax(parameter_space)), Val{1})
         length(int_pt) == N || throw(DimensionMismatch())
         new{N,SS}(manifold, parameter_space)
     end
@@ -28,8 +28,8 @@ discretization defined by ϵ-box fitness schema.
         pf = Dict{NTuple{N,Int}, IndexedTupleFitness{N,F}}()
         param = fill!(Vector{Float64}(undef, N-1), 0.0)
         #hat_compare = HatCompare(fs)
-        Base.Cartesian.@nloops $(N-1) t d->range(surf.parameter_space.mins[d], stop=surf.parameter_space.maxs[d],
-                                                 length=ceil(Int, surf.parameter_space.deltas[d]/param_step[d])) d->param[d]=t_d begin
+        Base.Cartesian.@nloops $(N-1) t d->range(dimmin(surf.parameter_space)[d], stop=dimmax(surf.parameter_space)[d],
+                                                 length=ceil(Int, dimdelta(surf.parameter_space)[d]/param_step[d])) d->param[d]=t_d begin
             fit = surf.manifold(param, Val{NP})
             if !isnafitness(fit, fs) # NA if given parameters do not correspond to any point on the manifold
                 ifit = convert(IndexedTupleFitness, fit, fs)

--- a/src/problems/multi_objective.jl
+++ b/src/problems/multi_objective.jl
@@ -148,8 +148,8 @@ See http://dces.essex.ac.uk/staff/zhang/MOEAcompetition/cec09testproblem0904.pdf
 const CEC09_Unconstrained_Set = Dict{Int,FunctionBasedProblemFamily}(
     8 => FunctionBasedProblemFamily(CEC09_UP8, "CEC09 UP8",  ParetoFitnessScheme{3}(is_minimizing=true),
                                     (-2.0, 2.0),
-                                    Hypersurface(CEC09_UP8_PF, symmetric_search_space(2, (0.0, 1.0))),
-                                    symmetric_search_space(2, (0.0, 1.0)))
+                                    Hypersurface(CEC09_UP8_PF, RectSearchSpace(2, (0.0, 1.0))),
+                                    RectSearchSpace(2, (0.0, 1.0)))
 )
 
 schaffer1(x) = (sum(abs2, x), sum(xx -> abs2(xx - 2.0), x))
@@ -157,4 +157,4 @@ schaffer1_PF(t, ::Type{Val{NP}}) where {NP} = (NP*t[1]^2, NP*(2-t[1])^2)
 
 const Schaffer1Family = FunctionBasedProblemFamily(schaffer1, "Schaffer1", ParetoFitnessScheme{2}(is_minimizing=true),
                                 (-10.0, 10.0),
-                                Hypersurface(schaffer1_PF, symmetric_search_space(1, (0.0, 2.0))))
+                                Hypersurface(schaffer1_PF, RectSearchSpace(1, (0.0, 2.0))))

--- a/src/problems/multi_objective.jl
+++ b/src/problems/multi_objective.jl
@@ -28,8 +28,8 @@ discretization defined by ϵ-box fitness schema.
         pf = Dict{NTuple{N,Int}, IndexedTupleFitness{N,F}}()
         param = fill!(Vector{Float64}(undef, N-1), 0.0)
         #hat_compare = HatCompare(fs)
-        Base.Cartesian.@nloops $(N-1) t d->range(dimmin(surf.parameter_space)[d], stop=dimmax(surf.parameter_space)[d],
-                                                 length=ceil(Int, dimdelta(surf.parameter_space)[d]/param_step[d])) d->param[d]=t_d begin
+        Base.Cartesian.@nloops $(N-1) t d->range(dimmin(surf.parameter_space, d), stop=dimmax(surf.parameter_space, d),
+                                                 length=ceil(Int, dimdelta(surf.parameter_space, d)/param_step[d])) d->param[d]=t_d begin
             fit = surf.manifold(param, Val{NP})
             if !isnafitness(fit, fs) # NA if given parameters do not correspond to any point on the manifold
                 ifit = convert(IndexedTupleFitness, fit, fs)

--- a/src/problems/problem_family.jl
+++ b/src/problems/problem_family.jl
@@ -44,7 +44,7 @@ Construct search space for `FunctionBasedProblem` with the given number of dimen
 function instantiate_search_space(family::FunctionBasedProblemFamily, ndim::Int)
     ndim >= numdims(family.reserved_ss) ||
         throw(ArgumentError("Cannot create $ndim-problem: number of dimensions less than reserved dimensions"))
-    vcat(family.reserved_ss, symmetric_search_space(ndim - numdims(family.reserved_ss), family.range_per_dim))
+    vcat(family.reserved_ss, RectSearchSpace(ndim - numdims(family.reserved_ss), family.range_per_dim))
 end
 
 """

--- a/src/problems/problem_family.jl
+++ b/src/problems/problem_family.jl
@@ -13,17 +13,17 @@ Family of `FunctionBasedProblem` optimization problems
 parameterized by the number of search space dimensions.
 """
 struct FunctionBasedProblemFamily{F,FS<:FitnessScheme,FO} <: ProblemFamily{FS}
-    objfunc::Function                     # Objective function
+    objfunc::Function               # Objective function
     name::String
     fitness_scheme::FS
-    reserved_ss::RangePerDimSearchSpace   # search space for the first reserved dimensions
-    range_per_dim::ParamBounds            # Default range per dimension
-    opt_value::FO                         # optional optimal value, or nothing
+    reserved_ss::RectSearchSpace    # search space for the first reserved dimensions
+    range_per_dim::ParamBounds      # Default range per dimension
+    opt_value::FO                   # optional optimal value, or nothing
 
     function FunctionBasedProblemFamily(
             objfunc::Function, name::String,
             fitness_scheme::FS, range::ParamBounds, opt_value::FO = nothing,
-            reserved_ss::RangePerDimSearchSpace = ZERO_SEARCH_SPACE
+            reserved_ss::RectSearchSpace = ZERO_SEARCH_SPACE
     ) where {FS<:FitnessScheme, FO}
         if FO <: Number
             fitness_type(fitness_scheme) == FO ||

--- a/src/random_search.jl
+++ b/src/random_search.jl
@@ -1,14 +1,14 @@
 """
 Optimize by randomly generating the candidates.
 """
-mutable struct RandomSearcher{S<:SearchSpace} <: AskTellOptimizer
+mutable struct RandomSearcher{SS<:SearchSpace} <: AskTellOptimizer
     name::String
-    search_space::S
+    search_space::SS
     best_fitness          # FIXME fitness type should be known
     best::Individual
 
-    RandomSearcher(searchSpace::S) where {S<:SearchSpace} =
-        new{S}("Random Search", searchSpace, nothing)
+    RandomSearcher(search_space::SS) where {SS<:SearchSpace} =
+        new{SS}("Random Search", search_space, nothing)
 end
 
 function ask(rs::RandomSearcher)
@@ -31,5 +31,5 @@ end
 random_search(problem::OptimizationProblem, parameters::Parameters) =
     RandomSearcher(search_space(problem))
 
-random_search(ss::SearchSpace) =
-    RandomSearcher(ss)
+random_search(search_space::SearchSpace) =
+    RandomSearcher(search_space)

--- a/src/resampling_memetic_search.jl
+++ b/src/resampling_memetic_search.jl
@@ -26,7 +26,7 @@ mutable struct ResamplingMemeticSearcher{E<:Evaluator} <: SteppingOptimizer
     resampling_func::Function
 
     precisions      # Cache the starting precision values so we need not calc them for each step
-    diameters       # Cache the diameters...
+    diameters       # Cache the dimdelta()...
 
     elite           # Current elite (best) candidate
     elite_fitness   # Fitness of current elite
@@ -36,7 +36,7 @@ mutable struct ResamplingMemeticSearcher{E<:Evaluator} <: SteppingOptimizer
             resampling_function::Function, name::String) where {E<:Evaluator}
         params = chain(RSDefaultParameters, parameters)
         elite = rand_individual(search_space(evaluator))
-        diams = diameters(search_space(evaluator))
+        diams = dimdelta(search_space(evaluator))
         new{E}(name, params, evaluator, resampling_function,
                params[:PrecisionRatio] * diams, diams,
                elite, fitness(elite, evaluator))
@@ -128,7 +128,7 @@ function local_search(rms::ResamplingMemeticSearcher, xstart, fitness)
     tfitness = copy(fitness)
 
     searchSpace = search_space(rms.evaluator)
-    ssmins, ssmaxs = mins(searchSpace), maxs(searchSpace)
+    ssmins, ssmaxs = dimmin(searchSpace), dimmax(searchSpace)
     n = numdims(rms.evaluator)
 
     indices = collect(1:n)

--- a/src/search_space.jl
+++ b/src/search_space.jl
@@ -1,21 +1,23 @@
 """
-A `SearchSpace` defines the valid candidate points that could be
-considered in a search/optimization.
-The base abstract class has very few restrictions
-and can allow varying number of dimensions etc.
+A base abstract type for `OptimizationProblem` search space.
+A concrete `SearchSpace` subtype specifies the valid
+candidate points that could be considered in a search/optimization.
 """
 abstract type SearchSpace end
 
 """
-`SearchSpace` with a fixed finite number of dimensions.
+A base abstract type for search spaces with a fixed finite number of dimensions.
 Applicable to the vast majority of problems.
 """
 abstract type FixedDimensionSearchSpace <: SearchSpace end
 
 """
-Fixed-dimensional space, each dimension has a continuous range of valid values.
+A `SearchSpace` with `N`-dimensional rectangle as a set of valid points.
+I.e. `mins(ss)[i]` ≤ `x[i]` ≤ `maxs(ss)[i]` for each dimension `i`.
 """
-abstract type ContinuousSearchSpace <: FixedDimensionSearchSpace end
+abstract type RectSearchSpace <: FixedDimensionSearchSpace end
+
+Base.@deprecate_binding ContinuousSearchSpace RectSearchSpace
 
 """
 The point of the `SearchSpace`.
@@ -33,40 +35,27 @@ The concrete type that could be used for storage.
 const Individual = Vector{Float64}
 
 """
-The valid range of values for a specific dimension in a `SearchSpace`.
+The valid range of values for a specific dimension in a `RectSearchSpace`.
 """
 const ParamBounds = Tuple{Float64,Float64}
+
+numdims(ss::RectSearchSpace) = length(mins(ss))
+
+mins(ss::RectSearchSpace) = ss.mins
+maxs(ss::RectSearchSpace) = ss.maxs
+deltas(ss::RectSearchSpace) = ss.deltas
+diameters(ss::RectSearchSpace) = deltas(ss)
 
 """
 Get the range of valid values for a specific dimension.
 """
-range_for_dim(ss::ContinuousSearchSpace, i) = (mins(ss)[i], maxs(ss)[i])
-
-ranges(ss::ContinuousSearchSpace) = collect(zip(mins(ss), maxs(ss)))
-
-"""
-Generate `numIndividuals` individuals by random sampling in the search space.
-"""
-rand_individuals(ss::ContinuousSearchSpace, numIndividuals) =
-    mins(ss) .+ deltas(ss) .* rand(numdims(ss), numIndividuals)
-
-"""
-Generate `numIndividuals` individuals by latin hypercube sampling (LHS).
-This should be the default way to create the initial population.
-"""
-rand_individuals_lhs(ss::ContinuousSearchSpace, numIndividuals) =
-    Utils.latin_hypercube_sampling(mins(ss), maxs(ss), numIndividuals)
-
-"""
-Generate one random candidate.
-"""
-rand_individual(ss::ContinuousSearchSpace) =
-    mins(ss) .+ deltas(ss) .* rand(numdims(ss))
+range_for_dim(ss::RectSearchSpace, i::Integer) = (mins(ss)[i], maxs(ss)[i])
+ranges(ss::RectSearchSpace) = collect(zip(dimmins(ss), dimmaxs(ss)))
 
 """
 Check if given individual lies in the given search space.
 """
-function Base.in(ind::AbstractIndividual, ss::ContinuousSearchSpace)
+function Base.in(ind::AbstractIndividual, ss::RectSearchSpace)
     @assert length(ind) == numdims(ss)
     @inbounds for i in eachindex(ind)
         (mins(ss)[i] <= ind[i] <= maxs(ss)[i]) || return false
@@ -75,51 +64,79 @@ function Base.in(ind::AbstractIndividual, ss::ContinuousSearchSpace)
 end
 
 """
-`SearchSpace` defined by a range of valid values for each dimension.
+`SearchSpace` defined by a continuous range of valid values for each dimension.
 """
-struct RangePerDimSearchSpace <: ContinuousSearchSpace
+struct ContinuousRectSearchSpace <: RectSearchSpace
     # We save the ranges as individual mins, maxs and deltas for faster access later.
     mins::Vector{Float64}
     maxs::Vector{Float64}
     deltas::Vector{Float64}
 
-    function RangePerDimSearchSpace(ranges)
-        mins = getindex.(ranges, 1)
-        maxs = getindex.(ranges, 2)
+    function ContinuousRectSearchSpace(
+        mins::AbstractVector{<:Real},
+        maxs::AbstractVector{<:Real}
+    )
+        length(mins) == length(maxs) ||
+            throw(DimensionMismatch("mins and maxs should have the same length"))
+        all(xy -> xy[1] <= xy[2], zip(mins, maxs)) ||
+            throw(ArgumentError("mins should not exceed maxs"))
         new(mins, maxs, maxs .- mins)
     end
-
-    RangePerDimSearchSpace(mins, maxs) = new(mins, maxs, maxs .- mins)
 end
 
-mins(ss::RangePerDimSearchSpace) = ss.mins
-maxs(ss::RangePerDimSearchSpace) = ss.maxs
-deltas(ss::RangePerDimSearchSpace) = ss.deltas
-numdims(ss::RangePerDimSearchSpace) = length(mins(ss))
+ContinuousRectSearchSpace(ranges) =
+    ContinuousRectSearchSpace(getindex.(ranges, 1), getindex.(ranges, 2))
 
-diameters(ss::RangePerDimSearchSpace) = deltas(ss)
-
-Base.:(==)(a::RangePerDimSearchSpace, b::RangePerDimSearchSpace) =
+Base.:(==)(a::ContinuousRectSearchSpace,
+           b::ContinuousRectSearchSpace) =
     numdims(a) == numdims(b) && (a.mins == b.mins) && (a.maxs == b.maxs)
 
 """
-Create `RangePerDimSearchSpace` with given number of dimensions
-and given range of valid values for each dimension.
+Generate one random candidate.
 """
-symmetric_search_space(numdims, range=(0.0, 1.0)) = RangePerDimSearchSpace(fill(range, numdims))
+rand_individual(ss::ContinuousRectSearchSpace) =
+    mins(ss) .+ deltas(ss) .* rand(numdims(ss))
+
+"""
+Generate `n` individuals by random sampling in the search space.
+"""
+rand_individuals(ss::ContinuousRectSearchSpace, n::Integer) =
+    mins(ss) .+ deltas(ss) .* rand(numdims(ss), n)
+
+"""
+Generate `n` individuals by latin hypercube sampling (LHS).
+This should be the default way to create the initial population.
+"""
+rand_individuals_lhs(ss::ContinuousRectSearchSpace, n::Integer) =
+    Utils.latin_hypercube_sampling(mins(ss), maxs(ss), n)
 
 """
 Projects a given point onto the search space coordinate-wise.
 """
-feasible(v::AbstractIndividual, ss::RangePerDimSearchSpace) = clamp.(v, mins(ss), maxs(ss))
+feasible(v::AbstractIndividual, ss::ContinuousRectSearchSpace) =
+    clamp.(v, mins(ss), maxs(ss))
 
 # concatenates two range-based search spaces
-Base.vcat(ss1::RangePerDimSearchSpace, ss2::RangePerDimSearchSpace) =
-    RangePerDimSearchSpace(vcat(mins(ss1), mins(ss2)),
-                           vcat(maxs(ss1), maxs(ss2)))
+Base.vcat(ss1::ContinuousRectSearchSpace,
+          ss2::ContinuousRectSearchSpace) =
+    ContinuousRectSearchSpace(vcat(mins(ss1), mins(ss2)),
+                              vcat(maxs(ss1), maxs(ss2)))
 
 """
 0-dimensional search space.
 Could be used as a placeholder for optional `SearchSpace` parameters.
 """
-const ZERO_SEARCH_SPACE = RangePerDimSearchSpace(Vector{Float64}(), Vector{Float64}())
+const ZERO_SEARCH_SPACE = ContinuousRectSearchSpace(Vector{Float64}(), Vector{Float64}())
+
+"""
+Create `RectSearchSpace` with given range of valid values for each dimension.
+"""
+RectSearchSpace(ranges::AbstractVector) =
+    ContinuousRectSearchSpace(ranges)
+
+"""
+Create `RectSearchSpace` with given number of dimensions
+and given range of valid values for each dimension.
+"""
+symmetric_search_space(numdims::Integer, range=(0.0, 1.0)) =
+    RectSearchSpace(fill(range, numdims))

--- a/src/search_space.jl
+++ b/src/search_space.jl
@@ -179,5 +179,7 @@ RectSearchSpace(ranges::AbstractVector) =
 Create `RectSearchSpace` with given number of dimensions
 and given range of valid values for each dimension.
 """
-symmetric_search_space(numdims::Integer, range=(0.0, 1.0)) =
+RectSearchSpace(numdims::Integer, range=(0.0, 1.0)) =
     RectSearchSpace(fill(range, numdims))
+
+@deprecate symmetric_search_space(numdims, range=(0.0, 1.0)) RectSearchSpace(numdims, range)

--- a/src/search_space.jl
+++ b/src/search_space.jl
@@ -40,36 +40,36 @@ const ParamBounds = Tuple{Float64,Float64}
 """
 Get the range of valid values for a specific dimension.
 """
-range_for_dim(css::ContinuousSearchSpace, i) = (mins(css)[i], maxs(css)[i])
+range_for_dim(ss::ContinuousSearchSpace, i) = (mins(ss)[i], maxs(ss)[i])
 
-ranges(css::ContinuousSearchSpace) = collect(zip(mins(css), maxs(css)))
+ranges(ss::ContinuousSearchSpace) = collect(zip(mins(ss), maxs(ss)))
 
 """
 Generate `numIndividuals` individuals by random sampling in the search space.
 """
-rand_individuals(css::ContinuousSearchSpace, numIndividuals) =
-    mins(css) .+ deltas(css) .* rand(numdims(css), numIndividuals)
+rand_individuals(ss::ContinuousSearchSpace, numIndividuals) =
+    mins(ss) .+ deltas(ss) .* rand(numdims(ss), numIndividuals)
 
 """
 Generate `numIndividuals` individuals by latin hypercube sampling (LHS).
 This should be the default way to create the initial population.
 """
-rand_individuals_lhs(css::ContinuousSearchSpace, numIndividuals) =
-    Utils.latin_hypercube_sampling(mins(css), maxs(css), numIndividuals)
+rand_individuals_lhs(ss::ContinuousSearchSpace, numIndividuals) =
+    Utils.latin_hypercube_sampling(mins(ss), maxs(ss), numIndividuals)
 
 """
 Generate one random candidate.
 """
-rand_individual(css::ContinuousSearchSpace) =
-    mins(css) .+ deltas(css) .* rand(numdims(css))
+rand_individual(ss::ContinuousSearchSpace) =
+    mins(ss) .+ deltas(ss) .* rand(numdims(ss))
 
 """
 Check if given individual lies in the given search space.
 """
-function Base.in(ind::AbstractIndividual, css::ContinuousSearchSpace)
-    @assert length(ind) == numdims(css)
+function Base.in(ind::AbstractIndividual, ss::ContinuousSearchSpace)
+    @assert length(ind) == numdims(ss)
     @inbounds for i in eachindex(ind)
-        (mins(css)[i] <= ind[i] <= maxs(css)[i]) || return false
+        (mins(ss)[i] <= ind[i] <= maxs(ss)[i]) || return false
     end
     return true
 end
@@ -92,12 +92,12 @@ struct RangePerDimSearchSpace <: ContinuousSearchSpace
     RangePerDimSearchSpace(mins, maxs) = new(mins, maxs, maxs .- mins)
 end
 
-mins(rss::RangePerDimSearchSpace) = rss.mins
-maxs(rss::RangePerDimSearchSpace) = rss.maxs
-deltas(rss::RangePerDimSearchSpace) = rss.deltas
-numdims(rss::RangePerDimSearchSpace) = length(mins(rss))
+mins(ss::RangePerDimSearchSpace) = ss.mins
+maxs(ss::RangePerDimSearchSpace) = ss.maxs
+deltas(ss::RangePerDimSearchSpace) = ss.deltas
+numdims(ss::RangePerDimSearchSpace) = length(mins(ss))
 
-diameters(rss::RangePerDimSearchSpace) = deltas(rss)
+diameters(ss::RangePerDimSearchSpace) = deltas(ss)
 
 Base.:(==)(a::RangePerDimSearchSpace, b::RangePerDimSearchSpace) =
     numdims(a) == numdims(b) && (a.mins == b.mins) && (a.maxs == b.maxs)

--- a/src/search_space.jl
+++ b/src/search_space.jl
@@ -13,7 +13,7 @@ abstract type FixedDimensionSearchSpace <: SearchSpace end
 
 """
 A `SearchSpace` with `N`-dimensional rectangle as a set of valid points.
-I.e. `dimmin(ss)[i]` ≤ `x[i]` ≤ `dimmax(ss)[i]` for each dimension `i`.
+I.e. `dimmin(ss, i)` ≤ `x[i]` ≤ `dimmax(ss, i)` for each dimension `i`.
 """
 abstract type RectSearchSpace <: FixedDimensionSearchSpace end
 
@@ -42,26 +42,35 @@ const ParamBounds = Tuple{Float64,Float64}
 numdims(ss::RectSearchSpace) = length(dimmin(ss))
 
 """
-    dimmin(ss::SearchSpace)
+    dimmin(ss::SearchSpace, [i::Integer])
 
-A vector of minimal valid values for each dimension of `ss`.
+A minimal valid value for `i`-th dimension of `ss`, or a vector of
+minimal valid values for each dimension of `ss` if no `i` was given.
 """
 dimmin(ss::RectSearchSpace) = ss.dimmin
 
-"""
-    dimmax(ss::SearchSpace)
+dimmin(ss::RectSearchSpace, i::Integer) = ss.dimmin[i]
 
-A vector of maximal valid values for each dimension of `ss`.
+"""
+    dimmax(ss::SearchSpace, [i::Integer])
+
+A maximal valid value for `i`-th dimension of `ss`, or a vector of
+maximal valid values for each dimension of `ss` if no `i` was given.
 """
 dimmax(ss::RectSearchSpace) = ss.dimmax
 
-"""
-    dimdelta(ss::SearchSpace)
+dimmax(ss::RectSearchSpace, i::Integer) = ss.dimmax[i]
 
-A vector of deltas between maximal and minimal valid values
-for each dimension of `ss`.
+"""
+    dimdelta(ss::SearchSpace, [i::Integer])
+
+A delta of maximal and minimal valid values for `i`-th dimension of `ss`
+(*diameter* of `i`-th dimension), or a vector of deltas for each dimension
+if no `i` given.
 """
 dimdelta(ss::RectSearchSpace) = ss.dimdelta
+
+dimdelta(ss::RectSearchSpace, i::Integer) = ss.dimdelta[i]
 
 @deprecate mins(ss) dimmin(ss)
 @deprecate maxs(ss) dimmax(ss)
@@ -75,19 +84,21 @@ Gets a `ParamsRange` tuple of minimal and maximal valid values for
 `i`-th dimension of `ss`, or a vector of `ParamsRange` tuples
 for each dimension if no `i` given.
 """
-dimrange(ss::RectSearchSpace, i::Integer) = (dimmin(ss)[i], dimmax(ss)[i])
+dimrange(ss::RectSearchSpace, i::Integer) = (dimmin(ss, i), dimmax(ss, i))
 @deprecate range_for_dim(ss, i) dimrange(ss, i)
 
 dimrange(ss::RectSearchSpace) = tuple.(dimmin(ss), dimmax(ss))
 @deprecate ranges(ss) dimrange(ss)
 
 """
+    in(ind::AbstractIndividual, ss::SearchSpace)
+
 Check if given individual lies in the given search space.
 """
 function Base.in(ind::AbstractIndividual, ss::RectSearchSpace)
     @assert length(ind) == numdims(ss)
     @inbounds for i in eachindex(ind)
-        (dimmin(ss)[i] <= ind[i] <= dimmax(ss)[i]) || return false
+        (dimmin(ss, i) <= ind[i] <= dimmax(ss, i)) || return false
     end
     return true
 end

--- a/test/problems/test_problem.jl
+++ b/test/problems/test_problem.jl
@@ -9,7 +9,7 @@ fsum_abs_and_sq(x) = (sum(abs, x), sum(abs2, x))
     @test fitness_scheme(p) == MinimizingFitnessScheme
     @test numobjectives(p) == 1
     @test numdims(p) == 1
-    @test search_space(p) == symmetric_search_space(1, (-1.0, 1.0))
+    @test search_space(p) == RectSearchSpace(1, (-1.0, 1.0))
 
     @test fitness([0.0], p) == 0.0
     @test fitness([1.2], p) == 1.2
@@ -22,14 +22,14 @@ end
     @test fitness_scheme(p) == MinimizingFitnessScheme
     @test numobjectives(p) == 1
     @test numdims(p) == 3
-    @test search_space(p) == symmetric_search_space(3, (-1.0, 1.0))
+    @test search_space(p) == RectSearchSpace(3, (-1.0, 1.0))
 
     @test fitness([0.0, 1.0, 2.0], p) == 3.0
     @test fitness([-1.0, 1.0, 2.0], p) == 4.0
 end
 
 @testset "1-dimensional, multi-objective sumabs_sumsq" begin
-    ss = symmetric_search_space(1)
+    ss = RectSearchSpace(1)
     p = FunctionBasedProblem(fsum_abs_and_sq, "sumabs_sumsq",
                              ParetoFitnessScheme{2}(), ss, (0.0, 0.0))
 
@@ -73,7 +73,7 @@ end
     @test BlackBoxOptim.orig_problem(sp) === p
     @test numobjectives(sp) == 1
     @test numdims(sp) == 1
-    @test search_space(sp) == symmetric_search_space(1, (-1.0, 1.0))
+    @test search_space(sp) == RectSearchSpace(1, (-1.0, 1.0))
     xs = sp.xshift
     @test xs == [0.5]
     @test sp.fitshift == 0.0
@@ -84,7 +84,7 @@ end
 end
 
 @testset "Shifted and biased 2-dim" begin
-    ss = symmetric_search_space(2, (-0.5, 1.0))
+    ss = RectSearchSpace(2, (-0.5, 1.0))
     p = minimization_problem(fsabs, "sumabs", (-0.5, 1.0), 2, 0.0)
     sp = BlackBoxOptim.ShiftedAndBiasedProblem(p; fitshift = 1.3)
 
@@ -93,7 +93,7 @@ end
     @test numdims(sp) == 2
     @test sp.xshift == [0.0, 0.0]
     @test sp.fitshift == 1.3
-    @test search_space(sp) == symmetric_search_space(2, (-0.5, 1.0))
+    @test search_space(sp) == RectSearchSpace(2, (-0.5, 1.0))
 
     xs = sp.xshift
     @test fitness([0.0, 1.0], sp) == 1.0 + 1.3

--- a/test/problems/test_single_objective.jl
+++ b/test/problems/test_single_objective.jl
@@ -13,7 +13,7 @@
 
     p2 = instantiate(p, 3)
     @test numdims(p2) == 3
-    @test ranges(search_space(p2)) == [(-100.0, 100.0), (-100.0, 100.0), (-100.0, 100.0)]
+    @test dimrange(search_space(p2)) == [(-100.0, 100.0), (-100.0, 100.0), (-100.0, 100.0)]
 end
 
 @testset "Schwefel2.22" begin
@@ -29,7 +29,7 @@ end
 
     p2 = instantiate(p, 4)
     @test numdims(p2) == 4
-    @test ranges(search_space(p2)) == [(-10.0, 10.0), (-10.0, 10.0), (-10.0, 10.0), (-10.0, 10.0)]
+    @test dimrange(search_space(p2)) == [(-10.0, 10.0), (-10.0, 10.0), (-10.0, 10.0), (-10.0, 10.0)]
 end
 
 @testset "Schwefel1.2" begin

--- a/test/test_adaptive_differential_evolution.jl
+++ b/test/test_adaptive_differential_evolution.jl
@@ -2,7 +2,7 @@ NumTestRepetitions = 100
 
 @testset "Adaptive differential evolution optimizer" begin
 
-ss = symmetric_search_space(1, (0.0, 10.0))
+ss = RectSearchSpace(1, (0.0, 10.0))
 fake_problem = FunctionBasedProblem(x -> 0.0, "test_problem", MinimizingFitnessScheme, ss)
 
 ade = adaptive_de_rand_1_bin(fake_problem, ParamsDict(

--- a/test/test_adaptive_differential_evolution.jl
+++ b/test/test_adaptive_differential_evolution.jl
@@ -31,11 +31,11 @@ end
 
         @test ndims(trial.params) == 1
         @test (1 <= trial.index <= popsize(ade))
-        @test in(trial.params, ade.embed.searchSpace)
+        @test in(trial.params, search_space(ade.embed))
 
         @test ndims(target.params) == 1
         @test (1 <= target.index <= popsize(ade))
-        @test in(target.params, ade.embed.searchSpace)
+        @test in(target.params, search_space(ade.embed))
 
         @test trial.index == target.index
     end

--- a/test/test_crossover_operators.jl
+++ b/test/test_crossover_operators.jl
@@ -1,6 +1,6 @@
 @testset "Crossover operators" begin
 
-ss = symmetric_search_space(1, (0.0, 10.0))
+ss = RectSearchSpace(1, (0.0, 10.0))
 fake_problem = FunctionBasedProblem(x -> 0.0, "test_problem", MinimizingFitnessScheme, ss)
 DE = de_rand_1_bin(fake_problem, ParamsDict(
     :Population => reshape(collect(1.0:10.0), (1, 10)),
@@ -63,7 +63,7 @@ DE = de_rand_1_bin(fake_problem, ParamsDict(
 end
 
 @testset "MutationWrapper" begin
-    ss = symmetric_search_space(2, (0.0, 10.0))
+    ss = RectSearchSpace(2, (0.0, 10.0))
     pop = reshape(collect(1.0:8.0), 2, 4)
     gibbs = UniformMutation(ss)
     gibbs_wrapper = BlackBoxOptim.MutationWrapper(gibbs)

--- a/test/test_differential_evolution.jl
+++ b/test/test_differential_evolution.jl
@@ -1,6 +1,6 @@
 @testset "Differential evolution optimizer" begin
 
-ss = symmetric_search_space(1, (0.0, 10.0))
+ss = RectSearchSpace(1, (0.0, 10.0))
 fake_problem = FunctionBasedProblem(x -> 0.0, "test_problem", MinimizingFitnessScheme, ss)
 DE = de_rand_1_bin(fake_problem, ParamsDict(
     :Population => reshape(collect(1.0:10.0), (1, 10)),

--- a/test/test_differential_evolution.jl
+++ b/test/test_differential_evolution.jl
@@ -16,11 +16,11 @@ DE = de_rand_1_bin(fake_problem, ParamsDict(
 
         @test ndims(trial.params) == 1
         @test (1 <= trial.index <= popsize(DE.population))
-        @test in(trial.params, DE.embed.searchSpace)
+        @test in(trial.params, search_space(DE.embed))
 
         @test ndims(target.params) == 1
         @test (1 <= target.index <= popsize(DE.population))
-        @test in(target.params, DE.embed.searchSpace)
+        @test in(target.params, search_space(DE.embed))
 
         @test trial.index == target.index
 

--- a/test/test_embedders.jl
+++ b/test/test_embedders.jl
@@ -2,35 +2,37 @@
 
 @testset "RandomBound" begin
     @testset "does nothing if within bounds" begin
-        @test apply!(RandomBound([(0.0, 1.0)]), [0.0], [0.0]) == [0.0]
+        @test apply!(RandomBound(RectSearchSpace(1, (0.0, 1.0))), [0.0], [0.0]) == [0.0]
 
-        @test apply!(RandomBound([(0.0, 1.0), (10.0, 15.0)]),
+        @test apply!(RandomBound(RectSearchSpace([(0.0, 1.0), (10.0, 15.0)])),
                      [0.0, 11.4], [0.1, 12.3] ) == [0.0, 11.4]
     end
 
     @testset "bounds if lower than min bound" begin
-        @test apply!(RandomBound([(0.0, 1.0)]), [-0.1], [0.0]) == [0.0]
+        @test apply!(RandomBound(RectSearchSpace([(0.0, 1.0)])),
+                     [-0.1], [0.0]) == [0.0]
 
-        res = apply!(RandomBound([(0.0, 1.0)]), [-0.1], [0.5])
-        @test res[1] >= 0.0
-        @test res[1] <= 0.5
+        res = apply!(RandomBound(RectSearchSpace([(0.0, 1.0)])),
+                     [-0.1], [0.5])
+        @test 0.0 <= res[1] <= 0.5
 
-        res = apply!(RandomBound([(-11.0, 1.0), (0.0, 1.0)]),
-                                                            [-11.1, 0.5], [-10.8, 0.5])
-        @test (-10.8 >= res[1] >= -11.0)
+        res = apply!(RandomBound(RectSearchSpace([(-11.0, 1.0), (0.0, 1.0)])),
+                     [-11.1, 0.5], [-10.8, 0.5])
+        @test -10.8 >= res[1] >= -11.0
         @test res[2] == 0.5
 
-        res = apply!(RandomBound([(30.0, 60.0), (-102.0, -1.0)]),
+        res = apply!(RandomBound(RectSearchSpace([(30.0, 60.0), (-102.0, -1.0)])),
                      [50.4, -103.1], [49.6, -101.4])
         @test res[1] == 50.4
-        @test (-101.4 >= res[2] >= -102.0)
+        @test -101.4 >= res[2] >= -102.0
     end
 
     @testset "bounds if higher than max bound" begin
-        @test apply!(RandomBound([(0.0, 1.0)]), [1.1], [1.0]) == [1.0]
+        @test apply!(RandomBound(RectSearchSpace([(0.0, 1.0)])),
+                     [1.1], [1.0]) == [1.0]
 
-        res = apply!(RandomBound([(-10.0, 96.0)]), [97.0], [95.0])
-        @test (95.0 <= res[1] <= 96.0)
+        res = apply!(RandomBound(RectSearchSpace([(-10.0, 96.0)])), [97.0], [95.0])
+        @test 95.0 <= res[1] <= 96.0
     end
 end
 

--- a/test/test_embedders.jl
+++ b/test/test_embedders.jl
@@ -34,6 +34,14 @@
         res = apply!(RandomBound(RectSearchSpace([(-10.0, 96.0)])), [97.0], [95.0])
         @test 95.0 <= res[1] <= 96.0
     end
+
+    @testset "MixedPrecisionRectSearchSpace" begin
+        ss = RectSearchSpace([(0.0, 1.0), (1.0, 2.0), (2.0, 3.0)], dimdigits=[-1, 0, 2])
+
+        @test apply!(RandomBound(ss), [0.0, 1.4, 2.1], [0.0, 1.45, 2.0]) == [0.0, 1.0, 2.1]
+        @test apply!(RandomBound(ss), [0.0, 5.0, 0.123], [0.0, 1.5, 2.0]) == [0.0, 2.0, 2.0]
+        @test apply!(RandomBound(ss), [1.12345, 1.12345, 2.1234], [1.0, 2.0, 3.0]) == [1.0, 1.0, 2.12]
+    end
 end
 
 end

--- a/test/test_fitness.jl
+++ b/test/test_fitness.jl
@@ -18,9 +18,15 @@
     @testset "ScalarFitnessScheme" begin
         @testset "is_minimizing()" begin
             mins = MinimizingFitnessScheme
+            @test numobjectives(mins) == 1
+            @test fitness_type(mins) === Float64
+            @test fitness_eltype(mins) === Float64
             @test is_minimizing(mins)
 
             maxs = MaximizingFitnessScheme
+            @test numobjectives(maxs) == 1
+            @test fitness_type(maxs) === Float64
+            @test fitness_eltype(maxs) === Float64
             @test is_minimizing(maxs) == false
         end
 
@@ -57,6 +63,8 @@
             @testset "ParetoFitnessScheme{1}" begin
                 scheme = ParetoFitnessScheme{1}()
                 @test numobjectives(scheme) == 1
+                @test fitness_type(scheme) === Tuple{Float64}
+                @test fitness_eltype(scheme) === Float64
                 @test is_minimizing(scheme)
                 @test isnafitness(nafitness(scheme), scheme)
                 @test isequal(nafitness(scheme), (NaN,))
@@ -66,6 +74,8 @@
 
             @testset "ParetoFitnessScheme{1}(is_minimizing=false)" begin
                 scheme = ParetoFitnessScheme{1}(is_minimizing=false)
+                @test fitness_type(scheme) == NTuple{1, Float64}
+                @test fitness_eltype(scheme) === Float64
                 @test numobjectives(scheme) == 1
                 @test is_minimizing(scheme) == false
                 @test isnafitness(nafitness(scheme), scheme)
@@ -74,8 +84,23 @@
                 @test isnafitness((1.0,), scheme) == false
             end
 
+            @testset "ParetoFitnessScheme{2}()" begin
+                scheme = ParetoFitnessScheme{2}()
+                @test fitness_type(scheme) == NTuple{2, Float64}
+                @test fitness_eltype(scheme) === Float64
+                @test isequal(nafitness(scheme), (NaN,NaN))
+                @test numobjectives(scheme) == 2
+                @test is_minimizing(scheme)
+                @test isnafitness(nafitness(scheme), scheme)
+                @test isnafitness((NaN, NaN), scheme)
+                @test isnafitness((1.0, NaN), scheme)
+                @test !isnafitness((1.0, 2.0), scheme)
+            end
+
             @testset "ParetoFitnessScheme{3}()" begin
                 scheme = ParetoFitnessScheme{3}()
+                @test fitness_type(scheme) == NTuple{3, Float64}
+                @test fitness_eltype(scheme) === Float64
                 @test isequal(nafitness(scheme), (NaN,NaN,NaN))
                 @test numobjectives(scheme) == 3
                 @test is_minimizing(scheme)
@@ -238,6 +263,10 @@
         @testset "hat_compare(..., EpsBoxDominanceFitnessScheme{2}(...))" begin
             minscheme = EpsBoxDominanceFitnessScheme{2}(0.1, is_minimizing=true)
             maxscheme = EpsBoxDominanceFitnessScheme{2}(0.1, is_minimizing=false)
+
+            @test numobjectives(minscheme) == numobjectives(maxscheme) == 2
+            @test fitness_type(minscheme) === fitness_type(maxscheme) === IndexedTupleFitness{2, Float64}
+            @test fitness_eltype(minscheme) === fitness_eltype(maxscheme) === Float64
 
             @test isnafitness(nafitness(minscheme), minscheme)
             @test isnafitness(nafitness(maxscheme), minscheme)

--- a/test/test_generating_set_search.jl
+++ b/test/test_generating_set_search.jl
@@ -1,9 +1,9 @@
 @testset "Generating set search" begin
 
-    ss = symmetric_search_space(3, (0.0, 1.0))
+    ss = RectSearchSpace(3, (0.0, 1.0))
     @test BlackBoxOptim.calc_initial_step_size(ss) == (0.5 * (1.0 - 0.0))
 
-    ss = symmetric_search_space(3, (-1.2, 42.0))
+    ss = RectSearchSpace(3, (-1.2, 42.0))
     @test BlackBoxOptim.calc_initial_step_size(ss, 0.80) == (0.80 * (42.0 + 1.2))  
 
 end

--- a/test/test_mutation_operators.jl
+++ b/test/test_mutation_operators.jl
@@ -1,5 +1,5 @@
 @testset "Mutation operators" begin
-    ss = RangePerDimSearchSpace([(-1.0, 1.0), (0.0, 100.0), (-5.0, 0.0)])
+    ss = RectSearchSpace([(-1.0, 1.0), (0.0, 100.0), (-5.0, 0.0)])
 
     @testset "UniformMutation" begin
         gibbs = UniformMutation(ss)

--- a/test/test_mutation_operators.jl
+++ b/test/test_mutation_operators.jl
@@ -9,10 +9,10 @@
         @test_throws BoundsError BlackBoxOptim.apply(gibbs, 2.0, 0, 1)
         @test_throws BoundsError BlackBoxOptim.apply(gibbs, 2.0, 4, 1)
 
-        for dim in 1:numdims(ss)
-            dim_range = range_for_dim(ss, dim)
-            for i in 1:NumTestRepetitions
-                t = BlackBoxOptim.apply(gibbs, 0.0, dim, 1)
+        for i in 1:numdims(ss)
+            dim_range = dimrange(ss, i)
+            for _ in 1:NumTestRepetitions
+                t = BlackBoxOptim.apply(gibbs, 0.0, i, 1)
                 @test t >= dim_range[1]
                 @test t <= dim_range[2]
             end

--- a/test/test_random_search.jl
+++ b/test/test_random_search.jl
@@ -6,7 +6,7 @@
         min = rand(1:123)
         range = (min * rand(), min + rand() * min)
 
-        ss = BlackBoxOptim.symmetric_search_space(dims, range)
+        ss = RectSearchSpace(dims, range)
         opt = BlackBoxOptim.random_search(ss)
 
         res1 = BlackBoxOptim.ask(opt)

--- a/test/test_search_space.jl
+++ b/test/test_search_space.jl
@@ -5,7 +5,7 @@
             ss1 = symmetric_search_space(reps, (0.0, 1.0))
             ind = rand_individual(ss1)
             for j in 1:reps
-                @test (dimmin(ss1)[j] <= ind[j] <= dimmax(ss1)[j])
+                @test (dimmin(ss1, j) <= ind[j] <= dimmax(ss1, j))
             end
         end
     end
@@ -13,8 +13,14 @@
     @testset "Symmetric search space with default range" begin
         ss1 = symmetric_search_space(1)
         @test numdims(ss1) == 1
+        @test dimmin(ss1) == [0.0]
+        @test dimmin(ss1, 1) == 0.0
+        @test dimmax(ss1) == [1.0]
+        @test dimmax(ss1, 1) == 1.0
+        @test dimdelta(ss1) == [1.0]
+        @test dimdelta(ss1, 1) == 1.0
         @test dimrange(ss1) == [(0.0, 1.0)]
-        @test dimrange(ss1,1) == (0.0, 1.0)
+        @test dimrange(ss1, 1) == (0.0, 1.0)
 
         for i in 1:NumTestRepetitions
             ind = rand_individual(ss1)
@@ -24,10 +30,16 @@
 
         ss3 = symmetric_search_space(3)
         @test numdims(ss3) == 3
+        @test dimmin(ss3) == [0.0, 0.0, 0.0]
+        @test dimmin(ss3, 2) == 0.0
+        @test dimmax(ss3) == [1.0, 1.0, 1.0]
+        @test dimmax(ss3, 2) == 1.0
+        @test dimdelta(ss3) == [1.0, 1.0, 1.0]
+        @test dimdelta(ss3, 2) == 1.0
         @test dimrange(ss3) == [(0.0, 1.0), (0.0, 1.0), (0.0, 1.0)]
-        @test dimrange(ss3,1) == (0.0, 1.0)
-        @test dimrange(ss3,2) == (0.0, 1.0)
-        @test dimrange(ss3,3) == (0.0, 1.0)
+        @test dimrange(ss3, 1) == (0.0, 1.0)
+        @test dimrange(ss3, 2) == (0.0, 1.0)
+        @test dimrange(ss3, 3) == (0.0, 1.0)
 
         for i in 1:NumTestRepetitions
             ind = rand_individual(ss3)
@@ -42,7 +54,7 @@
         @test ss1 isa ContinuousRectSearchSpace
         @test numdims(ss1) == 1
         @test dimrange(ss1) == [(-1.0, 1.0)]
-        @test dimrange(ss1,1) == (-1.0, 1.0)
+        @test dimrange(ss1, 1) == (-1.0, 1.0)
 
         for i in 1:NumTestRepetitions
             reps = rand(1:100)

--- a/test/test_search_space.jl
+++ b/test/test_search_space.jl
@@ -2,7 +2,7 @@
     @testset "in()" begin
         for i in 1:NumTestRepetitions
             reps = rand(1:10)
-            ss1 = symmetric_search_space(reps, (0.0, 1.0))
+            ss1 = RectSearchSpace(reps, (0.0, 1.0))
             ind = rand_individual(ss1)
             for j in 1:reps
                 @test (dimmin(ss1, j) <= ind[j] <= dimmax(ss1, j))
@@ -11,7 +11,7 @@
     end
 
     @testset "Symmetric search space with default range" begin
-        ss1 = symmetric_search_space(1)
+        ss1 = RectSearchSpace(1)
         @test numdims(ss1) == 1
         @test dimmin(ss1) == [0.0]
         @test dimmin(ss1, 1) == 0.0
@@ -28,7 +28,7 @@
             @test in(ind, ss1)
         end
 
-        ss3 = symmetric_search_space(3)
+        ss3 = RectSearchSpace(3)
         @test numdims(ss3) == 3
         @test dimmin(ss3) == [0.0, 0.0, 0.0]
         @test dimmin(ss3, 2) == 0.0
@@ -49,8 +49,8 @@
     end
 
     @testset "ContinuousRectSearchSpace with given range" begin
-        ss1 = symmetric_search_space(1, (-1.0, 1.0))
-        @test_throws ArgumentError symmetric_search_space(1, (0.0, -1.0))
+        ss1 = RectSearchSpace(1, (-1.0, 1.0))
+        @test_throws ArgumentError RectSearchSpace(1, (0.0, -1.0))
         @test ss1 isa ContinuousRectSearchSpace
         @test numdims(ss1) == 1
         @test dimrange(ss1) == [(-1.0, 1.0)]
@@ -60,7 +60,7 @@
             reps = rand(1:100)
             a = rand()
             range = (a, a + (1-a)*rand())
-            ss = symmetric_search_space(reps, range)
+            ss = RectSearchSpace(reps, range)
             @test numdims(ss) == reps
             @test all(dr -> dr == range, dimrange(ss))
         end
@@ -71,7 +71,7 @@
             reps = rand(1:100)
             mm = sort(rand(2,1), dims=1)
             range = (mm[1], mm[2])
-            ss = symmetric_search_space(reps, range)
+            ss = RectSearchSpace(reps, range)
             ind = rand_individual(ss)
             @test length(ind) == numdims(ss)
             @test in(ind, ss)
@@ -83,7 +83,7 @@
             reps = rand(1:10)
             mm = sort(rand(2,1), dims=1)
             range = (mm[1], mm[2])
-            ss = symmetric_search_space(reps, range)
+            ss = RectSearchSpace(reps, range)
             numinds = rand(1:10)
             inds = rand_individuals(ss, numinds)
             @test size(inds,1) == numdims(ss)

--- a/test/test_search_space.jl
+++ b/test/test_search_space.jl
@@ -10,148 +10,148 @@
         end
     end
 
-    @testset "Symmetric search space with default range" begin
-        ss1 = RectSearchSpace(1)
-        @test numdims(ss1) == 1
-        @test dimmin(ss1) == [0.0]
-        @test dimmin(ss1, 1) == 0.0
-        @test dimmax(ss1) == [1.0]
-        @test dimmax(ss1, 1) == 1.0
-        @test dimdelta(ss1) == [1.0]
-        @test dimdelta(ss1, 1) == 1.0
-        @test dimrange(ss1) == [(0.0, 1.0)]
-        @test dimrange(ss1, 1) == (0.0, 1.0)
+    @testset "RectSearchSpace" begin
+        @testset "RectSearchSpace() with given ranges per dimension" begin
+            ss = RectSearchSpace([(0.0, 1.0)])
+            @test dimmin(ss) == [0.0]
+            @test dimmax(ss) == [1.0]
+            @test dimdelta(ss) == [1.0]
 
-        for i in 1:NumTestRepetitions
-            ind = rand_individual(ss1)
-            @test size(ind) == (1,)
-            @test in(ind, ss1)
+            ss = RectSearchSpace([(0.0, 1.0), (0.5, 10.0)])
+            @test dimmin(ss) == [0.0, 0.5]
+            @test dimmax(ss) == [1.0, 10.0]
+            @test dimdelta(ss) == [1.0, 9.5]
         end
 
-        ss3 = RectSearchSpace(3)
-        @test numdims(ss3) == 3
-        @test dimmin(ss3) == [0.0, 0.0, 0.0]
-        @test dimmin(ss3, 2) == 0.0
-        @test dimmax(ss3) == [1.0, 1.0, 1.0]
-        @test dimmax(ss3, 2) == 1.0
-        @test dimdelta(ss3) == [1.0, 1.0, 1.0]
-        @test dimdelta(ss3, 2) == 1.0
-        @test dimrange(ss3) == [(0.0, 1.0), (0.0, 1.0), (0.0, 1.0)]
-        @test dimrange(ss3, 1) == (0.0, 1.0)
-        @test dimrange(ss3, 2) == (0.0, 1.0)
-        @test dimrange(ss3, 3) == (0.0, 1.0)
+        @testset "RectSearchSpace() search space with the default range" begin
+            ss1 = RectSearchSpace(1)
+            @test numdims(ss1) == 1
+            @test dimmin(ss1) == [0.0]
+            @test dimmin(ss1, 1) == 0.0
+            @test dimmax(ss1) == [1.0]
+            @test dimmax(ss1, 1) == 1.0
+            @test dimdelta(ss1) == [1.0]
+            @test dimdelta(ss1, 1) == 1.0
+            @test dimrange(ss1) == [(0.0, 1.0)]
+            @test dimrange(ss1, 1) == (0.0, 1.0)
 
-        for i in 1:NumTestRepetitions
-            ind = rand_individual(ss3)
-            @test size(ind) == (3,)
-            @test in(ind, ss3)
+            for i in 1:NumTestRepetitions
+                ind = rand_individual(ss1)
+                @test size(ind) == (1,)
+                @test in(ind, ss1)
+            end
+
+            ss3 = RectSearchSpace(3)
+            @test numdims(ss3) == 3
+            @test dimmin(ss3) == [0.0, 0.0, 0.0]
+            @test dimmin(ss3, 2) == 0.0
+            @test dimmax(ss3) == [1.0, 1.0, 1.0]
+            @test dimmax(ss3, 2) == 1.0
+            @test dimdelta(ss3) == [1.0, 1.0, 1.0]
+            @test dimdelta(ss3, 2) == 1.0
+            @test dimrange(ss3) == [(0.0, 1.0), (0.0, 1.0), (0.0, 1.0)]
+            @test dimrange(ss3, 1) == (0.0, 1.0)
+            @test dimrange(ss3, 2) == (0.0, 1.0)
+            @test dimrange(ss3, 3) == (0.0, 1.0)
+
+            for i in 1:NumTestRepetitions
+                ind = rand_individual(ss3)
+                @test size(ind) == (3,)
+                @test in(ind, ss3)
+            end
         end
-    end
 
-    @testset "ContinuousRectSearchSpace with given range" begin
-        ss1 = RectSearchSpace(1, (-1.0, 1.0))
-        @test_throws ArgumentError RectSearchSpace(1, (0.0, -1.0))
-        @test ss1 isa ContinuousRectSearchSpace
-        @test numdims(ss1) == 1
-        @test dimrange(ss1) == [(-1.0, 1.0)]
-        @test dimrange(ss1, 1) == (-1.0, 1.0)
+        @testset "ContinuousRectSearchSpace with given range" begin
+            ss1 = RectSearchSpace(1, (-1.0, 1.0))
+            @test_throws ArgumentError RectSearchSpace(1, (0.0, -1.0))
+            @test ss1 isa ContinuousRectSearchSpace
+            @test numdims(ss1) == 1
+            @test dimrange(ss1) == [(-1.0, 1.0)]
+            @test dimrange(ss1, 1) == (-1.0, 1.0)
 
-        for i in 1:NumTestRepetitions
-            reps = rand(1:100)
-            a = rand()
-            range = (a, a + (1-a)*rand())
-            ss = RectSearchSpace(reps, range)
-            @test numdims(ss) == reps
-            @test all(dr -> dr == range, dimrange(ss))
-        end
-    end
-
-    @testset "rand_individual is within the search space" begin
-        for i in 1:NumTestRepetitions
-            reps = rand(1:100)
-            mm = sort(rand(2,1), dims=1)
-            range = (mm[1], mm[2])
-            ss = RectSearchSpace(reps, range)
-            ind = rand_individual(ss)
-            @test length(ind) == numdims(ss)
-            @test in(ind, ss)
-        end
-    end
-
-    @testset "rand_individuals creates many individuals and all are within the search space" begin
-        for i in 1:NumTestRepetitions
-            reps = rand(1:10)
-            mm = sort(rand(2,1), dims=1)
-            range = (mm[1], mm[2])
-            ss = RectSearchSpace(reps, range)
-            numinds = rand(1:10)
-            inds = rand_individuals(ss, numinds)
-            @test size(inds,1) == numdims(ss)
-            @test size(inds,2) == numinds
-            for j in 1:numinds
-                @test in(inds[:,j], ss)
+            for i in 1:NumTestRepetitions
+                dims = rand(1:100)
+                a = rand()
+                range = (a, a + (1-a)*rand())
+                ss = RectSearchSpace(dims, range)
+                @test numdims(ss) == dims
+                @test all(dr -> dr == range, dimrange(ss))
             end
         end
     end
 
-    @testset "rand_individuals correctly handles column-wise generation in assymetric search spaces" begin
-        for _ in 1:NumTestRepetitions÷10
-            numdimensions = rand(1:13)
-            minbounds = rand(numdimensions)
-            ds = rand(1:10, numdimensions) .* rand(numdimensions)
-            maxbounds = minbounds .+ ds
-            parambounds = collect(zip(minbounds, maxbounds))
-            ss = RectSearchSpace(parambounds)
-            @test dimmin(ss) == minbounds
-            @test dimmax(ss) == maxbounds
-            @test round.(dimdelta(ss), digits=6) == round.(ds, digits=6)
+    @testset "rand_individuals()" begin
+        @testset "rand_individual() is within the search space" begin
+            for i in 1:NumTestRepetitions
+                reps = rand(1:100)
+                mm = sort(rand(2,1), dims=1)
+                range = (mm[1], mm[2])
+                ss = RectSearchSpace(reps, range)
+                ind = rand_individual(ss)
+                @test length(ind) == numdims(ss)
+                @test in(ind, ss)
+            end
+        end
 
-            # Now generate 100 individuals and make sure they are all within bounds
-            inds = rand_individuals(ss, 100)
-            @test size(inds, 2) == 100
-            @inbounds for i in 1:size(inds, 2)
-                for d in 1:numdimensions
-                    @test (minbounds[d] <= inds[d,i] <= maxbounds[d])
+        @testset "rand_individuals() creates many individuals and all are within the search space" begin
+            for i in 1:NumTestRepetitions
+                reps = rand(1:10)
+                mm = sort(rand(2,1), dims=1)
+                range = (mm[1], mm[2])
+                ss = RectSearchSpace(reps, range)
+                numinds = rand(1:10)
+                inds = rand_individuals(ss, numinds)
+                @test size(inds,1) == numdims(ss)
+                @test size(inds,2) == numinds
+                for j in 1:numinds
+                    @test in(inds[:,j], ss)
                 end
             end
         end
+
+        @testset "rand_individuals() correctly handles individual dimensions" begin
+            for _ in 1:NumTestRepetitions÷10
+                numdimensions = rand(1:13)
+                minbounds = rand(numdimensions)
+                maxbounds = minbounds .+ rand(1:10, numdimensions) .* rand(numdimensions)
+                ss = RectSearchSpace(tuple.(minbounds, maxbounds))
+                @test dimmin(ss) == minbounds
+                @test dimmax(ss) == maxbounds
+                @test round.(dimdelta(ss), digits=6) == round.(maxbounds .- minbounds, digits=6)
+
+                # Now generate 100 individuals and make sure they are all within bounds
+                inds = rand_individuals(ss, 100)
+                @test size(inds, 2) == 100
+                @inbounds for i in 1:size(inds, 2)
+                    indi = view(inds, :, i)
+                    @test indi == BlackBoxOptim.feasible(indi, ss)
+                    @test all(minbounds .<= indi .<= maxbounds)
+                end
+            end
+        end
+
+        @testset "rand_individuals_lhs() samples in LHS intervals" begin
+            ss = RectSearchSpace([(0.0, 1.0), (2.0, 3.0), (4.0, 5.0)])
+
+            inds = rand_individuals_lhs(ss, 2)
+            @test size(inds, 1) == 3
+            @test size(inds, 2) == 2
+
+            sorted = sort(inds, dims=2) # Sort per row --> in their ordered intervals
+            @test (0.0 <= sorted[1,1] <= 0.5)
+            @test (0.5 <= sorted[1,2] <= 1.0)
+
+            @test (2.0 <= sorted[2,1] <= 2.5)
+            @test (2.5 <= sorted[2,2] <= 3.0)
+
+            @test (4.0 <= sorted[3,1] <= 4.5)
+            @test (4.5 <= sorted[3,2] <= 5.0)
+        end
     end
 
-    @testset "RectSearchSpace" begin
-        ss = RectSearchSpace([(0.0, 1.0)])
-        @test dimmin(ss) == [0.0]
-        @test dimmax(ss) == [1.0]
-        @test dimdelta(ss) == [1.0]
-
-        ss = RectSearchSpace([(0.0, 1.0), (0.5, 10.0)])
-        @test dimmin(ss) == [0.0, 0.5]
-        @test dimmax(ss) == [1.0, 10.0]
-        @test dimdelta(ss) == [1.0, 9.5]
-    end
-
-    @testset "rand_individuals_lhs samples in LHS intervals" begin
+    @testset "feasible(x, ss) projects `x` to the search space `ss`" begin
         ss = RectSearchSpace([(0.0, 1.0), (2.0, 3.0), (4.0, 5.0)])
 
-        inds = rand_individuals_lhs(ss, 2)
-        @test size(inds, 1) == 3
-        @test size(inds, 2) == 2
-
-        sorted = sort(inds, dims=2) # Sort per row --> in their ordered intervals
-        @test (0.0 <= sorted[1,1] <= 0.5)
-        @test (0.5 <= sorted[1,2] <= 1.0)
-
-        @test (2.0 <= sorted[2,1] <= 2.5)
-        @test (2.5 <= sorted[2,2] <= 3.0)
-
-        @test (4.0 <= sorted[3,1] <= 4.5)
-        @test (4.5 <= sorted[3,2] <= 5.0)
-    end
-
-    @testset "feasible finds feasible points in the search space" begin
-        ss = RectSearchSpace([(0.0, 1.0), (2.0, 3.0), (4.0, 5.0)])
-
-        # We use the double transpose below to ensure the actual and expected
-        # values have the same type (matrices, not vectors).
         @test BlackBoxOptim.feasible([1.1, 2.0, 4.0], ss) == [1.0, 2.0, 4.0]
         @test BlackBoxOptim.feasible([1.1, 3.0, 4.0], ss) == [1.0, 3.0, 4.0]
         @test BlackBoxOptim.feasible([1.1, 2.0, 5.0], ss) == [1.0, 2.0, 5.0]
@@ -175,7 +175,7 @@
         @test BlackBoxOptim.feasible([-0.4, 3.3, 14.5], ss) == [0.0, 3.0, 5.0]
     end
 
-    @testset "dimrange" begin
+    @testset "dimrange()" begin
         ss = RectSearchSpace([(0.0, 1.0), (2.0, 3.0), (4.0, 5.0)])
         diams = dimdelta(ss)
 
@@ -183,7 +183,7 @@
         @test diams == [1.0, 1.0, 1.0]
     end
 
-    @testset "concat(ss1, ss2)" begin
+    @testset "vcat(ss1, ss2)" begin
         ss1 = RectSearchSpace([(0.0, 1.0), (2.0, 3.0), (4.0, 5.0)])
         ss2 = RectSearchSpace([(6.0, 7.0), (8.0, 9.0)])
 

--- a/test/test_search_space.jl
+++ b/test/test_search_space.jl
@@ -109,7 +109,8 @@
             end
         end
 
-        @testset "rand_individuals() correctly handles individual dimensions" begin
+        @testset "rand_individuals(method=:$method) correctly handles individual dimensions" for
+                method in (:uniform, :latin_hypercube)
             for _ in 1:NumTestRepetitions÷10
                 numdimensions = rand(1:13)
                 minbounds = rand(numdimensions)
@@ -120,7 +121,7 @@
                 @test round.(dimdelta(ss), digits=6) == round.(maxbounds .- minbounds, digits=6)
 
                 # Now generate 100 individuals and make sure they are all within bounds
-                inds = rand_individuals(ss, 100)
+                inds = rand_individuals(ss, 100, method=method)
                 @test size(inds, 2) == 100
                 @inbounds for i in 1:size(inds, 2)
                     indi = view(inds, :, i)
@@ -130,7 +131,7 @@
             end
         end
 
-        @testset "rand_individuals_lhs() samples in LHS intervals" begin
+        @testset "rand_individuals(method=:latin_hypercube) samples in LHS intervals" begin
             ss = RectSearchSpace([(0.0, 1.0), (2.0, 3.0), (4.0, 5.0)])
 
             inds = rand_individuals_lhs(ss, 2)
@@ -146,6 +147,10 @@
 
             @test (4.0 <= sorted[3,1] <= 4.5)
             @test (4.5 <= sorted[3,2] <= 5.0)
+        end
+
+        @testset "rand_individuals() unknown sampling method" begin
+            @test_throws ArgumentError rand_individuals(RectSearchSpace([(0.0, 1.0), (2.0, 3.0)]), 5, method=:simple)
         end
     end
 

--- a/test/test_search_space.jl
+++ b/test/test_search_space.jl
@@ -5,7 +5,7 @@
             ss1 = symmetric_search_space(reps, (0.0, 1.0))
             ind = rand_individual(ss1)
             for j in 1:reps
-                @test (mins(ss1)[j] <= ind[j] <= maxs(ss1)[j])
+                @test (dimmin(ss1)[j] <= ind[j] <= dimmax(ss1)[j])
             end
         end
     end
@@ -13,8 +13,8 @@
     @testset "Symmetric search space with default range" begin
         ss1 = symmetric_search_space(1)
         @test numdims(ss1) == 1
-        @test ranges(ss1) == [(0.0, 1.0)]
-        @test range_for_dim(ss1,1) == (0.0, 1.0)
+        @test dimrange(ss1) == [(0.0, 1.0)]
+        @test dimrange(ss1,1) == (0.0, 1.0)
 
         for i in 1:NumTestRepetitions
             ind = rand_individual(ss1)
@@ -24,10 +24,10 @@
 
         ss3 = symmetric_search_space(3)
         @test numdims(ss3) == 3
-        @test ranges(ss3) == [(0.0, 1.0), (0.0, 1.0), (0.0, 1.0)]
-        @test range_for_dim(ss3,1) == (0.0, 1.0)
-        @test range_for_dim(ss3,2) == (0.0, 1.0)
-        @test range_for_dim(ss3,3) == (0.0, 1.0)
+        @test dimrange(ss3) == [(0.0, 1.0), (0.0, 1.0), (0.0, 1.0)]
+        @test dimrange(ss3,1) == (0.0, 1.0)
+        @test dimrange(ss3,2) == (0.0, 1.0)
+        @test dimrange(ss3,3) == (0.0, 1.0)
 
         for i in 1:NumTestRepetitions
             ind = rand_individual(ss3)
@@ -36,13 +36,13 @@
         end
     end
 
-    @testset "SymmetricSearchSpace with given range" begin
+    @testset "ContinuousRectSearchSpace with given range" begin
         ss1 = symmetric_search_space(1, (-1.0, 1.0))
         @test_throws ArgumentError symmetric_search_space(1, (0.0, -1.0))
         @test ss1 isa ContinuousRectSearchSpace
         @test numdims(ss1) == 1
-        @test ranges(ss1) == [(-1.0, 1.0)]
-        @test range_for_dim(ss1,1) == (-1.0, 1.0)
+        @test dimrange(ss1) == [(-1.0, 1.0)]
+        @test dimrange(ss1,1) == (-1.0, 1.0)
 
         for i in 1:NumTestRepetitions
             reps = rand(1:100)
@@ -50,7 +50,7 @@
             range = (a, a + (1-a)*rand())
             ss = symmetric_search_space(reps, range)
             @test numdims(ss) == reps
-            @test all([(dr == range) for dr in ranges(ss)])
+            @test all(dr -> dr == range, dimrange(ss))
         end
     end
 
@@ -90,9 +90,9 @@
             maxbounds = minbounds .+ ds
             parambounds = collect(zip(minbounds, maxbounds))
             ss = RectSearchSpace(parambounds)
-            @test mins(ss) == minbounds
-            @test maxs(ss) == maxbounds
-            @test round.(deltas(ss), digits=6) == round.(ds, digits=6)
+            @test dimmin(ss) == minbounds
+            @test dimmax(ss) == maxbounds
+            @test round.(dimdelta(ss), digits=6) == round.(ds, digits=6)
 
             # Now generate 100 individuals and make sure they are all within bounds
             inds = rand_individuals(ss, 100)
@@ -107,14 +107,14 @@
 
     @testset "RectSearchSpace" begin
         ss = RectSearchSpace([(0.0, 1.0)])
-        @test mins(ss) == [0.0]
-        @test maxs(ss) == [1.0]
-        @test deltas(ss) == [1.0]
+        @test dimmin(ss) == [0.0]
+        @test dimmax(ss) == [1.0]
+        @test dimdelta(ss) == [1.0]
 
         ss = RectSearchSpace([(0.0, 1.0), (0.5, 10.0)])
-        @test mins(ss) == [0.0, 0.5]
-        @test maxs(ss) == [1.0, 10.0]
-        @test deltas(ss) == [1.0, 9.5]
+        @test dimmin(ss) == [0.0, 0.5]
+        @test dimmax(ss) == [1.0, 10.0]
+        @test dimdelta(ss) == [1.0, 9.5]
     end
 
     @testset "rand_individuals_lhs samples in LHS intervals" begin
@@ -163,12 +163,12 @@
         @test BlackBoxOptim.feasible([-0.4, 3.3, 14.5], ss) == [0.0, 3.0, 5.0]
     end
 
-    @testset "diameters" begin
+    @testset "dimrange" begin
         ss = RectSearchSpace([(0.0, 1.0), (2.0, 3.0), (4.0, 5.0)])
-        diams = diameters(ss)
+        diams = dimdelta(ss)
 
         @test length(diams) == 3
-        @test diams[:] == [1.0, 1.0, 1.0]
+        @test diams == [1.0, 1.0, 1.0]
     end
 
     @testset "concat(ss1, ss2)" begin
@@ -177,8 +177,8 @@
 
         sscat = vcat(ss1, ss2)
         @test numdims(sscat) == 5
-        @test mins(sscat) == [0.0, 2.0, 4.0, 6.0, 8.0]
-        @test maxs(sscat) == [1.0, 3.0, 5.0, 7.0, 9.0]
-        @test deltas(sscat) == fill(1.0, 5)
+        @test dimmin(sscat) == [0.0, 2.0, 4.0, 6.0, 8.0]
+        @test dimmax(sscat) == [1.0, 3.0, 5.0, 7.0, 9.0]
+        @test dimdelta(sscat) == fill(1.0, 5)
     end
 end

--- a/test/test_search_space.jl
+++ b/test/test_search_space.jl
@@ -38,13 +38,16 @@
 
     @testset "SymmetricSearchSpace with given range" begin
         ss1 = symmetric_search_space(1, (-1.0, 1.0))
+        @test_throws ArgumentError symmetric_search_space(1, (0.0, -1.0))
+        @test ss1 isa ContinuousRectSearchSpace
         @test numdims(ss1) == 1
         @test ranges(ss1) == [(-1.0, 1.0)]
         @test range_for_dim(ss1,1) == (-1.0, 1.0)
 
         for i in 1:NumTestRepetitions
             reps = rand(1:100)
-            range = (rand(), rand())
+            a = rand()
+            range = (a, a + (1-a)*rand())
             ss = symmetric_search_space(reps, range)
             @test numdims(ss) == reps
             @test all([(dr == range) for dr in ranges(ss)])
@@ -86,7 +89,7 @@
             ds = rand(1:10, numdimensions) .* rand(numdimensions)
             maxbounds = minbounds .+ ds
             parambounds = collect(zip(minbounds, maxbounds))
-            ss = RangePerDimSearchSpace(parambounds)
+            ss = RectSearchSpace(parambounds)
             @test mins(ss) == minbounds
             @test maxs(ss) == maxbounds
             @test round.(deltas(ss), digits=6) == round.(ds, digits=6)
@@ -102,20 +105,20 @@
         end
     end
 
-    @testset "RangePerDimSearchSpace" begin
-        ss = RangePerDimSearchSpace([(0.0, 1.0)])
+    @testset "RectSearchSpace" begin
+        ss = RectSearchSpace([(0.0, 1.0)])
         @test mins(ss) == [0.0]
         @test maxs(ss) == [1.0]
         @test deltas(ss) == [1.0]
 
-        ss = RangePerDimSearchSpace([(0.0, 1.0), (0.5, 10.0)])
+        ss = RectSearchSpace([(0.0, 1.0), (0.5, 10.0)])
         @test mins(ss) == [0.0, 0.5]
         @test maxs(ss) == [1.0, 10.0]
         @test deltas(ss) == [1.0, 9.5]
     end
 
     @testset "rand_individuals_lhs samples in LHS intervals" begin
-        ss = RangePerDimSearchSpace([(0.0, 1.0), (2.0, 3.0), (4.0, 5.0)])
+        ss = RectSearchSpace([(0.0, 1.0), (2.0, 3.0), (4.0, 5.0)])
 
         inds = rand_individuals_lhs(ss, 2)
         @test size(inds, 1) == 3
@@ -133,7 +136,7 @@
     end
 
     @testset "feasible finds feasible points in the search space" begin
-        ss = RangePerDimSearchSpace([(0.0, 1.0), (2.0, 3.0), (4.0, 5.0)])
+        ss = RectSearchSpace([(0.0, 1.0), (2.0, 3.0), (4.0, 5.0)])
 
         # We use the double transpose below to ensure the actual and expected
         # values have the same type (matrices, not vectors).
@@ -161,7 +164,7 @@
     end
 
     @testset "diameters" begin
-        ss = RangePerDimSearchSpace([(0.0, 1.0), (2.0, 3.0), (4.0, 5.0)])
+        ss = RectSearchSpace([(0.0, 1.0), (2.0, 3.0), (4.0, 5.0)])
         diams = diameters(ss)
 
         @test length(diams) == 3
@@ -169,8 +172,8 @@
     end
 
     @testset "concat(ss1, ss2)" begin
-        ss1 = RangePerDimSearchSpace([(0.0, 1.0), (2.0, 3.0), (4.0, 5.0)])
-        ss2 = RangePerDimSearchSpace([(6.0, 7.0), (8.0, 9.0)])
+        ss1 = RectSearchSpace([(0.0, 1.0), (2.0, 3.0), (4.0, 5.0)])
+        ss2 = RectSearchSpace([(6.0, 7.0), (8.0, 9.0)])
 
         sscat = vcat(ss1, ss2)
         @test numdims(sscat) == 5

--- a/test/test_selectors.jl
+++ b/test/test_selectors.jl
@@ -1,6 +1,6 @@
 @testset "Selection operators" begin
 
-ss = symmetric_search_space(1, (0.0, 10.0))
+ss = RectSearchSpace(1, (0.0, 10.0))
 fake_problem = FunctionBasedProblem(x -> 0.0, "test_problem", MinimizingFitnessScheme, ss)
 fake_pop = reshape(collect(1.0:10.0), (1, 10))
 


### PR DESCRIPTION
PR adds support for search spaces with discrete dimensions. I also used this opportunity to propose some cleanups to `SearchSpace` API.

**`SearchSpace` API changes**
  * `ContinuousSearchSpace` type was dropped -- it was not used, also it was ambiguous whether "continuous" refers to the functional-valued space or to finite-dimensional spaces with continuous-valued dimensions
  * `RangePerDimSearchSpace` renamed to `RectSearchSpace` (shorter + IMHO better describes the space)
  * `mins()`/`maxs()`/`deltas()` (aka `diameters()`) renamed to `dimmin()`/`dimmax()`/`dimdelta()` respectively. IMHO the new names better describe what these functions do and make them distinct from `Base.min/max`. Dropping the plural form allows `dimmin(ss, i)` methods to access individual dimensions (similar to `Base.size(arr, [i])`).
  * `ranges()`/`range_per_dim()` unified into `dimrange()`
  * `symmetric_search_space()` renamed to `RectSearchSpace`, since it's essentially an external constructor
  * `rand_individuals()`/`rand_individuals_lhs()` unified into `rand_individuals(...; method=)` with `:uniform` and `:latin_hypercube` (the default) methods currently supported.
  * `population()` also got `method=` keyword arg that is passed to `rand_individuals()`

The old types/functions still available via `@deprecate`/`@deprecate_binding` macros.

**Discrete dimensions**

The motivation is to better support discrete optimization problems + reduce the redundancy of populations for some continuous problems making the evolutionary optimization more efficient.
I have considered several other options, e.g.
* parameterize `RectSearchSpace{T}` and allow integer `T`, but that doesn't allow mixing discrete and continuous dimensions + may break some mutation/crossover operators
* add `discrete::Vector{Bool}` to `RectSearchSpace` that specifies the integer dimensions and automatically rounds them. However, when used to reduce redundancy, it may require rescaling the discrete dimensions back to the original range inside `fitness()` method, which introduces some overhead.

In this PR I've implemented the following:
* `RectSearchSpace` was renamed to `ContinuousRectSearchSpace`, and `RectSearchSpace` is its base abstract type
* added `MixedPrecisionsRectSearchSpace <: RectSearchSpace`. It has `dimdigits::Vector{Int}` field, which defines the digits of precision for each dimension (as in `Base.round(Float64, x, digits=)`. If `dimdigits[i]` < 0, `i` dimension is considered continuous. With this scheme, no rescaling of dimensions is required, while truly integral dimensions are also supported (`dimdigits[i]=0`).
* `RectSearchSpace()` constructor learned the new keyword argument `dimdigits` (defaults to `Nothing`). When no discrete dimensions are required, it constructs `ContinuousRectSearchSpace` as before.
* `RandomBound` embedding operator and `rand_individuals()` were updated to correctly project the individuals to `MixedPrecisionRectSearchSpace`.
