### PR TITLE
Allow callables as objectives.

### DIFF
--- a/src/bboptimize.jl
+++ b/src/bboptimize.jl
@@ -23,7 +23,7 @@ function setup_problem(family::FunctionBasedProblemFamily, parameters::Parameter
     return problem, parameters
 end
 
-function setup_problem(func::Function, parameters::Parameters)
+function setup_problem(func, parameters::Parameters)
     ss = check_and_create_search_space(parameters)
 
     # Now create an optimization problem with the given information. We currently reuse the type

--- a/src/problem.jl
+++ b/src/problem.jl
@@ -29,14 +29,14 @@ defined by some Julia `Function` and search space.
 Optionally, a known optimal value could be provided to terminate
 the optimization once it is reached.
 """
-mutable struct FunctionBasedProblem{FS<:FitnessScheme,SS<:SearchSpace,FO} <: OptimizationProblem{FS}
-    objfunc::Function     # Objective function
+mutable struct FunctionBasedProblem{F,FS<:FitnessScheme,SS<:SearchSpace,FO} <: OptimizationProblem{FS}
+    objfunc::F            # Objective function
     name::String
     fitness_scheme::FS
     search_space::SS      # search space
     opt_value::FO         # known optimal value or nothing
 
-    function FunctionBasedProblem(objfunc::Function, name::String,
+    function FunctionBasedProblem(objfunc, name::String,
                                   fitness_scheme::FS, search_space::SS,
                                   opt_value::FO = nothing) where {FS<:FitnessScheme,SS<:SearchSpace,FO}
         if FO <: Number
@@ -47,7 +47,7 @@ mutable struct FunctionBasedProblem{FS<:FitnessScheme,SS<:SearchSpace,FO} <: Opt
                 #throw(ArgumentError("Known optimal value cannot be NA"))
             end
         end
-        new{FS,SS,typeof(opt_value)}(objfunc, name, fitness_scheme, search_space, opt_value)
+        new{typeof(objfunc),FS,SS,typeof(opt_value)}(objfunc, name, fitness_scheme, search_space, opt_value)
     end
 end
 

--- a/test/test_toplevel_bboptimize.jl
+++ b/test/test_toplevel_bboptimize.jl
@@ -198,7 +198,7 @@
         interval = 0.005
         NumCalls = 30
         res = bboptimize(rosenbrock; SearchRange = (-5.0, 5.0), NumDimensions = 20,
-            TraceMode = :silent, 
+            TraceMode = :silent,
             MaxTime = 1.0 + interval * NumCalls, # Some extra time for startup/compilation etc
             CallbackInterval = interval, CallbackFunction = callbackfn)
         @test length(callbacktimes) >= NumCalls
@@ -210,9 +210,16 @@
         # If we call with an interval which is negative there are no callbacks
         prenumcalls = length(callbacktimes)
         res = bboptimize(rosenbrock; SearchRange = (-5.0, 5.0), NumDimensions = 20,
-            TraceMode = :silent, 
+            TraceMode = :silent,
             MaxTime = 1.0 + interval * NumCalls, # Some extra time for startup/compilation etc
             CallbackInterval = -2.0, CallbackFunction = callbackfn)
         @test length(callbacktimes) == prenumcalls
+    end
+
+    @testset "callable as objective" begin
+        struct CallableObjective1 end
+        (::CallableObjective1)(x) = sum(abs2, x)
+        res = bboptimize(CallableObjective1(); SearchRange = [(-2.0, 3.0), (-4.0, 5.0)])
+        @test best_candidate(res) ≈ zeros(2) atol = 1e-5
     end
 end


### PR DESCRIPTION
Incidentally, make `objfunc` concretely typed.

Fixes #131.