### PR TITLE
Honor explicit MaxSteps/MaxFuncEvals alongside MaxTime

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "BlackBoxOptim"
 uuid = "a134a8b2-14d6-55f6-9291-3336d3ab0209"
-version = "0.6.4"
+version = "0.6.5"
 
 [deps]
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"

--- a/src/bboptimize.jl
+++ b/src/bboptimize.jl
@@ -108,8 +108,9 @@ See also [BlackBoxOptim.OptRunController](@ref) for a full list of supported par
 """
 function bbsetup(functionOrProblem, parameters::Parameters = EMPTY_PARAMS; kwargs...)
     parameters = chain(convert(ParamsDict, parameters), kwargs2dict(kwargs))
+    user_explicit = Set{Symbol}(keys(flatten(parameters)))
     problem, params = setup_problem(functionOrProblem, chain(DefaultParameters, parameters))
-    check_valid!(params)
+    check_valid!(params; user_explicit)
 
     optimizer_func = chain(SingleObjectiveMethods, MultiObjectiveMethods)[params[:Method]]
     optimizer = optimizer_func(problem, params)

--- a/src/default_parameters.jl
+++ b/src/default_parameters.jl
@@ -76,15 +76,30 @@ function check_and_create_search_space(params::Parameters)
                         "NumDimensions = $(params[:NumDimensions]))"))
 end
 
-function check_valid!(params::Parameters)
+function check_valid!(params::Parameters;
+                      user_explicit::Union{AbstractSet{Symbol},Nothing} = nothing)
+    # When the caller did not tell us which keys came from the user (vs. from
+    # `DefaultParameters`), fall back to the legacy behavior of letting MaxTime
+    # silently override the other budget knobs. This keeps third-party callers
+    # (e.g. `update_parameters!` with no extra info) on the old contract.
+    is_explicit(k) = user_explicit === nothing || k in user_explicit
+
     # Check that max_time is larger than zero if it has been specified.
     if haskey(params, :MaxTime)
         if !isa(params[:MaxTime], Number) || params[:MaxTime] < 0.0
             throw(ArgumentError("MaxTime parameter must be a non-negative number"))
         elseif params[:MaxTime] > 0.0
             params[:MaxTime] = convert(Float64, params[:MaxTime])
-            params[:MaxFuncEvals] = 0
-            params[:MaxSteps] = 0
+            # MaxTime historically disabled the iteration / fevals budgets so
+            # the default MaxSteps would not trip first. Preserve that for the
+            # defaults, but if the user *explicitly* set MaxSteps / MaxFuncEvals
+            # alongside MaxTime, honor them — first budget to be hit wins.
+            if !is_explicit(:MaxFuncEvals)
+                params[:MaxFuncEvals] = 0
+            end
+            if !is_explicit(:MaxSteps)
+                params[:MaxSteps] = 0
+            end
         end
     end
 
@@ -97,7 +112,9 @@ function check_valid!(params::Parameters)
                 @warn("Number of allowed function evals is $(params[:MaxFuncEvals]); this can take a LONG time")
             end
             params[:MaxFuncEvals] = convert(Int, params[:MaxFuncEvals])
-            params[:MaxSteps] = 0
+            if !is_explicit(:MaxSteps)
+                params[:MaxSteps] = 0
+            end
         end
     end
 

--- a/src/opt_controller.jl
+++ b/src/opt_controller.jl
@@ -433,8 +433,10 @@ function update_parameters!(oc::OptController, parameters::Parameters = EMPTY_DI
 
     # Add new params in front if any are specified and they are valid.
     if length(parameters) > 0
+        user_explicit = Set{Symbol}(keys(parameters))
         oc.parameters = chain(oc.parameters, parameters)
-        check_valid!(oc.parameters) # We must recheck that new param settings are valid
+        # We must recheck that new param settings are valid
+        check_valid!(oc.parameters; user_explicit)
     end
 end
 

--- a/test/test_toplevel_bboptimize.jl
+++ b/test/test_toplevel_bboptimize.jl
@@ -94,6 +94,30 @@
         #end
     end
 
+    @testset "explicit MaxSteps is honored alongside MaxTime" begin
+        # Regression for SciML/Optimization.jl#1206: when both MaxTime and
+        # MaxSteps are passed, MaxTime used to silently clear MaxSteps so the
+        # iteration cap was ignored.
+        res = bboptimize(rosenbrock; SearchRange = (-5.0, 5.0), NumDimensions = 2,
+                         MaxTime = 30.0, MaxSteps = 50, TraceMode = :silent)
+        @test parameters(res)[:MaxSteps] == 50
+        @test parameters(res)[:MaxTime] == 30.0
+        @test BlackBoxOptim.iterations(res) <= 60  # 50 + small slack for the step/check loop
+        @test occursin("steps", BlackBoxOptim.stop_reason(res))
+
+        # MaxTime alone still suppresses the default MaxSteps so the run is not
+        # capped at the 10000 default — preserves the original contract.
+        res2 = bboptimize(rosenbrock; SearchRange = (-5.0, 5.0), NumDimensions = 2,
+                          MaxTime = 0.5, TraceMode = :silent)
+        @test parameters(res2)[:MaxSteps] == 0
+
+        # Same story for MaxFuncEvals: explicit MaxSteps should not be cleared.
+        res3 = bboptimize(rosenbrock; SearchRange = (-5.0, 5.0), NumDimensions = 2,
+                          MaxFuncEvals = 100000, MaxSteps = 75, TraceMode = :silent)
+        @test parameters(res3)[:MaxSteps] == 75
+        @test BlackBoxOptim.iterations(res3) <= 85
+    end
+
     @testset "continue running an optimization after it finished" begin
         optctrl = bbsetup(rosenbrock; SearchRange = (-5.0, 5.0), NumDimensions = 100,
             MaxTime = 0.5, TraceMode = :silent)


### PR DESCRIPTION
> Please ignore this PR until it has been reviewed by @ChrisRackauckas.

## Summary

Fixes the underlying cause of SciML/Optimization.jl#1206. Sister PR on the wrapper side (workaround): SciML/Optimization.jl#1207 — that one can be closed once this lands and a new release goes out.

When a user passes both `MaxTime` and `MaxSteps` (or `MaxFuncEvals`) to `bboptimize` / `bbsetup`, `MaxTime` silently clears the other budgets:

```julia
# src/default_parameters.jl
elseif params[:MaxTime] > 0.0
    params[:MaxTime] = convert(Float64, params[:MaxTime])
    params[:MaxFuncEvals] = 0
    params[:MaxSteps] = 0    # <-- user's MaxSteps lost
end
```

That clearing is needed so the *default* \`MaxSteps = 10000\` (from \`DefaultParameters\`) doesn't trip first when the user only set \`MaxTime\`. But it's too aggressive: it also wipes a user-supplied \`MaxSteps\`. After this, \`check_stop_condition\` only has \`max_time\` to look at.

## Fix

Track which budget keys came from the user (vs. the default param dict), and only clear ones that came from defaults:

- \`bbsetup\`: captures the user's explicit keys via \`Set{Symbol}(keys(flatten(parameters)))\` before merging with \`DefaultParameters\`, then passes it as a \`user_explicit\` kwarg to \`check_valid!\`.
- \`update_parameters!\`: same — uses the keys of the incoming \`parameters\` dict.
- \`check_valid!\`: gains a \`user_explicit::Union{AbstractSet{Symbol},Nothing}\` kwarg. \`nothing\` falls back to the old behavior so any other callers stay on the existing contract. When provided, \`MaxSteps\` / \`MaxFuncEvals\` are only cleared if the user did **not** explicitly pass them.

The downstream check in \`check_stop_condition\` already handles multiple budgets correctly — first to be hit wins — so once we stop clearing them, both fire as expected.

## Behavior

| User passes | Before | After |
|---|---|---|
| \`MaxTime\` | \`MaxSteps\`/\`MaxFuncEvals\` cleared | same |
| \`MaxSteps\` | \`MaxSteps\` honored | same |
| \`MaxTime\` + \`MaxSteps\` | **\`MaxSteps\` silently dropped** (bug) | both honored; first cap to hit wins |
| \`MaxFuncEvals\` + \`MaxSteps\` | \`MaxSteps\` cleared | both honored |

## Test plan
- [x] Added \`@testset "explicit MaxSteps is honored alongside MaxTime"\` in \`test/test_toplevel_bboptimize.jl\` covering the three behaviors above.
- [x] \`julia --project=. -e 'include("test/test_toplevel_bboptimize.jl")'\` — only the 2 pre-existing errors (parallel evaluator + serialization) remain; new test set passes (7 assertions).
- [x] Verified the issue reproducer from SciML/Optimization.jl#1206: with both \`MaxTime = 10\` and \`MaxSteps = 1000\`, \`iterations(res)\` is now \`1001\` (was 12k+), stop reason is \`"Max number of steps (1000) reached"\`.