### PR TITLE
[RFC] Asynchronous multithreaded evaluator

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,7 @@ os:
   - linux
   - osx
 julia:
-  - 1.2
-  - 1.3
+  - 1
   - nightly
 matrix:
   allow_failures:

--- a/Project.toml
+++ b/Project.toml
@@ -15,7 +15,7 @@ StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 
 [compat]
 SpatialIndexing = "≥ 0.1.0"
-julia = "≥ 1.0.3"
+julia = "≥ 1.3.0"
 
 [extras]
 CSV = "336ed68f-0bac-5ca0-87d4-7b16caf5d00b"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,8 +1,6 @@
 environment:
   matrix:
-  - julia_version: 1.0
-  - julia_version: 1.1
-  - julia_version: 1.2
+  - julia_version: 1.3
   - julia_version: latest
 
 platform:

--- a/src/BlackBoxOptim.jl
+++ b/src/BlackBoxOptim.jl
@@ -31,8 +31,8 @@ export  Optimizer, AskTellOptimizer, SteppingOptimizer, PopulationOptimizer,
 
         # Evaluator
         #ProblemEvaluator,
-        AbstractAsyncEvaluator,
-        update_fitness!, async_update_fitness, sync_update_fitness!, is_fitness_ready,
+        AbstractAsyncEvaluator, AbstractFitnessEvaluationJob,
+        update_fitness!, async_update_fitness!, sync_update_fitness,
 
         # Problems
         Problems,

--- a/src/BlackBoxOptim.jl
+++ b/src/BlackBoxOptim.jl
@@ -31,6 +31,8 @@ export  Optimizer, AskTellOptimizer, SteppingOptimizer, PopulationOptimizer,
 
         # Evaluator
         #ProblemEvaluator,
+        AbstractAsyncEvaluator,
+        update_fitness!, async_update_fitness, sync_update_fitness!, is_fitness_ready,
 
         # Problems
         Problems,

--- a/src/BlackBoxOptim.jl
+++ b/src/BlackBoxOptim.jl
@@ -98,6 +98,7 @@ include("search_space.jl")
 include("parameters.jl")
 include("fitness.jl")
 include("ntuple_fitness.jl")
+include("sliding_bitset.jl")
 
 include("problem.jl")
 

--- a/src/BlackBoxOptim.jl
+++ b/src/BlackBoxOptim.jl
@@ -115,6 +115,7 @@ include("genetic_operators/genetic_operator.jl")
 
 include("evaluator.jl")
 include("parallel_evaluator.jl")
+include("multithread_evaluator.jl")
 
 include("population.jl")
 include("optimizer.jl")

--- a/src/borg_moea.jl
+++ b/src/borg_moea.jl
@@ -14,6 +14,7 @@ mutable struct BorgMOEA{FS<:FitnessScheme,V<:Evaluator,P<:Population,M<:GeneticO
     last_restart_check::Int
     last_restart::Int
     last_wrecombinate_update::Int
+    recomb_fit_jobids::BitSet   # jobids for fitness calculation of recombined candidates (for AsyncEval version)
 
     τ::Float64        # tournament size, fraction of the population
     γ::Float64        # recommended population-to-archive ratio
@@ -49,7 +50,7 @@ mutable struct BorgMOEA{FS<:FitnessScheme,V<:Evaluator,P<:Population,M<:GeneticO
         fit_scheme = EpsBoxDominanceFitnessScheme(fit_scheme, params[:ϵ])
         archive = EpsBoxArchive(fit_scheme, params)
         evaluator = make_evaluator(problem, archive, params)
-        new{typeof(fit_scheme),typeof(evaluator),P,M,E}(evaluator, pop, Vector{Int}(), 0, 0, 0, 0, 0,
+        new{typeof(fit_scheme),typeof(evaluator),P,M,E}(evaluator, pop, Vector{Int}(), 0, 0, 0, 0, 0, BitSet(),
                 params[:τ], params[:γ], params[:γ_δ], params[:PopulationSize],
                 Categorical(ones(length(recombinate))/length(recombinate)),
                 params[:θ], params[:ζ], params[:OperatorsUpdatePeriod], params[:RestartCheckPeriod],
@@ -114,14 +115,16 @@ function step!(alg::BorgMOEA)
     if alg.n_steps >= alg.last_wrecombinate_update + alg.wrecombinate_update_period
         update_recombination_weights!(alg)
     end
+
+    prepare_recombination(alg)
     # Select the operators to apply based on their probabilities
     recomb_op_ix = rand(alg.recombinate_distr)
-    recombinate!(alg, recomb_op_ix, alg.recombinate[recomb_op_ix])
+    recombine_individuals!(alg, recomb_op_ix, alg.recombinate[recomb_op_ix])
     return alg
 end
 
 # "kernel function" of step() that would specialize to given xover operator type
-function recombinate!(alg::BorgMOEA, recomb_op_ix::Int, recomb_op::CrossoverOperator)
+function recombine_individuals!(alg::BorgMOEA, recomb_op_ix::Int, recomb_op::CrossoverOperator)
     # select parents for recombination
     n_parents = numparents(recomb_op)
     # parent indices
@@ -138,16 +141,44 @@ function recombinate!(alg::BorgMOEA, recomb_op_ix::Int, recomb_op::CrossoverOper
     apply!(recomb_op, Individual[child.params for child in children],
            zeros(Int, length(children)), alg.population, parent_indices)
     for child in children
+        apply!(alg.embed, child.params, alg.population, parent_indices[1])
+        reset_fitness!(child, alg.population)
         child.extra = recomb_op
         child.tag = recomb_op_ix
-        process_candidate!(alg, child, parent_indices[1])
+        postprocess_recombined!(alg, child)
     end
 end
 
-function process_candidate!(alg::BorgMOEA, candi::Candidate, ref_index::Int)
-    apply!(alg.embed, candi.params, alg.population, ref_index)
-    reset_fitness!(candi, alg.population)
-    ifitness = fitness(update_fitness!(alg.evaluator, candi)) # implicitly updates the archive
+prepare_recombination(alg::BorgMOEA) = nothing # do nothing
+
+# AsyncEvaluator version -- process previously submitted candidates with the completed fitness
+function prepare_recombination(alg::BorgMOEA{<:FitnessScheme, <:AbstractAsyncEvaluator})
+    sync_update_fitness!(alg.evaluator, alg.recomb_fit_jobids) do candi
+        process_candidate!(alg, candi)
+        return true
+    end
+    @assert isempty(alg.recomb_fit_jobids)
+    empty!(alg.recomb_fit_jobids) # reset bitset (resets offset, so that bits do not grow over time)
+    return nothing
+end
+
+function postprocess_recombined!(alg::BorgMOEA, candi::Candidate)
+    update_fitness!(alg.evaluator, candi) # implicitly updates the archive
+    process_candidate!(alg, candi)
+end
+
+# AsyncEvaluator version, just submit to fitness calculation, nothing else
+# if the queue is full, waits until some jobs are processed -- that established the
+# balance between recombining and fitness evaluation
+function postprocess_recombined!(alg::BorgMOEA{<:FitnessScheme, <:AbstractAsyncEvaluator}, candi::Candidate)
+    jobid = async_update_fitness(alg.evaluator, candi, wait=true)
+    @assert jobid > 0
+    push!(alg.recomb_fit_jobids, jobid)
+    return candi
+end
+
+function process_candidate!(alg::BorgMOEA, candi::Candidate)
+    ifitness = fitness(candi)
     # test the population
     hat_comp = HatCompare(fitness_scheme(archive(alg)))
     popsz = popsize(alg.population)
@@ -190,7 +221,7 @@ function process_candidate!(alg::BorgMOEA, candi::Candidate, ref_index::Int)
     else
         release_candi(alg.population, candi)
     end
-    alg
+    return nothing
 end
 
 # trace current optimization state,

--- a/src/borg_moea.jl
+++ b/src/borg_moea.jl
@@ -209,17 +209,13 @@ function trace_state(io::IO, alg::BorgMOEA, mode::Symbol)
     end
 end
 
-function update_population_fitness!(alg::BorgMOEA)
-    fs = fitness_scheme(alg.evaluator.archive)
-    for i in 1:popsize(alg.population)
-        if isnafitness(fitness(alg.population, i), fs)
-            candi = acquire_candi(alg.population, i)
-            update_fitness!(alg.evaluator, candi)
-            alg.population.fitness[candi.index] = candi.fitness
-            release_candi(alg.population, candi)
-        end
+update_population_fitness!(alg::BorgMOEA) =
+    update_fitness!(alg.evaluator,
+                    PopulationCandidatesIterator(alg.population,
+                                                 alg.population.nafitness)) do candi
+        alg.population.fitness[candi.index] = candi.fitness
+        release_candi(alg.population, candi)
     end
-end
 
 """
 Update recombination operator probabilities based on the archive tag counts.

--- a/src/evaluator.jl
+++ b/src/evaluator.jl
@@ -52,6 +52,67 @@ update_fitness!(e::Evaluator, candidates::Any; force::Bool=false) =
     update_fitness!(nothing, e, candidates, force=force)
 
 """
+The abstract base type for asynchronous evaluators.
+
+Asynchronous evaluator allows submitting fitness calculation requests via
+[`async_update_fitness`](@ref) method that returns *jobid* without waiting for
+the calculation completion. Job Ids could then be passed to [`sync_update_fitness!`](@ref)
+that waits until fitnesses for all specified jobs is calculated.
+"""
+abstract type AbstractAsyncEvaluator{P <: OptimizationProblem} <: Evaluator{P} end
+
+"""
+    async_update_fitness(eval::AbstractAsyncEvaluator, candi::Candidate;
+                         force::Bool=false, wait::Bool=false) -> Int
+
+Asynchronously calculate the fitness of a candidate.
+
+Returns
+  - the id of the fitness calculation job
+  - *0* if the candidate already has fitness
+  - *-1* if no fitness calculation was scheduled (`wait` unset, and all resources occupied)
+  - *-2* if evaluator does not accept jobs because it's shutting down
+
+# Arguments
+ - `force::Bool`: force fitness calculation even if the candidate already has
+   non-NA fitness
+ - `wait::Bool`: if all calculation resources are occupied, wait until the
+   calculation slot becomes available
+
+See also: [`sync_update_fitness!`](@ref), [`is_fitness_ready`](@ref)
+"""
+async_update_fitness
+
+"""
+    sync_fitness_update!([f], eval::AbstractAsyncEvaluator, jobids)
+
+Waits until all fitness `jobids` are calculated and optionally applies `f`
+function to each processed candidate.
+
+See also: [`async_update_fitness`](@ref), [`update_fitness!`](@ref).
+"""
+sync_update_fitness!
+
+"""
+    is_fitness_ready(eval::AbstractAsyncEvaluator, jobid::Integer) -> Bool
+
+Check if given asynchronous fitness job calculation is complete.
+
+See also [`async_update_fitness`](@ref), [`sync_update_fitness!`](@ref).
+"""
+is_fitness_ready
+
+"""
+    is_stopping(eval::AbstractAsyncEvaluator) -> Bool
+
+Check if the evaluator is in the shutdown sequence.
+
+When the evaluator is being shut down, it waits for the workers to finish
+their jobs and stop, no new jobs could be submitted.
+"""
+is_stopping
+
+"""
 Default implementation of the `Evaluator`.
 
 `FP` is the original problem's fitness type

--- a/src/multithread_evaluator.jl
+++ b/src/multithread_evaluator.jl
@@ -100,8 +100,11 @@ MultithreadEvaluator(
 
 num_evals(eval::MultithreadEvaluator) = eval.num_evals
 
+# FIXME move these method to abstract Evaluator (it would need to support A and FA)
 archfitness_type(::Type{<:MultithreadEvaluator{F,FA}}) where {F, FA} = FA
 archfitness_type(eval::MultithreadEvaluator) = archfitness_type(typeof(eval))
+candidate_type(::Type{T}) where T<:MultithreadEvaluator = Candidate{archfitness_type(T)}
+candidate_type(eval::MultithreadEvaluator) = candidate_type(typeof(eval))
 
 nworkers(eval::MultithreadEvaluator) = length(eval.workers)
 #queue_capacity(eval::MultithreadEvaluator) = nworkers(eval)

--- a/src/multithread_evaluator.jl
+++ b/src/multithread_evaluator.jl
@@ -1,37 +1,69 @@
-#= master <-> worker params_status/fitness_status codes =#
-
-const MEStatus_Available = 0 # message received; positive statuses = jobid
-const MEStatus_Assigned = -1
-const MEStatus_Working = -2
-const MEStatus_Success = -3
-const MEStatus_Finished = -4
-const MEStatus_Error = -5
-
-mutable struct MTEvaluatorWorker{FA}
-    status::Int
-    jobid::Int
+# MultithreadEvaluator worker
+# that calculates fitnesses in it's own separate thread
+mutable struct MTEvaluatorWorker
     task::Task
-    jobid_chan::Channel{Int}
-    candi::Union{Candidate{FA}, Nothing}
     num_evals::Int
 
-    MTEvaluatorWorker{FA}(task::Task, ch::Channel{Int}) where FA =
-        new{FA}(MEStatus_Available, 0, task, ch, nothing, 0)
+    MTEvaluatorWorker(task::Task) = new(task, 0)
 end
 
-isbusy(worker::MTEvaluatorWorker) = worker.status == MEStatus_Working || worker.status == MEStatus_Assigned
-isdone(worker::MTEvaluatorWorker) = worker.status == MEStatus_Error || worker.status == MEStatus_Success
-isavailable(worker::MTEvaluatorWorker) = worker.status == MEStatus_Available
-isrunning(worker::MTEvaluatorWorker) = !istaskdone(worker.task)
+# check whether the worker task is running
+isactive(worker::MTEvaluatorWorker) =
+    istaskstarted(worker.task) && !(istaskdone(worker.task) || istaskfailed(worker.task))
 
-function assign!(worker::MTEvaluatorWorker, jobid::Integer, candi::Candidate)
-    @assert worker.status == MEStatus_Available
-    @assert worker.candi === nothing
-    @assert worker.jobid == 0
-    worker.status = MEStatus_Assigned
-    worker.candi = candi
-    put!(worker.jobid_chan, jobid)
-    return worker
+# Job object returned by async_update_fitness() method of MultithreadEvaluator
+mutable struct MTFitnessEvalJob{FA, NFA, I, S} <: AbstractFitnessEvaluationJob{FA}
+    candidates::I   # candidates iterator
+    next_candidate::Union{Nothing, Tuple{Candidate{FA}, S}} # next candidate and iter state
+    nafitness::NFA
+
+    npending::Threads.Atomic{Int}   # how many candidates are currently being evaluated
+    results_lock::Threads.SpinLock
+    results::Vector{Candidate{FA}}
+    discarded::Bool
+end
+
+# all candidates have been iterated over by workers
+has_next_candidate(job::MTFitnessEvalJob) = !isnothing(job.next_candidate)
+# fitness calculation of all candidates is done
+iscomplete(job::MTFitnessEvalJob) = isnothing(job.next_candidate) && (job.npending[] == 0)
+Base.isready(job::MTFitnessEvalJob) = iscomplete(job)
+
+# all calculated fitness candidates are claimed by the caller
+isclaimed(job::MTFitnessEvalJob) = iscomplete(job) && isempty(job.results)
+
+# wrapper around iterate()
+iterate_candidates(candidates, state, nafitness::Nothing) =
+    isnothing(state) ? iterate(candidates) : iterate(candidates, state)
+
+# wrapper around iterate() that skips candidate, if their fitness
+# doens't match nafitness
+function iterate_candidates(candidates, state, nafitness)
+    next = isnothing(state) ? iterate(candidates) : iterate(candidates, state)
+    while !isnothing(next) && !isequal(next[1].fitness, nafitness)
+        next = iterate(candidates, next[2])
+    end
+    return next
+end
+
+# pick the next candidate from the iterator, requires Evaluator's jobs_queue_lock
+function take_candidate!(job::MTFitnessEvalJob)
+    isnothing(job.next_candidate) && error("No candidates to take")
+    candi = job.next_candidate[1]
+    # increment before iterating to avoid job being complete for a short while
+    Threads.atomic_add!(job.npending, 1)
+    # prepare next candidate
+    job.next_candidate = iterate_candidates(job.candidates, job.next_candidate[2], job.nafitness)
+    return candi
+end
+
+# put the candidate to the results, requires job's results_lock
+function put_candidate!(job::MTFitnessEvalJob, candi::Candidate)
+    job.npending[] > 0 || error("Job doesn't expect candidates to be put back")
+    push!(job.results, candi)
+    # decrement after adding to avoid job being subject for discarding
+    Threads.atomic_sub!(job.npending, 1)
+    return job
 end
 
 """
@@ -42,25 +74,22 @@ mutable struct MultithreadEvaluator{F, FA, FS, P<:OptimizationProblem, A<:Archiv
     problem::P          # optimization problem
     archive::A          # archive where good candidates are automatically stored
     num_evals::Int      # fitness evaluations counter
+    num_jobs::Int       # counter of completed claimed jobs
     last_fitness::F     # last fitness
     arch_nafitness::FA  # NA fitness
 
-    workers::Vector{MTEvaluatorWorker{FA}}
-
-    #new_result::Condition            # new result is available
-    #results_lock::ReentrantLock      # results update critical section
-    results::Dict{Int, Candidate{FA}} # yet unclaimed candidates with calculated fitness
-
-    done_workers::Channel{Int}
-    #busy_workers::Base.Semaphore   # gets acquired when a worker needs to be assigned to a task;
-    #                               # used to organize waiting when all workers are busy
-    #job_assignment::ReentrantLock  # workers assignment critical section
-
-    done_jobids::SlidingBitset      # ids of completed jobs
-    next_jobid::Int                 # ID to assign for the next job
-
     is_stopping::Bool       # whether the evaluator is in the shutdown sequence
-    jobids_pool::Vector{BitSet}     # pool of temporary jobids sets for update_fitness!()
+    workers::Vector{MTEvaluatorWorker}
+
+    jobs_queue::Vector{MTFitnessEvalJob} # jobs for workers to pick up
+    jobs_queue_lock::Threads.SpinLock
+    iterated_jobs::Vector{MTFitnessEvalJob} # jobs with all candidates iterated (some calculations might be pending), but not yet fully claimed
+    iterated_jobs_lock::Threads.SpinLock
+
+    resources_lock::Threads.SpinLock
+    atomics_pool::Vector{Threads.Atomic{Int}}
+    locks_pool::Vector{Threads.SpinLock}
+    results_pool::Vector{Vector{Candidate{FA}}}
 
     function MultithreadEvaluator(
         problem::P, archive::A;
@@ -75,18 +104,18 @@ mutable struct MultithreadEvaluator{F, FA, FS, P<:OptimizationProblem, A<:Archiv
 
         eval = new{F, FA, typeof(fs), P, A}(
             problem, archive,
-            0, nafitness(fs), nafitness(FA),
-            Vector{MTEvaluatorWorker{FA}}(),
-            #Condition(), ReentrantLock(),
-            Dict{Int, Candidate{FA}}(),
-            Channel{Int}(10*nworkers), #Base.Semaphore(nworkers), #ReentrantLock(),
-            SlidingBitset(), 1,
-            false,
-            Vector{BitSet}()
+            0, 0, nafitness(fs), nafitness(FA), false,
+            Vector{MTEvaluatorWorker}(),
+            Vector{MTFitnessEvalJob}(), Threads.SpinLock(),
+            Vector{MTFitnessEvalJob}(), Threads.SpinLock(),
+            Threads.SpinLock(),
+            Vector{Threads.Atomic{Int}}(),
+            Vector{Threads.SpinLock}(),
+            Vector{Vector{Candidate{FA}}}(),
         )
         create_workers!(eval, nworkers)
 
-        #finalizer(eval, _shutdown!)
+        finalizer(_shutdown!, eval)
         return eval
     end
 end
@@ -107,80 +136,199 @@ candidate_type(::Type{T}) where T<:MultithreadEvaluator = Candidate{archfitness_
 candidate_type(eval::MultithreadEvaluator) = candidate_type(typeof(eval))
 
 nworkers(eval::MultithreadEvaluator) = length(eval.workers)
-#queue_capacity(eval::MultithreadEvaluator) = nworkers(eval)
-#nbusyworkers(eval::MultithreadEvaluator) = eval.busy_workers.curr_cnt
 
 is_stopping(eval::MultithreadEvaluator) = eval.is_stopping
 
-# Create and run the evaluator worker.
-# It runs in the separate thread than the master process.
-function run_mteval_worker(
-    eval::MultithreadEvaluator,
-    workerix::Int,
-    jobid_chan::Channel{Int}
-)
-    @debug "Initializing MultithreadEvaluator worker #$workerix at thread=#$(Threads.threadid())"
-    ini_jobid = take!(jobid_chan) # get initial jobid=0
-    @debug "worker #$workerix: got initial jobid=$ini_jobid"
-    @assert ini_jobid == 0
-    try
-        worker = eval.workers[workerix]
-        while !is_stopping(eval)
-            #@debug "worker #$workerix: waiting for jobid..."
-            jobid = take!(worker.jobid_chan)
-            #@debug "worker #$workerix: got jobid=$jobid"
-            jobid > 0 || continue
-            @assert worker.status == MEStatus_Assigned
-            @assert worker.jobid == 0
-            @assert worker.candi !== nothing
-            #@debug "worker #$workerix: calculating fitness jobid=$jobid"
-            worker.jobid = jobid
-            worker.status = MEStatus_Working
-            eval.last_fitness = candi_fitness = fitness(params(worker.candi), eval.problem)
-            worker.candi.fitness = archived_fitness(candi_fitness, eval.archive)
-            worker.num_evals += 1
-            # clear busy state and notify completion
-            worker.status = MEStatus_Success
-            #@debug "worker #$workerix: notifying jobid=$jobid done"
-            put!(eval.done_workers, workerix)
+# what the worker thread should do while waiting for a lock/condition
+pause(worker::MTEvaluatorWorker; longer::Bool=false) =
+    longer ? yield() : ccall(:jl_cpu_pause, Cvoid, ())
+
+# what the master evaluator thread should do while waiting for a lock/condition
+pause(eval::MultithreadEvaluator; longer::Bool=false) =
+    longer ? yield() : ccall(:jl_cpu_pause, Cvoid, ());
+
+# Locks SpinLock in a "smart" way: allows yielding to other task from time to
+# time, cancels waiting for a lock if the evaluator is being shut down.
+# Returns true if the lock was acquired
+function smartlock(spinlock::Threads.SpinLock, eval::MultithreadEvaluator,
+                   worker::Union{MTEvaluatorWorker, Nothing} = nothing;
+                   adaptive::Bool=true)
+    locked = false
+    threadowner = isnothing(worker) ? eval : worker
+    if adaptive
+        i = 0
+        while !is_stopping(eval) && !(locked = trylock(spinlock))
+            pause(threadowner, longer=((i += 1) & 0xFFFF) == 0)
         end
-    catch ex
-        #eval.workers[workerix].status = MEStatus_Error
-        put!(eval.done_workers, workerix)
-        # send -id to notify about an error and to release
-        # the master from waiting for worker readiness
-        @warn "Exception at MultithreadEvaluator worker #$workerix" exception=ex
-        showerror(stderr, ex, catch_backtrace())
-        rethrow(ex)
+    else
+        while !is_stopping(eval) && !(locked = trylock(spinlock))
+            pause(threadowner, longer=false)
+        end
     end
-    @debug "worker #$workerix finished"
-    eval.workers[workerix].status = MEStatus_Finished
-    nothing
+    return locked
 end
 
+# constructs Job object given the candidates iterator.
+# Skips candidates with non-natifness, if nafitness !== nothing.
+function MTFitnessEvalJob(eval::MultithreadEvaluator, candidates::Any, nafitness::Any)
+    next_candidate = iterate_candidates(candidates, nothing, nafitness)
+    isnothing(next_candidate) && return nothing
+
+    if smartlock(eval.resources_lock, eval)
+        res = MTFitnessEvalJob{archfitness_type(eval), typeof(nafitness),
+                               typeof(candidates), typeof(last(next_candidate))}(
+            candidates, next_candidate, nafitness,
+            isempty(eval.atomics_pool) ? Threads.Atomic{Int}(0) : pop!(eval.atomics_pool),
+            isempty(eval.locks_pool) ? Threads.SpinLock() : pop!(eval.locks_pool),
+            isempty(eval.results_pool) ? eltype(eval.results_pool)() : pop!(eval.results_pool),
+            false)
+        unlock(eval.resources_lock)
+        return res
+    else
+        error("Failed to lock MultithreadEvaluator resources")
+    end
+end
+
+# create MTEvaluatorWorker and assign it to a given tread
 # HACK (ab)use julia internals to make sure that workers are spawned on different threads
 # HACK "inspired" by enq_work() (base/task.jl) and Channel ctor (base/channels.jl)
-function MTEvaluatorWorker(eval::MultithreadEvaluator, workerix::Integer, tid::Integer)
-    ch = Channel{Int}(1)
-    task = Task(() -> run_mteval_worker(eval, workerix, ch))
+function MTEvaluatorWorker(eval::MultithreadEvaluator, workerix::Integer, tid::Integer,
+                           readysteadygo::Threads.Atomic{Int})
+    task = Task(() -> run_mteval_worker(eval, workerix, readysteadygo))
     task.sticky = true
-    bind(ch, task)
     ccall(:jl_set_task_tid, Cvoid, (Any, Cint), task, tid-1)
     push!(Base.Workqueues[tid], task)
     ccall(:jl_wakeup_thread, Cvoid, (Int16,), (tid - 1) % Int16)
-    return MTEvaluatorWorker{archfitness_type(eval)}(task, ch)
+    return MTEvaluatorWorker(task)
 end
 
 # creates workers and assigns them to different threads
 function create_workers!(eval::MultithreadEvaluator, nworkers::Integer)
     @debug "Initializing $nworkers multithread workers..."
-    FA = archfitness_type(eval)
-    eval.workers = [MTEvaluatorWorker(eval, i, i+1) for i in 1:nworkers]
-    @debug "create_workers!(): sending initial jobid=0 to the workers"
-    for worker in eval.workers
-        put!(worker.jobid_chan, 0)
+    readysteadygo = Threads.Atomic{Int}(-nworkers)
+    eval.workers = [MTEvaluatorWorker(eval, i, i >= Threads.threadid() ? i+1 : i, readysteadygo)
+                    for i in 1:nworkers]
+    @debug "Waiting for workers initialization..."
+    while !any(w -> istaskfailed(w.task) || istaskdone(w.task), eval.workers) &&
+        (readysteadygo[] < 0)
+        pause(eval, longer=true)
     end
-    @info "MultithreadEvaluator: $nworkers workers ready"
+    if !all(isactive, eval.workers) || readysteadygo[] < 0
+        @info "MultithreadEvaluator: workers initialization failed, shutting down"
+        shutdown!(eval)
+    else
+        @info "MultithreadEvaluator: $nworkers workers ready, starting"
+        Threads.atomic_add!(readysteadygo, 1)
+    end
+    return eval.workers
+end
+
+# Runs the evaluator worker until the evaluator is shut down.
+# The workers look and pick up the first job in the jobs_queue and send it
+# to calculate_fitness()
+function run_mteval_worker(
+    eval::MultithreadEvaluator,
+    workerix::Int,
+    readysteadygo::Threads.Atomic{Int}
+)
+    @debug "Initializing MultithreadEvaluator worker #$workerix at thread=#$(Threads.threadid())"
+    Threads.atomic_add!(readysteadygo, 1)
+    while !is_stopping(eval) && readysteadygo[] <= 0
+        yield()
+    end
+    @debug "MultithreadEvaluator worker #$workerix started"
+    try
+        worker = eval.workers[workerix]
+        i = 0
+        nlock_failed = 0
+        while !is_stopping(eval)
+            queuelock = false
+            if isempty(eval.jobs_queue) || islocked(eval.jobs_queue_lock)
+                nlock_failed = 0
+            else
+                if !(queuelock = trylock(eval.jobs_queue_lock))
+                    if (nlock_failed += 1) >= 1000000
+                        nlock_failed = 0
+                        @warn("worker #$workerix: waiting for job for too long (jobs_queue=$(length(eval.jobs_queue)), iterated_jobs=$(length(eval.iterated_jobs)), worker_num_evals=$(worker.num_evals), total_num_evals=$(num_evals(eval)), num_jobs=$(eval.num_jobs))")
+                    end
+                end
+            end
+            if queuelock
+                nlock_failed = 0
+                if !is_stopping(eval) && !isempty(eval.jobs_queue)
+                    #@debug "worker #$workerix: got job, calculating"
+                    calculate_fitness(first(eval.jobs_queue), eval, workerix)
+                    # jobs_queue unlocked by calculate_fitness()
+                else
+                    @debug "worker #$workerix: locked empty jobs queue ($(length(eval.jobs_queue))) or stopping evaluator ($(is_stopping(eval))), worker_num_evals=$(worker.num_evals), total_num_evals=$(num_evals(eval)), num_jobs=$(eval.num_jobs)"
+                    unlock(eval.jobs_queue_lock)
+                end
+            else
+                pause(worker, longer=((i += 1) & 0xFFFF) == 0)
+            end
+        end
+    catch ex
+        @warn "Exception at MultithreadEvaluator worker #$workerix" exception=ex
+        showerror(stderr, ex, catch_backtrace())
+        rethrow(ex)
+    end
+    @debug "MultithreadEvaluator worker #$workerix finished"
+    nothing
+end
+
+# Calculates the fitness of the next candidate in the job and puts the
+# candidate with the evaluated fitness to job.results.
+# Moves the job from eval.jobs_queue to eval.iterated_jobs if it has no
+# other candidates.
+function calculate_fitness(
+    job::MTFitnessEvalJob,
+    eval::MultithreadEvaluator,
+    workerix::Int
+)
+    worker = eval.workers[workerix]
+    #@debug "worker #$workerix calculate(): taking candidate"
+    candi = take_candidate!(job)
+    @assert !isnothing(candi)
+    no_next = !has_next_candidate(job)
+    if no_next
+        #@debug "worker #$workerix calculate(): removing iterated job from the jobs_queue"
+        first_job = popfirst!(eval.jobs_queue)
+        @assert first_job === job # the job should be the first in the running list
+    end
+    unlock(eval.jobs_queue_lock) # release the jobs queue lock as soon as possible
+
+    if no_next
+        # move the job with no further candidates to iterated
+        #@debug "worker #$workerix calculate(): move the job to iterated"
+        if smartlock(eval.iterated_jobs_lock, eval, worker)
+            push!(eval.iterated_jobs, job)
+            if length(eval.iterated_jobs) > 100
+                @warn "$(length(eval.iterated_jobs)) unclaimed iterated job(s)"
+            end
+            unlock(eval.iterated_jobs_lock)
+        elseif !is_stopping(eval)
+            error("Failed to lock iterated_jobs")
+        end
+    end
+    #@debug "worker #$workerix calculate(): calculating fitness..."
+    eval.last_fitness = candi_fitness = fitness(params(candi), eval.problem)
+    candi.fitness = archived_fitness(candi_fitness, eval.archive)
+    worker.num_evals += 1
+
+    #@debug "worker #$workerix calculate(): putting the result back to the job..."
+    if smartlock(job.results_lock, eval, worker)
+        put_candidate!(job, candi)
+        unlock(job.results_lock)
+    elseif !is_stopping(eval)
+        error("Failed to lock job results")
+    end
+    return nothing
+end
+
+# silent (no IO) shutdown of the evaluator, to please the finalizer()
+# set the is_stopping flag so that the workers can quit from their locks
+function _shutdown!(eval::MultithreadEvaluator)
+    eval.is_stopping = true
 end
 
 # shutdown the evaluator, automatically called when the error occurs
@@ -188,225 +336,136 @@ function shutdown!(eval::MultithreadEvaluator)
     @debug "shutdown!(MultithreadEvaluator)"
     eval.is_stopping && error("Cannot shutdown!(MultithreadEvaluator) twice")
     eval.is_stopping = true
-    # notify the workers that they should shutdown (each worker should pick exactly one message)
-    for worker in eval.workers
-        isopen(worker.jobid_chan) && put!(worker.jobid_chan, -1)
-    end
-    # resume workers listener if it is waiting for the new jobs
-    put!(eval.done_workers, 0)
     # make sure all the workers tasks are done
     for (i, worker) in enumerate(eval.workers)
-        if isrunning(worker)
+        if isactive(worker)
             @debug "shutdown!(MultithreadEvaluator): worker #$i is still running, waiting..."
             wait(worker.task)
             @debug "shutdown!(MultithreadEvaluator): worker #$i finished"
         end
     end
-    #@assert nbusyworkers(eval) == 0 "Some workers are still busy" upon abnormal termination might not hold
     @info "shutdown!(MultithreadEvaluator): all $(nworkers(eval)) workers stopped"
     @info "shutdown!(MultithreadEvaluator): function evals per worker: $(join([worker.num_evals for worker in eval.workers], ", "))"
 end
 
-# Wait until the first incoming fitness completion (or any other) notification from any worker.
-# Completed worker is made available again, the candidate is put to the results,
-# and its fitness is put to the archive
-function wait_workers!(eval::MultithreadEvaluator)
-    #@debug "check_workers!(): taking next done worker..."
-    workerix = take!(eval.done_workers)
-    if workerix <= 0
-        @debug "check_workers!(): got worker #$workerix, stopping"
-        return false
+# Discards the job object releasing the reusable resources back to the
+# evaluator's resources pool.
+# Called from sync_update_fitness()
+function discard!(eval::MultithreadEvaluator, job::MTFitnessEvalJob)
+    #@debug "discard!(): discarding job..."
+    job.discarded && error("Job is already discarded")
+    @assert isclaimed(job)
+    job.discarded = true
+
+    #@debug "discard!(): removing the job from iterated_jobs"
+    if smartlock(eval.iterated_jobs_lock, eval)
+        ix = findfirst(j -> j===job, eval.iterated_jobs)
+        @assert !isnothing(ix)
+        deleteat!(eval.iterated_jobs, ix)
+        unlock(eval.iterated_jobs_lock)
+    elseif !is_stopping(eval)
+        error("Failed to lock iterated_jobs")
     end
 
-    worker = eval.workers[workerix]
-    if worker.status != MEStatus_Success # communication not in a normal state
-        @warn "check_workers!(): worker #$workerix jobid=#$(worker.jobid) status=$(worker.status), shutting down"
-        worker.jobid = 0
-        worker.candi = nothing
-        shutdown!(eval)
-        return false
+    #@debug "discard!(): return the job resources to the pool"
+    if smartlock(eval.resources_lock, eval)
+        push!(eval.results_pool, empty!(job.results))
+        @assert !islocked(job.results_lock)
+        @assert job.npending[] == 0
+        push!(eval.locks_pool, job.results_lock)
+        push!(eval.atomics_pool, job.npending)
+        unlock(eval.resources_lock)
+    elseif !is_stopping(eval)
+        error("Failed to lock resources")
     end
-
-    #@debug "check_workers!(): worker #$workerix jobid=$(worker.jobid) success"
-    @assert worker.candi !== nothing
-    candi = worker.candi
-    #@debug "check_workers!(): store jobid=#$(worker.jobid) result"
-    #lock(eval.results_lock)
-    push!(eval.done_jobids, worker.jobid)
-    eval.results[worker.jobid] = candi
-    if length(eval.results) > 10*nworkers(eval)
-        @warn "$(length(eval.results)) unclaimed result(s)"
-    end
-    #unlock(eval.results_lock)
-    #@debug "check_workers!(): notify new result"
-    #notify(eval.new_result)
-    #lock(eval.job_assignment)
-    worker.status = MEStatus_Available
-    worker.jobid = 0
-    worker.candi = nothing
-    #unlock(eval.job_assignment)
-    #@debug "check_workers!(): add_candidate(archive)"
-    eval.num_evals += 1
-    add_candidate!(eval.archive, candi.fitness, candi.params, candi.tag, num_evals(eval))
-    #@debug "check_workers!(): add_candidate(archive) done"
-    return true
-end
-
-function async_update_fitness(
-    eval::MultithreadEvaluator{F,FA}, candi::Candidate{FA};
-    force::Bool=false, wait::Bool=false
-) where {F, FA}
-    jobid = eval.next_jobid # tentative job id, but not assigned yet, only for logging
-    @debug "async_update_fitness(jobid=$jobid?): starting to assign job"
-    if is_stopping(eval)
-        return -2 # doesn't accept jobs
-    elseif !force && !isnafitness(fitness(candi), fitness_scheme(eval.archive))
-        @debug "async_update_fitness(jobid=$jobid?): don't recalculate fitness, quit"
-        return 0 # the candidate has fitness, skip recalculation
-    end
-    if !any(isavailable, eval.workers)
-        if wait
-            #@debug "async_update_fitness(): wait for the completed jobs..."
-            wait_workers!(eval) || return -2
-            #@debug "async_update_fitness(): done waiting"
-        else
-            @debug "async_update_fitness(jobid=$jobid?): queue is full, quit"
-            return -1 # queue full, job not submitted
-        end
-    end
-    #lock(eval.job_assignment)
-    #@debug "worker statuses: $([(worker.status, length(worker.jobid_chan.data)) for worker in eval.workers])"
-    workerix = Base.findfirst(isavailable, eval.workers)
-    #@debug "async_update_fitness(jobid=$jobid?): assigning job to worker #$workerix"
-    if workerix === nothing
-        #unlock(eval.job_assignment)
-        error("Cannot find a worker to put a job to")
-    end
-    jobid = eval.next_jobid # now assign job id
-    #@debug "async_update_fitness(jobid=$jobid): assigning job to worker #$workerix"
-    assign!(eval.workers[workerix], jobid, candi)
-    @debug "async_update_fitness(jobid=$jobid): assigned job to worker #$workerix"
-    eval.next_jobid += 1
-    #unlock(eval.job_assignment)
-
-    #@debug "async_update_fitness(jobid=$jobid): job assigned"
-    return jobid
-end
-
-is_fitness_ready(eval::MultithreadEvaluator, jobid::Integer) =
-    jobid > 0 ? in(eval.done_jobids, jobid) :
-    throw(ArgumentError("Invalid job Id=$jobid"))
-
-# Processes all unclaimed candidates with calculated fitnesses (results dict).
-# `f` accepts the completed fitness job Id and the corresponding candidate,
-# returns `true` if the candidate was successfully claimed by `f` and
-# removes the candidate from the unclaimed dict.
-function claim_calculated!(f::Function, eval::MultithreadEvaluator)
-    nclaimed = 0
-    for (jobid, candi) in eval.results
-        if f(jobid, candi)
-            # remove jobid from the results
-            #@debug "claim_calculated!(jobid=#$jobid)"
-            delete!(eval.results, jobid)
-            nclaimed += 1
-        end
-    end
-    return nclaimed
-end
-
-function sync_update_fitness!(f::Any, eval::MultithreadEvaluator, jobids::Any)
-    while !is_stopping(eval) && !isempty(jobids) &&
-          (any(isrunning, eval.workers) || !isempty(eval.results))
-        #@debug "sync_update_fitness!(): jobids=$jobids"
-        # pick up the candidates that are for us
-        claim_calculated!(eval) do jobid, candi
-            our_job = pop!(jobids, jobid, 0)>0
-            if our_job # job for one of our candidates
-                f !== nothing && f(candi) # externally process the candidate
-            end
-            return our_job
-        end
-        # wait if all the workers are busy or all the candidates queued
-        if !is_stopping(eval) && !isempty(jobids) && any(isrunning, eval.workers)
-            #@debug "sync_update_fitness!(): wait for the completed jobs..."
-            wait_workers!(eval)
-            #@debug "sync_update_fitness!(): waiting done"
-        end
-    end
+    #@debug "discard!(): done"
     return nothing
 end
 
-function update_fitness!(f::Any, eval::MultithreadEvaluator, candidates::Any;
-                         force::Bool=false)
-    # submit the jobs
-    isempty(candidates) && return candidates
-    jobids = isempty(eval.jobids_pool) ? BitSet() : empty!(pop!(eval.jobids_pool))
-    (Base.IteratorSize(candidates) === Base.HasLength()) && sizehint!(jobids, length(candidates))
-    next = iterate(candidates)
-    n_queued = 0
-    n_processed = 0
-    while ((next !== nothing) || n_queued > 0) && !is_stopping(eval)
-        #@debug "update_fitness!(): jobids=$jobids"
-        # claim candidates that are for us
-        nclaimed = claim_calculated!(eval) do jobid, candi
-            our_job = pop!(jobids, jobid, 0)>0
-            if our_job # job for one of our candidates
-                f !== nothing && f(candi) # externally process the candidate
-            end
-            return our_job
-        end
-        n_queued -= nclaimed
-        n_processed += nclaimed
-        if next !== nothing
-            # queue the next candidate
-            candi, state = next
-            jobid = async_update_fitness(eval, candi, force=force, wait=true)
-            #@debug "update_fitness!(): got jobid=#$jobid"
-            if jobid > 0
-                n_queued += 1
-                push!(jobids, jobid)
-            elseif (jobid < 0) || (force && jobid == 0)
-                @warn "fitness calculation rejected"
-            end
-            next = iterate(candidates, state)
-        end
-        # wait if all the workers are busy or all the candidates queued
-        if !is_stopping(eval) && n_queued > 0 &&
-           (next === nothing || !any(isavailable, eval.workers))
-            #@debug "update_fitness!(): wait for the completed jobs..."
-            wait_workers!(eval)
-            #@debug "update_fitness!(): waiting done"
-        end
+# Creates MTFitnessEvalJob object and puts it to the jobs_queue
+function async_update_fitness!(eval::MultithreadEvaluator, candidates::Any; force::Bool = false)
+    #@debug "async_update_fitness!(): creating job..."
+    job = MTFitnessEvalJob(eval, candidates, force ? nothing : eval.arch_nafitness)
+    isnothing(job) && return job # empty job, do not process further
+    #@debug "async_update_fitness!(): adding the job to the queue"
+    if smartlock(eval.jobs_queue_lock, eval)
+        push!(eval.jobs_queue, job)
+        unlock(eval.jobs_queue_lock)
+    elseif !is_stopping(eval)
+        error("Failed to lock jobs_queue")
     end
-    push!(eval.jobids_pool, jobids)
-    @assert (Base.IteratorSize(typeof(candidates)) === Base.HasLength() ?
-             n_processed == length(candidates) :
-             n_queued == 0) "Fitnesses not evaluated ($jobids)"
-    return candidates
+    #@debug "async_update_fitness!(): done"
+    return job
 end
+
+sync_update_fitness(f::Any, job::Nothing, eval::MultithreadEvaluator) = nothing
+
+# Waits until MTFitnessEvalJob is fully processed.
+# Constantly monitors job.results for the new candidates and adds them
+# to the fitnesses archive.
+function sync_update_fitness(f::Any, job::MTFitnessEvalJob, eval::MultithreadEvaluator)
+    while !is_stopping(eval) && !isclaimed(job) # continue until all candidates processed
+        #@debug "sync_update_fitness(): wait until new results: hasnext=$(has_next_candidate(job)), npending=$(job.npending[]), results=$(length(job.results))"
+        i = 0
+        while !is_stopping(eval) && isempty(job.results)
+            if ((i+=1) & 0xFFFF) == 0
+                if all(isactive, eval.workers)
+                    pause(eval, longer=true)
+                else
+                    @warn "MultithreadEvaluator: some workers have stopped, shutting down"
+                    shutdown!(eval)
+                end
+            else
+                pause(eval, longer=false)
+            end
+        end
+        is_stopping(eval) && continue
+        #@debug "sync_update_fitness(): locking results and resources"
+        reslock = false
+        if (reslock = smartlock(job.results_lock, eval)) && smartlock(eval.resources_lock, eval)
+            #@debug "sync_update_fitness(): swapping results with an empty vector"
+            @assert !isempty(job.results)
+            results = job.results
+            job.results = isempty(eval.results_pool) ?
+                similar(results, 0) : pop!(eval.results_pool)
+            @assert isempty(job.results)
+            unlock(job.results_lock) # the workers can put their results
+            reslock = false
+            unlock(eval.resources_lock)
+            #@debug "sync_update_fitness(): adding $(length(results)) candidate(s) to archive"
+            for candi in results
+                add_candidate!(eval.archive, candi.fitness, candi.params, candi.tag, eval.num_evals += 1)
+                f !== nothing && f(candi)
+            end
+            #@debug "sync_update_fitness(): returning results vector to the pool"
+            if smartlock(eval.resources_lock, eval)
+                push!(eval.results_pool, empty!(results))
+                unlock(eval.resources_lock)
+            elseif !is_stopping(eval)
+                error("Failed to lock resources")
+            end
+        elseif !is_stopping(eval)
+            error("Failed to lock resources and job results")
+        end
+        reslock && unlock(job.results_lock)
+    end
+    #@debug "sync_update_fitness(): job is done, discarding"
+    discard!(eval, job)
+    eval.num_jobs += 1
+
+    return job.candidates
+end
+
+update_fitness!(f::Any, eval::MultithreadEvaluator, candidates::Any; force::Bool=false) =
+    sync_update_fitness(f, async_update_fitness!(eval, candidates, force=force), eval)
+
+update_fitness!(f::Any, eval::MultithreadEvaluator, candidate::Candidate; force::Bool=false) =
+    update_fitness!(f, eval, (candidate,), force=force)[1]
 
 # WARNING it's not efficient to synchronously calculate single fitness using
 # asynchronous `MultithreadEvaluator`
-function fitness(params::Individual, eval::MultithreadEvaluator{F,FA}, tag::Int=0) where {F, FA}
-    candi = Candidate{FA}(params, -1, eval.arch_nafitness, nothing, tag)
-    jobid = async_update_fitness(eval, candi, wait=true)
-    @assert jobid > 0
-    @debug "fitness(): is_stopping=$(is_stopping(eval)) has_busy_workers=$(any(isrunning, eval.workers)) has_results=$(!isempty(eval.results))"
-    while !is_stopping(eval) && !all(isavailable, eval.workers)
-        if is_fitness_ready(eval, jobid)
-            break
-        else
-            #@debug "fitness(): job #$jobid wait for workers"
-            wait_workers!(eval)
-            #@debug "fitness(): job #$jobid resumed"
-        end
-        #@debug "fitness(): is_stopping=$(is_stopping(eval)) has_busy_workers=$(any(isrunning, eval.workers)) has_results=$(!isempty(eval.results))"
-    end
-    if is_fitness_ready(eval, jobid)
-        #@debug "fitness(): job #$jobid done"
-        pop!(eval.results, jobid) # remove from the results, throws if jobid is not there
-        return fitness(candi)
-    else
-        error("Fitness not evaluated")
-    end
+function fitness(params::Individual, eval::MultithreadEvaluator, tag::Int=0)
+    candi = candidate_type(eval)(params, -1, eval.arch_nafitness, nothing, tag)
+    update_fitness!(eval, (candi,))
+    return fitness(candi)
 end

--- a/src/multithread_evaluator.jl
+++ b/src/multithread_evaluator.jl
@@ -160,7 +160,7 @@ end
 function MTEvaluatorWorker(eval::MultithreadEvaluator, workerix::Integer, tid::Integer)
     ch = Channel{Int}(1)
     task = Task(() -> run_mteval_worker(eval, workerix, ch))
-    task.sticky = false
+    task.sticky = true
     bind(ch, task)
     ccall(:jl_set_task_tid, Cvoid, (Any, Cint), task, tid-1)
     push!(Base.Workqueues[tid], task)

--- a/src/multithread_evaluator.jl
+++ b/src/multithread_evaluator.jl
@@ -1,0 +1,426 @@
+#= master <-> worker params_status/fitness_status codes =#
+
+const MEStatus_Available = 0 # message received; positive statuses = jobid
+const MEStatus_Assigned = -1
+const MEStatus_Working = -2
+const MEStatus_Success = -3
+const MEStatus_Finished = -4
+const MEStatus_Error = -5
+
+mutable struct MTEvaluatorWorker{FA}
+    status::Int
+    jobid::Int
+    task::Task
+    jobid_chan::Channel{Int}
+    candi::Union{Candidate{FA}, Nothing}
+
+    MTEvaluatorWorker{FA}(task::Task, ch::Channel{Int}) where FA =
+        new{FA}(MEStatus_Available, 0, task, ch, nothing)
+end
+
+isbusy(worker::MTEvaluatorWorker) = worker.status == MEStatus_Working || worker.status == MEStatus_Assigned
+isdone(worker::MTEvaluatorWorker) = worker.status == MEStatus_Error || worker.status == MEStatus_Success
+isavailable(worker::MTEvaluatorWorker) = worker.status == MEStatus_Available
+isrunning(worker::MTEvaluatorWorker) = !istaskdone(worker.task)
+
+function assign!(worker::MTEvaluatorWorker, jobid::Integer, candi::Candidate)
+    @assert worker.status == MEStatus_Available
+    @assert worker.candi === nothing
+    @assert worker.jobid == 0
+    worker.status = MEStatus_Assigned
+    worker.candi = candi
+    put!(worker.jobid_chan, jobid)
+    return worker
+end
+
+"""
+Fitness evaluator that asynchronously distributes calculation
+among several worker threads.
+"""
+mutable struct MultithreadEvaluator{F, FA, FS, P<:OptimizationProblem, A<:Archive} <: AbstractAsyncEvaluator{P}
+    problem::P          # optimization problem
+    archive::A          # archive where good candidates are automatically stored
+    num_evals::Threads.Atomic{Int}  # fitness evaluations counter
+    last_fitness::F     # last fitness
+    arch_nafitness::FA  # NA fitness
+
+    workers::Vector{MTEvaluatorWorker{FA}}
+
+    #new_result::Condition            # new result is available
+    #results_lock::ReentrantLock      # results update critical section
+    results::Dict{Int, Candidate{FA}} # yet unclaimed candidates with calculated fitness
+
+    done_workers::Channel{Int}
+    busy_workers::Base.Semaphore   # gets acquired when a worker needs to be assigned to a task;
+                                   # used to organize waiting when all workers are busy
+    #job_assignment::ReentrantLock # workers assignment critical section
+
+    done_jobids::SlidingBitset      # ids of completed jobs
+    next_jobid::Threads.Atomic{Int} # ID to assign for the next job
+
+    is_stopping::Bool       # whether the evaluator is in the shutdown sequence
+
+    workers_listener::Task  # task in the main process that runs workers_listener!()
+
+    function MultithreadEvaluator(
+        problem::P, archive::A;
+        nworkers::Integer = Threads.nthreads() - 1
+    ) where {P<:OptimizationProblem, A<:Archive}
+        nworkers > 0 || throw(ArgumentError("nworkers must be positive"))
+        nworkers < Threads.nthreads() ||
+            throw(ArgumentError("nworkers must be less than threads count ($(Threads.nthreads()))"))
+        fs = fitness_scheme(problem)
+        F = fitness_type(fs)
+        FA = fitness_type(archive)
+
+        eval = new{F, FA, typeof(fs), P, A}(
+            problem, archive,
+            Threads.Atomic{Int}(0), nafitness(fs), nafitness(FA),
+            Vector{MTEvaluatorWorker{FA}}(),
+            #Condition(), ReentrantLock(),
+            Dict{Int, Candidate{FA}}(),
+            Channel{Int}(10*nworkers), Base.Semaphore(nworkers), #ReentrantLock(),
+            SlidingBitset(), Threads.Atomic{Int}(1),
+            false,
+            @async workers_listener!(eval) # create listener before workers
+        )
+        create_workers!(eval, nworkers)
+
+        #finalizer(eval, _shutdown!)
+        return eval
+    end
+end
+
+MultithreadEvaluator(
+    problem::OptimizationProblem;
+    nworkers::Integer = Threads.nthreads() - 1,
+    archiveCapacity::Integer = 10) =
+    MultithreadEvaluator(problem, TopListArchive(fitness_scheme(problem), numdims(problem), archiveCapacity),
+                         nworkers=nworkers)
+
+num_evals(eval::MultithreadEvaluator) = eval.num_evals[]
+
+archfitness_type(::Type{<:MultithreadEvaluator{F,FA}}) where {F, FA} = FA
+archfitness_type(eval::MultithreadEvaluator) = archfitness_type(typeof(eval))
+
+nworkers(eval::MultithreadEvaluator) = length(eval.workers)
+queue_capacity(eval::MultithreadEvaluator) = nworkers(eval)
+nbusyworkers(eval::MultithreadEvaluator) = eval.busy_workers.curr_cnt
+
+is_stopping(eval::MultithreadEvaluator) = eval.is_stopping || istaskdone(eval.workers_listener)
+
+# Create and run the evaluator worker.
+# It runs in the separate thread than the master process.
+function run_mteval_worker(
+    eval::MultithreadEvaluator,
+    workerix::Int,
+    jobid_chan::Channel{Int}
+)
+    @debug "Initializing MultithreadEvaluator worker #$workerix at thread=#$(Threads.threadid())"
+    ini_jobid = take!(jobid_chan) # get initial jobid=0
+    @debug "worker #$workerix: got initial jobid=$ini_jobid"
+    @assert ini_jobid == 0
+    try
+        worker = eval.workers[workerix]
+        while !is_stopping(eval)
+            #@debug "worker #$workerix: waiting for jobid..."
+            jobid = take!(worker.jobid_chan)
+            #@debug "worker #$workerix: got jobid=$jobid"
+            jobid > 0 || continue
+            @assert worker.status == MEStatus_Assigned
+            @assert worker.jobid == 0
+            @assert worker.candi !== nothing
+            #@debug "worker #$workerix: calculating fitness jobid=$jobid"
+            worker.jobid = jobid
+            worker.status = MEStatus_Working
+            eval.last_fitness = candi_fitness = fitness(params(worker.candi), eval.problem)
+            worker.candi.fitness = archived_fitness(candi_fitness, eval.archive)
+            # clear busy state and notify completion
+            worker.status = MEStatus_Success
+            Threads.atomic_add!(eval.num_evals, 1)
+            #@debug "worker #$workerix: notifying jobid=$jobid done"
+            put!(eval.done_workers, workerix)
+        end
+    catch ex
+        #eval.workers[workerix].status = MEStatus_Error
+        put!(eval.done_workers, workerix)
+        # send -id to notify about an error and to release
+        # the master from waiting for worker readiness
+        @warn "Exception at MultithreadEvaluator worker #$workerix" exception=ex
+        showerror(stderr, ex, catch_backtrace())
+        rethrow(ex)
+    end
+    @debug "worker #$workerix finished"
+    eval.workers[workerix].status = MEStatus_Finished
+    nothing
+end
+
+# HACK (ab)use julia internals to make sure that workers are spawned on different threads
+# HACK "inspired" by enq_work() (base/task.jl) and Channel ctor (base/channels.jl)
+function MTEvaluatorWorker(eval::MultithreadEvaluator, workerix::Integer, tid::Integer)
+    ch = Channel{Int}(1)
+    task = Task(() -> run_mteval_worker(eval, workerix, ch))
+    task.sticky = false
+    bind(ch, task)
+    ccall(:jl_set_task_tid, Cvoid, (Any, Cint), task, tid-1)
+    push!(Base.Workqueues[tid], task)
+    ccall(:jl_wakeup_thread, Cvoid, (Int16,), (tid - 1) % Int16)
+    return MTEvaluatorWorker{archfitness_type(eval)}(task, ch)
+end
+
+# creates workers and assigns them to different threads
+function create_workers!(eval::MultithreadEvaluator, nworkers::Integer)
+    @debug "Initializing $nworkers multithread workers..."
+    FA = archfitness_type(eval)
+    eval.workers = [MTEvaluatorWorker(eval, i, i+1) for i in 1:nworkers]
+    @debug "create_workers!(): sending initial jobid=0 to the workers"
+    for worker in eval.workers
+        put!(worker.jobid_chan, 0)
+    end
+    @info "MultithreadEvaluator: $nworkers workers ready"
+end
+
+# shutdown the evaluator, automatically called when the error occurs
+function shutdown!(eval::MultithreadEvaluator)
+    @debug "shutdown!(MultithreadEvaluator)"
+    eval.is_stopping && error("Cannot shutdown!(MultithreadEvaluator) twice")
+    eval.is_stopping = true
+    # notify the workers that they should shutdown (each worker should pick exactly one message)
+    for worker in eval.workers
+        isopen(worker.jobid_chan) && put!(worker.jobid_chan, -1)
+    end
+    # resume workers listener if it is waiting for the new jobs
+    put!(eval.done_workers, 0)
+    wait(eval.workers_listener)
+    @assert istaskdone(eval.workers_listener) "Workers listener is still running"
+    # make sure all the workers tasks are done
+    for (i, worker) in enumerate(eval.workers)
+        if isrunning(worker)
+            @debug "shutdown!(MultithreadEvaluator): worker #$i is still running, waiting..."
+            wait(worker.task)
+            @debug "shutdown!(MultithreadEvaluator): worker #$i finished"
+        end
+    end
+    #@assert nbusyworkers(eval) == 0 "Some workers are still busy" upon abnormal termination might not hold
+    @info "shutdown!(MultithreadEvaluator): all $(nworkers(eval)) workers stopped"
+end
+
+# Process all incoming fitness completion (or any other) notifications from the workers
+# until the evaluator is stopped.
+# Completed worker is made available again, the candidate is put to the results,
+# and its fitness is put to the archive
+function workers_listener!(eval::MultithreadEvaluator)
+    @info "MultithreadEvaluator: workers_listener!() started"
+    workers_ok = true
+    try while workers_ok & !is_stopping(eval)
+        #@debug "workers_listener!(): yield to other tasks"
+        # avoid yielding when all workers are busy, since the main task may
+        # be waiting on busy_workers for the worker to be released,
+        # which would result in deadlock
+        (nbusyworkers(eval) < nworkers(eval)) && !isempty(eval.results) && yield()
+
+        #@debug "workers_listener!(): taking next done worker..."
+        workerix = take!(eval.done_workers)
+        workerix > 0 || continue # skip stop signal
+        worker = eval.workers[workerix]
+        if worker.status == MEStatus_Success # communication in normal state, update the archive
+            #@debug "workers_listener!(): worker #$workerix jobid=$(worker.jobid) success"
+            @assert worker.candi !== nothing
+            candi = worker.candi
+            #@debug "workers_listener!(): store jobid=#$(worker.jobid) result"
+            #lock(eval.results_lock)
+            push!(eval.done_jobids, worker.jobid)
+            eval.results[worker.jobid] = candi
+            if length(eval.results) > 10*nworkers(eval)
+                @warn "$(length(eval.results)) unclaimed result(s)"
+            end
+            #unlock(eval.results_lock)
+            #@debug "workers_listener!(): notify new result"
+            #notify(eval.new_result)
+        else
+            @debug "workers_listener!(): worker #$workerix jobid=#$(worker.jobid) status=$(worker.status), stopping"
+            workers_ok = false
+            candi = nothing
+        end
+        #@debug "workers_listener!(): making worker #$workerix available for assignments"
+        #lock(eval.job_assignment)
+        if worker.status == MEStatus_Success
+            worker.status = MEStatus_Available
+        end
+        worker.jobid = 0
+        worker.candi = nothing
+        #unlock(eval.job_assignment)
+        Base.release(eval.busy_workers)
+        if candi !== nothing
+            #@debug "workers_listener!(): add_candidate(archive)"
+            add_candidate!(eval.archive, candi.fitness, candi.params, candi.tag, num_evals(eval))
+            #@debug "workers_listener!(): add_candidate(archive) done"
+        end
+    end
+    catch ex
+        @warn "workers_listener!(): got exception, stopping" exception=ex
+        rethrow(ex)
+    end
+    @info "MultithreadEvaluator: workers_listener!() stopped normally"
+end
+
+function async_update_fitness(
+    eval::MultithreadEvaluator{F,FA}, candi::Candidate{FA};
+    force::Bool=false, wait::Bool=false
+) where {F, FA}
+    jobid = eval.next_jobid[] # tentative job id, but not assigned yet, only for logging
+    @debug "async_update_fitness(jobid=$jobid?): starting to assign job"
+    if is_stopping(eval)
+        return -2 # doesn't accept jobs
+    elseif !force && !isnafitness(fitness(candi), fitness_scheme(eval.archive))
+        @debug "async_update_fitness(jobid=$jobid?): don't recalculate fitness, quit"
+        return 0 # the candidate has fitness, skip recalculation
+    end
+    if nbusyworkers(eval) >= nworkers(eval) && !wait
+        @debug "async_update_fitness(jobid=$jobid?): queue is full, quit"
+        return -1 # queue full, job not submitted
+    end
+    #@debug "async_update_fitness(jobid=$jobid?): sem_size=$(eval.busy_workers.sem_size) cur_count=$(eval.busy_workers.curr_cnt)"
+    #@debug "async_update_fitness(jobid=$jobid?): waiting to assign jobid..."
+    Base.acquire(eval.busy_workers)
+    #@debug "async_update_fitness(jobid=$jobid?): sem_size=$(eval.busy_workers.sem_size) cur_count=$(eval.busy_workers.curr_cnt)"
+    #lock(eval.job_assignment)
+    #@debug "worker statuses: $([(worker.status, length(worker.jobid_chan.data)) for worker in eval.workers])"
+    workerix = Base.findfirst(isavailable, eval.workers)
+    #@debug "async_update_fitness(jobid=$jobid?): assigning job to worker #$workerix"
+    if workerix === nothing
+        #unlock(eval.job_assignment)
+        error("Cannot find a worker to put a job to")
+    end
+    jobid = eval.next_jobid[] # now assign job id
+    #@debug "async_update_fitness(jobid=$jobid): assigning job to worker #$workerix"
+    assign!(eval.workers[workerix], jobid, candi)
+    @debug "async_update_fitness(jobid=$jobid): assigned job to worker #$workerix"
+    Threads.atomic_add!(eval.next_jobid, 1)
+    #unlock(eval.job_assignment)
+
+    #@debug "async_update_fitness(jobid=$jobid): job assigned"
+    #yield() # dispatch the job ASAP, without this it's not getting queued
+    return jobid
+end
+
+is_fitness_ready(eval::MultithreadEvaluator, jobid::Integer) =
+    jobid > 0 ? in(eval.done_jobids, jobid) :
+    throw(ArgumentError("Invalid job Id=$jobid"))
+
+# Processes all unclaimed candidates with calculated fitnesses (results dict).
+# `f` accepts the completed fitness job Id and the corresponding candidate,
+# returns `true` if the candidate was successfully claimed by `f` and
+# removes the candidate from the unclaimed dict.
+function claim_calculated!(f::Function, eval::MultithreadEvaluator)
+    for (jobid, candi) in eval.results
+        if f(jobid, candi)
+            # remove jobid from the results
+            #@debug "process_completed!(jobid=#$jobid)"
+            delete!(eval.results, jobid)
+        end
+    end
+    return eval
+end
+
+function sync_update_fitness!(f::Any, eval::MultithreadEvaluator, jobids::Any)
+    while !is_stopping(eval) && !isempty(jobids) &&
+          (nbusyworkers(eval) > 0 || !isempty(eval.results))
+        #@debug "sync_update_fitness!(): jobids=$jobids"
+        # pick up the candidates that are for us
+        claim_calculated!(eval) do jobid, candi
+            our_job = pop!(jobids, jobid, 0)>0
+            if our_job # job for one of our candidates
+                f !== nothing && f(candi) # externally process the candidate
+            end
+            return our_job
+        end
+        # switch to listener if all the workers are busy or all the candidates queued
+        if !is_stopping(eval) && !isempty(jobids) && (nbusyworkers(eval) > 0)
+            #@debug "sync_update_fitness!(): yield to listener..."
+            yield()
+            # waiting for new result is not a good idea, since, apparently,
+            # combined with waiting in the listener it will result in a deadlock
+            #@debug "sync_update_fitness!(): wait for any of $n_queued job(s)..."
+            #wait(eval.new_result)
+        end
+    end
+end
+
+function update_fitness!(f::Any, eval::MultithreadEvaluator, candidates::Any;
+                         force::Bool=false)
+    # submit the jobs
+    isempty(candidates) && return candidates
+    jobids = BitSet()
+    (Base.IteratorSize(candidates) === Base.HasLength()) && sizehint!(jobids, length(candidates))
+    next = iterate(candidates)
+    n_queued = 0
+    n_processed = 0
+    while ((next !== nothing) || n_queued > 0) && !is_stopping(eval)
+        #@debug "update_fitness!(): jobids=$jobids"
+        # claim candidates that are for us
+        claim_calculated!(eval) do jobid, candi
+            our_job = pop!(jobids, jobid, 0)>0
+            if our_job # job for one of our candidates
+                n_queued -= 1
+                f !== nothing && f(candi) # externally process the candidate
+                n_processed += 1
+            end
+            return our_job
+        end
+        if next !== nothing
+            # queue the next candidate
+            candi, state = next
+            jobid = async_update_fitness(eval, candi, force=force, wait=true)
+            #@debug "update_fitness!(): got jobid=#$jobid"
+            if jobid > 0
+                n_queued += 1
+                push!(jobids, jobid)
+            elseif (jobid < 0) || (force && jobid == 0)
+                @warn "fitness calculation rejected"
+            end
+            next = iterate(candidates, state)
+        end
+        # switch to listener if all the workers are busy or all the candidates queued
+        if !is_stopping(eval) && n_queued > 0 &&
+           (next === nothing || nbusyworkers(eval) >= nworkers(eval))
+            #@debug "update_fitness!(): yield to listener..."
+            yield()
+            # waiting for new result is not a good idea, since, apparently,
+            # combined with waiting in the listener it will result in a deadlock
+            #@debug "update_fitness!(): wait for any of $n_queued job(s)..."
+            #wait(eval.new_result)
+        end
+    end
+    @assert (Base.IteratorSize(typeof(candidates)) === Base.HasLength() ?
+             n_processed == length(candidates) :
+             n_queued == 0) "Fitnesses not evaluated ($jobids)"
+    return candidates
+end
+
+# WARNING it's not efficient to synchronously calculate single fitness using
+# asynchronous `MultithreadEvaluator`
+function fitness(params::Individual, eval::MultithreadEvaluator{F,FA}, tag::Int=0) where {F, FA}
+    candi = Candidate{FA}(params, -1, eval.arch_nafitness, nothing, tag)
+    jobid = async_update_fitness(eval, candi, wait=true)
+    @assert jobid > 0
+    @debug "fitness(): is_stopping=$(is_stopping(eval)) busy_workers=$(nbusyworkers(eval)) has_results=$(!isempty(eval.results))"
+    while !is_stopping(eval) && !all(isavailable, eval.workers)
+        if is_fitness_ready(eval, jobid)
+            break
+        else
+            #@debug "fitness(): job #$jobid yield()"
+            #wait(eval.new_result)
+            yield()
+            #@debug "fitness(): job #$jobid resumed"
+        end
+        #@debug "fitness(): is_stopping=$(is_stopping(eval)) busy_workers=$(nbusyworkers(eval)) has_results=$(!isempty(eval.results))"
+    end
+    if is_fitness_ready(eval, jobid)
+        #@debug "fitness(): job #$jobid done"
+        pop!(eval.results, jobid) # remove from the results, throws if jobid is not there
+        return fitness(candi)
+    else
+        error("Fitness not evaluated")
+    end
+end

--- a/src/opt_controller.jl
+++ b/src/opt_controller.jl
@@ -3,6 +3,7 @@ Create `Evaluator` instance for a given `problem`.
 """
 function make_evaluator(problem::OptimizationProblem, archive=nothing, params::Parameters=ParamsDict())
     workers = get(params, :Workers, Vector{Int}())
+    nthreads = get(params, :NThreads, 0)
     if archive===nothing
         # make the default archive
         archiveCapacity = get(params, :ArchiveCapacity, 10)
@@ -10,6 +11,8 @@ function make_evaluator(problem::OptimizationProblem, archive=nothing, params::P
     end
     if length(workers) > 0
         return ParallelEvaluator(problem, archive, pids=workers)
+    elseif nthreads > 0
+        return MultithreadEvaluator(problem, archive, nworkers=nthreads)
     else
         return ProblemEvaluator(problem, archive)
     end

--- a/src/population.jl
+++ b/src/population.jl
@@ -12,6 +12,11 @@ fitness.
 """
 abstract type PopulationWithFitness{F} <: Population end
 
+fitness_type(::Type{<:PopulationWithFitness{F}}) where F = F
+fitness_type(pop::PopulationWithFitness) = fitness_type(typeof(pop))
+candidate_type(::Type{P}) where P<:PopulationWithFitness = Candidate{fitness_type(P)}
+candidate_type(pop::PopulationWithFitness) = candidate_type(typeof(pop))
+
 const AbstractPopulationMatrix = AbstractMatrix{Float64}
 
 """
@@ -121,9 +126,6 @@ function Base.append!(pop::FitPopulation{F}, extra_pop::FitPopulation{F}) where 
     append!(pop.fitness, extra_pop.fitness)
     return pop
 end
-
-fitness_type(pop::FitPopulation{F}) where {F} = F
-candidate_type(pop::FitPopulation{F}) where {F} = Candidate{F}
 
 """
     acquire_candi(pop::FitPopulation[, {ix::Int, candi::Candidate}])

--- a/src/sliding_bitset.jl
+++ b/src/sliding_bitset.jl
@@ -1,0 +1,49 @@
+"""
+BitSet-based container that could be used to e.g. store the ids of completed
+jobs by `MultithreadEvaluator`.
+Assumes there is `max_seq_el` element, so that all *1:max_seq_el* elements
+are in the set.
+"""
+mutable struct SlidingBitset
+    max_seq_el::Int # the set contains all elements from 1 to max_seq_el
+    max_el::Int     # max element contained in the set
+    els::BitSet     # elements greater than max_seq_el that are in the set
+
+    SlidingBitset(; max_seq_el::Integer=0) = new(max_seq_el, max_seq_el, BitSet())
+end
+
+# how much the BitSet offset could differ from max_seq_el/64
+# might need to be increased in massively parallel environments
+# (more than SLIDE_OFFSET*64 threads)
+const SLIDE_OFFSET = 8
+
+function Base.push!(set::SlidingBitset, el::Integer)
+    if el > set.max_el
+        set.max_el = el
+    end
+    if el == set.max_seq_el+1
+        # update the next sequential el
+        set.max_seq_el = el
+        # see if max_seq_el could be further advanced using els
+        while (set.max_el > set.max_seq_el) && in(set.els, set.max_seq_el+1)
+            set.max_seq_el += 1
+        end
+        if !isempty(set.els) && Base._div64(set.max_seq_el) > set.els.offset + SLIDE_OFFSET
+            # slide els bitset
+            len = length(set.els.bits)
+            if len > SLIDE_OFFSET
+                copyto!(set.els.bits, 1, set.els.bits, SLIDE_OFFSET+1, len-SLIDE_OFFSET)
+                fill!(view(set.els.bits, max(1, len-SLIDE_OFFSET+1):len), 0)
+            else
+                fill!(set.els.bits, 0)
+            end
+            set.els.offset += SLIDE_OFFSET
+        end
+    else
+        push!(set.els, el)
+    end
+    return set
+end
+
+Base.in(set::SlidingBitset, el::Integer) =
+    el <= set.max_seq_el || in(set.els, el)

--- a/test/test_borg_moea.jl
+++ b/test/test_borg_moea.jl
@@ -6,7 +6,24 @@
                          MaxSteps=5000, TraceMode=:silent)
         @test BlackBoxOptim.IGD(BlackBoxOptim.Schaffer1Family.opt_value, pareto_frontier(res),
                                 fitness_scheme(res), Val{length(best_candidate(res))}) < 0.05
+
+        @testset "using MultithreadEvaluator" begin
+            if Threads.nthreads() > 1
+                opt = bbsetup(BlackBoxOptim.Schaffer1Family; Method=:borg_moea,
+                              FitnessScheme=ParetoFitnessScheme{2}(is_minimizing=true),
+                              SearchRange=(-10.0, 10.0), NumDimensions=2, ϵ=0.01,
+                              MaxSteps=5000, TraceMode=:verbose, TraceInterval=1.0, NThreads=Threads.nthreads()-1)
+                res = bboptimize(opt)
+                @test isa(BlackBoxOptim.evaluator(lastrun(opt)), BlackBoxOptim.MultithreadEvaluator)
+                @test BlackBoxOptim.IGD(BlackBoxOptim.Schaffer1Family.opt_value, pareto_frontier(res),
+                           fitness_scheme(res), Val{length(best_candidate(res))}) < 0.05
+            else
+                @warn "BorgMOEA MultithreadEvaluator tests require >1 threads, $(Threads.nthreads()) found, use JULIA_NUM_THREADS"
+                @test_skip Threads.nthreads() > 1
+            end
+        end
     end
+
     @testset "CEC09_UP8" begin
         res = bboptimize(BlackBoxOptim.CEC09_Unconstrained_Set[8]; Method=:borg_moea,
                          NumDimensions=4, ϵ=0.025,

--- a/test/test_evaluator.jl
+++ b/test/test_evaluator.jl
@@ -102,4 +102,13 @@ end
         multiobj_evaluator_tests((p, a) -> BlackBoxOptim.ParallelEvaluator(p, a))
     end
 
+    @testset "MultithreadEvaluator" begin
+        if Threads.nthreads() > 1
+            evaluator_tests(() -> BlackBoxOptim.MultithreadEvaluator(p))
+            multiobj_evaluator_tests((p, a) -> BlackBoxOptim.MultithreadEvaluator(p, a))
+        else
+            @warn "MultithreadEvaluator tests require >1 threads, $(Threads.nthreads()) found, use JULIA_NUM_THREADS"
+            @test_skip Threads.nthreads() > 1
+        end
+    end
 end

--- a/test/test_toplevel_bboptimize.jl
+++ b/test/test_toplevel_bboptimize.jl
@@ -79,6 +79,18 @@
             @test isa(BlackBoxOptim.evaluator(lastrun(opt)), BlackBoxOptim.ParallelEvaluator)
         end
 
+        @testset "using population optimizer and multithread evaluator" begin
+            if Threads.nthreads() > 1
+                opt = bbsetup(rosenbrock; Method=:adaptive_de_rand_1_bin,
+                                            SearchRange = (-5.0, 5.0), NumDimensions = 2,
+                                            MaxSteps = 2000, TraceMode = :silent, NThreads=Threads.nthreads()-1)
+                res = bboptimize(opt) 
+                @test isa(BlackBoxOptim.evaluator(lastrun(opt)), BlackBoxOptim.MultithreadEvaluator)
+            else
+                @warn "Top-level MultithreadEvaluator tests require >1 threads, $(Threads.nthreads()) found, use JULIA_NUM_THREADS"
+                @test_skip Threads.nthreads() > 1
+            end
+        end
     end
 
     @testset "continue running an optimization after it finished" begin


### PR DESCRIPTION
Julia 1.3.0 finally supported threads, so I've implemented *MultithreadEvaluator* that makes use of it.

The PR adds the concept of *AbstractAsynchronousEvaluator*. The idea is that one can submit fitness calculation jobs to such evaluator via *async_update_fitness()* call, which immediately returns the job id, so that the optimization algorithm can continue, while the fitness calculation is being done in the background. When required, the results could be collected/waited for by *sync_update_fitness!()*. The support of asynchronous evaluation was added to *BorgMOEA*: it can generate recombined individuals and then immediately proceed to the next step, while their fitnesses are calculated (the synchronization happens before the next recombination).

The PR also generalizes the *update_fitness!()* by supporting any iterator over *Candidate* objects. This allows the generic support for fitness calculation over the whole population (via *PopulationCandidatesIterator*) or over Borg mutants (*BorgMutantsIterator*). The benefit over *AbstractVector{<:Candidate}* is that the candidates are only created when they are required for fitness calculation, thereby reducing memory footprint. I haven't checked, but single-objective algorithms, such as NES family, which require massive fitness recalculations, might benefit from using *update_fitness!()* as well.

The main component of PR is *MultithreadEvaluator*, which implements *AbstractAsynchronousEvaluator* interface and (on top of it) the parallelized version of *update_fitness!()*. It's loosely based on #46, but since it uses threads within the same process and over the same data, the communication is much simpler:
 * The evaluator spawns *N* worker tasks in separate threads (Julia public API doesn't yet allow to control which threads the tasks are being assigned to, so I had to use the non-public API (see *MTEvaluatorWorker()* ctor); maybe it's worth submitting an issue to *julia* project).
 * The master task (where the optimization algorithm runs) notifies the workers on the new jobs via *jobid_chan::Channel{Int}* that is uniquely bound to each worker task. 
 * The workers notify the master about the completion of fitness calculation via shared *done_workers::Channel{Int}* channel.
 * To efficiently keep track of the completed and pending fitness jobs, there's *SlidingBitSet* type.

So far I'm testing *BorgMOEA* with 36 threads and it runs fine. I haven't done the benchmarks, but hopefully the overhead of communication between the threads is minimal (in comparison to #43). However, with many threads I see that Pareto frontier update becomes the main bottleneck. Although it uses R*-tree for efficient indexing, maintaining large frontier (~8000 points) is quite expensive, so it looks like using 36 threads is not much more efficient than, say, 18. ATM I don't know how to efficiently address it. Hopefully, single-objective algorithms that can benefit from parallel fitness calculation (*NES*) will not have this issue.

*make_evaluator()* (and so *bboptimize()* as well) is taught to create *MultithreadEvaluator* when called with *NThreads=n* keyarg.

Any optimization algorithm that uses *update_fitness!(..., candidatesIterator, ...)* should be effectively supported by *MultithreadEvaluator*.

Of course, problem-specific *fitness()* method have to be made multithread-compatible. If any (temporary) objects are being modified during fitness calculation, one needs to check that each worker thread will operate on its own objects. There's an example of using array pools and *Threads.SpinLock* in [*OptEnrichedSetCover.jl*](https://github.com/alyst/OptEnrichedSetCover.jl/blob/1a0f1dd321c07d46ad266d4632c1e85f0c6cb97d/src/multiobj_cover_problem.jl#L353), but probably some clean and simple example has to be added to *BBO*.