### PR TITLE
format docu of OptRunController as list

### DIFF
--- a/design/design_by_testcode/test_bboptimize_toplevel_interface.jl
+++ b/design/design_by_testcode/test_bboptimize_toplevel_interface.jl
@@ -1,3 +1,4 @@
+#using FactCheck
 facts("Top-level interface") do
   context("run a simple optimization with mostly defaults") do
     res = bboptimize(rosenbrock; SearchRange = (-5.0, 5.0), NumDimensions = 2,

--- a/src/bboptimize.jl
+++ b/src/bboptimize.jl
@@ -26,12 +26,13 @@ end
 function setup_problem(func, parameters::Parameters)
     ss = check_and_create_search_space(parameters)
 
-    # Now create an optimization problem with the given information. We currently reuse the type
-    # from our pre-defined problems so some of the data for the constructor is dummy.
+    # Now create an optimization problem with the given information. We currently reuse the 
+    # type from our pre-defined problems so some of the data for the constructor is dummy.
     problem = FunctionBasedProblem(func, "<unknown>", parameters[:FitnessScheme], ss,
                                    parameters[:TargetFitness])
 
-    # validate fitness: create a random solution from the search space and ensure that fitness(problem) returns fitness_type(problem).
+    # validate fitness: create a random solution from the search space and ensure that 
+    # fitness(problem) returns fitness_type(problem).
     ind = rand_individual(search_space(problem))
     res = fitness(ind, problem)
     fitnessT = fitness_type(problem)

--- a/src/opt_controller.jl
+++ b/src/opt_controller.jl
@@ -65,25 +65,36 @@ mutable struct OptRunController{O<:Optimizer, E<:Evaluator}
 end
 
 """
+    OptRunController(optimizer::O, evaluator::E, params)
+
 Create `OptRunController` for a given problem using specified `optimizer`.
 
-#Arguments
-    * `optimizer` initialized optimization method
-    * `evaluator` the evaluator of the problem fitness
-    * `params` controller settings, see `DefaultParameters` for the default values:
-        * `:MaxTime` max time in seconds (takes precedence over the other budget-related params if specified), 0.0 disables the check
-        * `:MaxFuncEvals` max fitness evals (takes precedence over max iterations, but not max time), 0 disables the check
-        * `:MaxSteps` max iterations gives the least control since different optimizers have different "size" of their "iterations"
-        * `:MaxStepsWithoutProgress` max iterations without fitness improvement
-        * `:MinDeltaFitnessTolerance` minimum delta fitness (difference between the two consecutive best fitness improvements) we can accept before terminating
-        * `:FitnessTolerance` stop the optimization when the best fitness found is within this distance of the actual optimum (if known)
-        * `:MaxNumStepsWithoutFuncEvals` stop optimization if no new fitness evals in this many steps (indicates a converged/degenerate search)
-        * `:NumRepetitions` number of repetitions to run for each optimizer for each problem
-        * `:TraceMode` how the optimizer state is traced to the STDOUT during the optimization (one of `:silent`, `:verbose`)
-        * `:TraceInterval` the trace interval (in seconds)
-        * `:SaveTrace` whether to save it to a file (defaults to `false`)
-        * `:SaveFitnessTraceToCsv` whether the history of fitness changes during optimization should be save to a csv file
-        * `:SaveParameters` save method/controller parameters to a JSON file
+# Arguments
+
+* `optimizer` initialized optimization method
+* `evaluator` the evaluator of the problem fitness
+* `params` controller settings, see `DefaultParameters` for the default values:
+    * `:MaxTime` max time in seconds (takes precedence over the other budget-related params 
+      if specified), 0.0 disables the check
+    * `:MaxFuncEvals` max fitness evals (takes precedence over max iterations, but not max 
+      time), 0 disables the check
+    * `:MaxSteps` max iterations gives the least control since different optimizers have 
+      different "size" of their "iterations"
+    * `:MaxStepsWithoutProgress` max iterations without fitness improvement
+    * `:MinDeltaFitnessTolerance` minimum delta fitness (difference between the two 
+      consecutive best fitness improvements) we can accept before terminating
+    * `:FitnessTolerance` stop the optimization when the best fitness found is within this 
+      distance of the actual optimum (if known)
+    * `:MaxNumStepsWithoutFuncEvals` stop optimization if no new fitness evals in this 
+      many steps (indicates a converged/degenerate search)
+    * `:NumRepetitions` number of repetitions to run for each optimizer for each problem
+    * `:TraceMode` how the optimizer state is traced to the STDOUT during the optimization 
+      (one of `:silent`, `:verbose`)
+    * `:TraceInterval` the trace interval (in seconds)
+    * `:SaveTrace` whether to save it to a file (defaults to `false`)
+    * `:SaveFitnessTraceToCsv` whether the history of fitness changes during optimization 
+      should be save to a csv file
+    * `:SaveParameters` save method/controller parameters to a JSON file
 """
 function OptRunController(optimizer::O, evaluator::E, params) where {O<:Optimizer, E<:Evaluator}
     OptRunController{O,E}(optimizer, evaluator,


### PR DESCRIPTION
Thanks for this useful package.
I am learning about the available options and discovered the link to the docu of `OptRunController`. However, this docu is currently not formatted properly in the Julia help, because of spaces at the beginnings of the lines and hence difficult to read. Therefore I create this pull request. Please, do not mind the few other formatting  long comments in bboptimize.jl.