### PR TITLE
Providing multiple initial candidates to multi-objective optimization

### DIFF
--- a/src/bboptimize.jl
+++ b/src/bboptimize.jl
@@ -65,8 +65,10 @@ function bboptimize(optctrl::OptController, x0 = nothing; kwargs...)
     if length(kwargs) > 0
         update_parameters!(optctrl, kwargs2dict(kwargs))
     end
-    if !isnothing(x0)
+    if isa(x0, Vector{T} where T <: Number) #Provided a single x0
         set_candidate!(optimizer(optctrl), x0)
+    elseif isa(x0, Vector{T} where T <: Vector) #Provided a list of multiple x0s
+        set_multi_candidate!(optimizer(optctrl), x0)
     end
     run!(optctrl)
 end

--- a/src/borg_moea.jl
+++ b/src/borg_moea.jl
@@ -95,6 +95,8 @@ archive(alg::BorgMOEA) = alg.evaluator.archive
 
 set_candidate!(o::BorgMOEA, x0) = set_candidate!(o.population, x0)
 
+set_multi_candidate!(o::BorgMOEA, x0_list) = set_multi_candidate!(o.population, x0_list)
+
 # Take one step of Borg MOEA.
 function step!(alg::BorgMOEA)
     if alg.n_steps == 0

--- a/src/optimizer.jl
+++ b/src/optimizer.jl
@@ -105,6 +105,8 @@ popsize(popopt::PopulationOptimizer) = popsize(population(popopt))
 
 set_candidate!(o::PopulationOptimizer, x0) = set_candidate!(population(o), x0)
 
+set_multi_candidate!(o::PopulationOptimizer, x0_list) = set_multi_candidate!(population(o), x0_list)
+
 function setup!(o::SteppingOptimizer)
     # Do nothing, override if you need to setup prior to the optimization loop
 end

--- a/src/population.jl
+++ b/src/population.jl
@@ -117,6 +117,22 @@ function set_candidate!(pop::FitPopulation, x0)
     pop[idx] = x0
 end
 
+
+#Function for adding multiple elements to the starting population of the multi-obj optim
+# assumes all elements of x0_list have been verified as within search range 
+# (based on BlackBoxOptim.set_candidate at BlackBoxOptim/src/population.jl ln:114) 
+function set_multi_candidate!(pop::FitPopulation, x0_list)
+    idxs = StatsBase.sample(1:popsize(pop), length(x0_list), replace=false) #Use sample instead of rand(1:popsize(pop), length(x0_list)) to ensure no duplicates
+    for (i, x0) in zip(idxs, x0_list)
+        @assert numdims(pop) == length(x0)
+        pop[i] = x0
+    end
+end
+
+# #Convenience methods to dispatch on OptController
+# set_multi_candidate!(oc::BlackBoxOptim.OptController, x0_list) = set_multi_candidate!(oc.optimizer.population, x0_list)
+
+
 function Base.setindex!(pop::FitPopulation{F}, indi::FitIndividual{F}, indi_ix::Integer) where F
     pop.individuals[:, indi_ix] = params(indi)
     pop.fitness[indi_ix] = fitness(indi)


### PR DESCRIPTION
This branch adds the option to specify multiple 'x0' candidates within the starting population for the borg-moea algorithm. 

The current implementation works and I have been using it myself, but may not be the cleanest way to do things. If this feature is something that you're interested in merging then I'd be happy think about tidying up the implementation if needed.