### PR TITLE
Exclude unparseable legacy dirs from Runic Format Check

### DIFF
--- a/.github/workflows/FormatCheck.yml
+++ b/.github/workflows/FormatCheck.yml
@@ -16,3 +16,5 @@ jobs:
     name: "Format Check"
     uses: "SciML/.github/.github/workflows/runic.yml@v1"
     secrets: "inherit"
+    with:
+      exclude: "spikes examples/benchmarking"


### PR DESCRIPTION
## Problem

The Format Check (Runic via `SciML/.github/.github/workflows/runic.yml@v1`) has failed on **every** master run. The cause is ~11 legacy scratch files under `spikes/` and `examples/benchmarking/` that fail to **parse** under Runic.jl — they use pre-Julia-1.0 ambiguous `.` syntax such as `20.*exp(...)`. `src/` and `test/` are fully Runic-clean.

The 11 parse-failing files:

```
examples/benchmarking/updatetoplist.jl
spikes/benchmarking.jl
spikes/comparing_covariate_selection_schemes.jl
spikes/covar_matrix_adaptation_es.jl
spikes/diversity_guided_mutation.jl
spikes/experiments/gss_initial.jl
spikes/lasso_active_factor_prediction.jl
spikes/parameter_study.jl
spikes/subset_tournament_cmsa_es/subset_tournament_cmsa_es.jl
spikes/test_acd.jl
spikes/test_acd_acf.jl
```

## Fix

`runic.yml@v1` already supports an `exclude` input (space-separated paths), which runs `git rm -r --cached --ignore-unmatch <paths>` before the check so `runic-action`'s `git ls-files` skips them. The working tree and history are untouched — the legacy files are **not** rewritten.

This PR sets that input in the caller to exclude `spikes` and `examples/benchmarking`.

## Local verification

Ran Runic.jl v1.7.0 exactly as the action does (`Runic.main(["--check", "--diff", "--verbose", files...])`) over the file set produced by `git ls-files -- '*.jl'` after `git rm -r --cached spikes examples/benchmarking`:

- 148 remaining `.jl` files (all of `src/`, `ext/`, `design/`, `test/`, and the non-benchmarking `examples/`)
- All passed; **exit code 0**

Without the exclude, the same run exits non-zero with exactly the 11 parse errors above. No parse failures exist outside `spikes/` and `examples/benchmarking/`, so excluding just those two directories is sufficient.

---

Ignore until reviewed by @ChrisRackauckas.