### PR TITLE
Add a docs breadcrumb for supported kwargs

### DIFF
--- a/src/bboptimize.jl
+++ b/src/bboptimize.jl
@@ -57,7 +57,7 @@ The optimization method parameters could be specified via `kwargs` or `parameter
 
 Returns `OptimizationResults` instance.
 
-See also `bbsetup()`.
+See also `bbsetup()` and [`BlackBoxOptim.OptRunController`](@ref) for a full list of supported parameters.
 """
 function bboptimize(optctrl::OptController; kwargs...)
     if length(kwargs) > 0
@@ -81,6 +81,8 @@ The optimization method parameters could be specified via `kwargs` or `parameter
 
 Returns the initialized `OptController` instance. To actually run the method
 call `bboptimize()` or `run!()`.
+
+See also [BlackBoxOptim.OptRunController](@ref) for a full list of supported parameters.
 """
 function bbsetup(functionOrProblem, parameters::Parameters = EMPTY_PARAMS; kwargs...)
     parameters = chain(convert(ParamsDict, parameters), kwargs2dict(kwargs))


### PR DESCRIPTION
Not sure if this is how you'd prefer this to be documented (or if it's even always accurate), but I had a hard time discovering this and figured the breadcrumb would be helpful.