### PR TITLE
Tolerate more kinds of bounds

### DIFF
--- a/src/default_parameters.jl
+++ b/src/default_parameters.jl
@@ -65,7 +65,7 @@ function check_and_create_search_space(params::Parameters)
                 throw(ArgumentError("You MUST specify NumDimensions= in a solution when giving a SearchRange=$(sr)"))
             end
             return RectSearchSpace(params[:NumDimensions], sr)
-        elseif isa(sr, typeof([(0.0, 1.0)]))
+        elseif isa(sr, Vector{<:Tuple{<:Real,<:Real}})
             return RectSearchSpace(sr)
         else
             throw(ArgumentError("Using $(typeof(sr)) for SearchRange is not supported."))


### PR DESCRIPTION
This allows, e.g., `[(1, 2.5)]` which is a mix of ints and floats.