### PR TITLE
Re-enable downgrade CI with genuine test-at-floor (allow_reresolve: false)

### DIFF
--- a/.github/workflows/Downgrade.yml
+++ b/.github/workflows/Downgrade.yml
@@ -13,8 +13,6 @@ on:
 jobs:
   downgrade:
     name: "Downgrade"
-    # Disabled: lower compat bounds (Distributions 0.24, Compat 3.27, etc.) don't resolve on Julia 1.10
-    if: false
     strategy:
       matrix:
         julia-version: ['1.10']

--- a/Project.toml
+++ b/Project.toml
@@ -20,12 +20,12 @@ Sockets = "6462fe0b-24de-5631-8697-dd941f90decc"
 [extensions]
 
 [compat]
-Compat = "3.27, 4"
-Distributions = "0.24, 0.25"
+Compat = "4.18.1"
+Distributions = "0.25.88"
 HTTP = "0.9, 1"
 Requires = "1"
 SpatialIndexing = "0.1.0"
-StatsBase = "0.33, 0.34"
+StatsBase = "0.34.11"
 julia = "1.3.0"
 
 [extras]


### PR DESCRIPTION
**Please ignore until reviewed by @ChrisRackauckas.** Draft.

Re-enables the Downgrade workflow (removes `if: false`) with `allow_reresolve: false`, so the test suite runs against the **minimal (downgraded) dependency versions** rather than a re-resolved/latest set. Raises the `[compat]` lower bounds (declared deps only) needed for the downgraded floor set to build and pass:

- `Distributions 0.24, 0.25 -> 0.25.88` (resolve floor)
- `StatsBase 0.33, 0.34 -> 0.34.11` (build-skew: old StatsBase missing API used at precompile)
- `Compat 3.27, 4 -> 4.18.1` (build-skew)

Verified locally on Julia 1.10 (CI matrix) in a clean depot + fresh registry: downgrade resolve + `Pkg.test(allow_reresolve=false)` pass at the floor with **0 re-resolve events**.

Note: the two build-skew floors (StatsBase, Compat) were raised to a confirmed-working version (latest in series) rather than bisected to the strict minimum — happy to tighten on request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)