### PR TITLE
Convert test suite to SciMLTesting.jl v1.2 (explicit-args run_tests)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -20,19 +20,19 @@ Sockets = "6462fe0b-24de-5631-8697-dd941f90decc"
 [extensions]
 
 [compat]
-Aqua = "0.8"
 CSV = "0.10"
 Compat = "4.18.1"
 Distributed = "1"
 Distributions = "0.25.88"
 HTTP = "0.9, 1, 2.1"
-JET = "0.9, 0.10, 0.11"
 LinearAlgebra = "1"
 Logging = "1"
 Printf = "1"
 Random = "1"
 Requires = "1"
 SHA = "0.7"
+SafeTestsets = "0.1, 1"
+SciMLTesting = "1.2"
 Serialization = "1"
 Sockets = "1"
 SpatialIndexing = "0.1.0"
@@ -41,19 +41,20 @@ Test = "1"
 julia = "1.10"
 
 [extras]
-Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 CSV = "336ed68f-0bac-5ca0-87d4-7b16caf5d00b"
 Distributed = "8ba89e20-285c-5b6f-9357-94700520ee1b"
 HTTP = "cd3eb016-35fb-5094-929b-558a96fad6f3"
-JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 SHA = "ea8e919c-243c-51af-8825-aaa63cd721ce"
+SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
+SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
 Serialization = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
 Sockets = "6462fe0b-24de-5631-8697-dd941f90decc"
+SpatialIndexing = "d4ead438-fe20-5cc5-a293-4fd39a41b74c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Aqua", "CSV", "Serialization", "SHA", "LinearAlgebra", "Test", "Random", "Printf", "Distributed", "Logging", "JET"]
+test = ["CSV", "Serialization", "SHA", "LinearAlgebra", "Test", "Random", "Printf", "Distributed", "Logging", "SafeTestsets", "SciMLTesting", "SpatialIndexing"]

--- a/test/problems/test_problem.jl
+++ b/test/problems/test_problem.jl
@@ -1,3 +1,5 @@
+include("../helper.jl")
+
 fsabs(x) = sum(abs, x)
 fsum_abs_and_sq(x) = (sum(abs, x), sum(abs2, x))
 

--- a/test/problems/test_single_objective.jl
+++ b/test/problems/test_single_objective.jl
@@ -1,3 +1,5 @@
+include("../helper.jl")
+
 @testset "Single objective functions" begin
 
     @testset "Sphere" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,125 +1,66 @@
-const GROUP = get(ENV, "GROUP", "All")
+using SciMLTesting
+using SafeTestsets
+using Random
 
-if GROUP == "QA"
-    include(joinpath(@__DIR__, "qa", "qa.jl"))
-    exit()
+# BlackBoxOptim's test suite is not cleanly folder-partitionable: the test files
+# live flat in test/ (plus test/utilities and test/problems) and are enumerated by
+# testset_normal.txt rather than discovered per-folder, and test/problems holds both
+# real test units and shared helper code (common.jl, included only by the heavy
+# manual problem suites). So this uses the explicit-args run_tests form: core_body
+# lists the real Core test files, each run isolated in its own @safetestset module.
+function core_body()
+    # The suite has no per-file seeding and several stochastic tests assert on
+    # optimizer outcomes (e.g. test_set_candidate's "found the injected optimum").
+    # Those are sensitive to the global-RNG state inherited from all preceding
+    # files, so the run is only reproducible if the RNG is pinned up front. Seed
+    # once here so the whole Core run (and CI) is deterministic.
+    Random.seed!(1234)
+
+    @safetestset "Latin hypercube sampling" include("utilities/test_latin_hypercube_sampling.jl")
+    @safetestset "Halton sequence" include("utilities/test_halton_sequence.jl")
+    @safetestset "Assign ranks" include("utilities/test_assign_ranks.jl")
+
+    @safetestset "Parameters" include("test_parameters.jl")
+    @safetestset "Fitness" include("test_fitness.jl")
+    @safetestset "Evaluator" include("test_evaluator.jl")
+    @safetestset "Population" include("test_population.jl")
+    @safetestset "Bimodal Cauchy distribution" include("test_bimodal_cauchy_distribution.jl")
+    @safetestset "Search space" include("test_search_space.jl")
+    @safetestset "Mutation operators" include("test_mutation_operators.jl")
+    @safetestset "Crossover operators" include("test_crossover_operators.jl")
+    @safetestset "Selectors" include("test_selectors.jl")
+    @safetestset "Embedders" include("test_embedders.jl")
+    @safetestset "Frequency adaptation" include("test_frequency_adaptation.jl")
+    @safetestset "Archive" include("test_archive.jl")
+    @safetestset "EpsBox archive" include("test_epsbox_archive.jl")
+    @safetestset "Optimization result" include("test_optimizationresult.jl")
+
+    @safetestset "Random search" include("test_random_search.jl")
+    @safetestset "Differential evolution" include("test_differential_evolution.jl")
+    @safetestset "Adaptive differential evolution" include("test_adaptive_differential_evolution.jl")
+    @safetestset "Natural evolution strategies" include("test_natural_evolution_strategies.jl")
+
+    @safetestset "BORG MOEA" include("test_borg_moea.jl")
+
+    @safetestset "Tracing" include("test_tracing.jl")
+    @safetestset "Top-level bboptimize" include("test_toplevel_bboptimize.jl")
+    @safetestset "Smoketest bboptimize" include("test_smoketest_bboptimize.jl")
+
+    @safetestset "Set candidate" include("test_set_candidate.jl")
+    @safetestset "Max func evals" include("test_max_func_evals.jl")
+
+    @safetestset "Problem" include("problems/test_problem.jl")
+    @safetestset "Single objective problems" include("problems/test_single_objective.jl")
+
+    @safetestset "Generating set search" include("test_generating_set_search.jl")
+    @safetestset "Direct search with probabilistic descent" include("test_direct_search_with_probabilistic_descent.jl")
+    return nothing
 end
 
-if !@isdefined(TimeTestExecution)
-    const TimeTestExecution = false
-end
-
-module BlackBoxOptimTests
-
-    using LinearAlgebra, Random
-    using Printf: @printf, @sprintf
-    using SpatialIndexing
-
-    const SI = SpatialIndexing
-
-    TestDir = first(splitdir(@__FILE__()))
-
-    # If two arguments the second one is filename of a testset file
-    # listing the testfiles to use.
-    if length(ARGS) == 2 && isfile(ARGS[2])
-        test_file_list = ARGS[2]
-    else
-        test_file_list = if isfile(joinpath(TestDir, "testset_current.txt"))
-            joinpath(TestDir, "testset_current.txt")
-        else
-            joinpath(TestDir, "testset_normal.txt")
-        end
-    end
-
-    TestFiles = filter(
-        fn -> isfile(joinpath(TestDir, fn)),
-        readlines(test_file_list)
-    )
-
-    function latest_changed_file(files, dir = "")
-        return files[first(sortperm(map(fn -> mtime(joinpath(dir, fn)), files), rev = true))]
-    end
-
-    # If a first argument is given it must be either:
-    #  all =>           run all test files in the testset
-    #  latestchanged => run only the latest changed file in the testset
-    if length(ARGS) > 0
-        if ARGS[1] == "all"
-            TestFiles = TestFiles # Change nothing so run them all
-        elseif ARGS[1] == "latestchanged"
-            TestFiles = AbstractString[latest_changed_file(TestFiles, TestDir)]
-            println("Testing files: $(TestFiles)")
-        end
-    end
-
-    startclocktime = time()
-    include("helper.jl")
-
-    import Compat.String
-
-    if Main.TimeTestExecution
-
-        function get_git_remote_and_branch()
-            lines = split(read(`git remote -v show`, String), "\n")
-            remote = match(r"[a-z0-9]+\s+([^\s]+)", lines[1]).captures[1]
-            branch = strip(read(`git rev-parse --abbrev-ref HEAD`, String))
-            commit = strip(read(`git rev-parse HEAD`, String))
-            return remote, branch, commit
-        end
-
-        gitremote, gitbranch, gitcommit = get_git_remote_and_branch()
-        gitstr = gitremote * "/" * gitbranch * "/" * gitcommit[1:6]
-        versionstr = string(VERSION)
-
-        using CSV, DataFrames
-
-        TestTimingFileName = "test/timing_testing.csv"
-
-        if isfile("test/timing_testing.csv")
-            timing_data = CSV.read("test/timing_testing.csv")
-        else
-            timing_data = DataFrame(
-                TimeStamp = AbstractString[],
-                Julia = AbstractString[],
-                Git = AbstractString[],
-                TestFile = AbstractString[],
-                Elapsed = Float64[]
-            )
-        end
-
-    end
-
-    starttime = time()
-    @testset "BlackBoxOptim test suite" begin
-
-        for t in TestFiles
-            local test_start_time
-            Main.TimeTestExecution && (test_start_time = time())
-
-            # Including the test file runs the tests in there...
-            include(t)
-
-            if Main.TimeTestExecution
-                elapsed = time() - test_start_time
-                datestr = Libc.strftime("%Y%m%d %H:%M.%S", time())
-                push!(timing_data, [datestr, versionstr, gitstr, t, elapsed])
-            end
-            print("."); flush(stdout)
-        end
-        println() # So Base.Test summary is correctly aligned...
-    end
-    elapsed = time() - starttime
-
-    if Main.TimeTestExecution
-        datestr = Libc.strftime("%Y%m%d %H:%M.%S", time())
-        using SHA
-        hash = bytes2hex(sha512(join(map(fn -> read(open(joinpath("test", fn)), String), TestFiles))))[1:16]
-        push!(timing_data, [datestr, versionstr, gitstr, "TOTAL TIME for $(length(TestFiles)) test files, $(hash)", elapsed])
-        CSV.write(TestTimingFileName, timing_data)
-        println("Wrote $(nrow(timing_data)) rows to file $TestTimingFileName")
-    end
-
-    elapsedclock = time() - startclocktime
-    println("Tested $(length(TestFiles)) files in $(round(elapsedclock, digits = 1)) seconds.")
-
-end # module BlackBoxOptimTests
+run_tests(;
+    core = core_body,
+    qa = (; env = joinpath(@__DIR__, "qa"), body = joinpath(@__DIR__, "qa", "qa.jl")),
+    # Curated "All": run only Core. QA stays selectable by name but out of the
+    # aggregate (it has its own CI lane).
+    all = ["Core"],
+)

--- a/test/test_adaptive_differential_evolution.jl
+++ b/test/test_adaptive_differential_evolution.jl
@@ -1,3 +1,5 @@
+include("helper.jl")
+
 NumTestRepetitions = 100
 
 @testset "Adaptive differential evolution optimizer" begin

--- a/test/test_archive.jl
+++ b/test/test_archive.jl
@@ -1,3 +1,5 @@
+include("helper.jl")
+
 @testset "TopListArchive" begin
     @testset "TopListIndividual" begin
         # test equality

--- a/test/test_bimodal_cauchy_distribution.jl
+++ b/test/test_bimodal_cauchy_distribution.jl
@@ -1,3 +1,5 @@
+include("helper.jl")
+
 @testset "Bimodal Cauchy Distributions" begin
 
     @testset "sample bimodal cauchy with truncation above 1" begin

--- a/test/test_borg_moea.jl
+++ b/test/test_borg_moea.jl
@@ -1,3 +1,5 @@
+include("helper.jl")
+
 @testset "BorgMOEA" begin
     @testset "Schaffer1" begin
         res = bboptimize(

--- a/test/test_crossover_operators.jl
+++ b/test/test_crossover_operators.jl
@@ -1,3 +1,5 @@
+include("helper.jl")
+
 @testset "Crossover operators" begin
 
     ss = RectSearchSpace(1, (0.0, 10.0))

--- a/test/test_differential_evolution.jl
+++ b/test/test_differential_evolution.jl
@@ -1,3 +1,5 @@
+include("helper.jl")
+
 @testset "Differential evolution optimizer" begin
 
     ss = RectSearchSpace(1, (0.0, 10.0))

--- a/test/test_direct_search_with_probabilistic_descent.jl
+++ b/test/test_direct_search_with_probabilistic_descent.jl
@@ -1,3 +1,6 @@
+include("helper.jl")
+using LinearAlgebra
+
 @testset "Random sampling on unit, n-dimensional sphere" begin
 
     uv1 = BlackBoxOptim.sample_unit_hypersphere(1)

--- a/test/test_embedders.jl
+++ b/test/test_embedders.jl
@@ -1,3 +1,5 @@
+include("helper.jl")
+
 @testset "Embedding operators" begin
 
     @testset "RandomBound" begin

--- a/test/test_epsbox_archive.jl
+++ b/test/test_epsbox_archive.jl
@@ -1,3 +1,7 @@
+include("helper.jl")
+using SpatialIndexing
+SI = SpatialIndexing
+
 @testset "EpsBoxArchive" begin
     # check that frontier elements are mutually nondominated and
     # there are no epsilon-index duplicates

--- a/test/test_evaluator.jl
+++ b/test/test_evaluator.jl
@@ -1,3 +1,6 @@
+include("helper.jl")
+using Distributed
+
 function evaluator_tests(make_eval::Function)
     @testset "Basic evaluation with a single-objective function to be minimized" begin
         e = make_eval()

--- a/test/test_fitness.jl
+++ b/test/test_fitness.jl
@@ -1,3 +1,6 @@
+include("helper.jl")
+using LinearAlgebra
+
 @testset "Fitness" begin
     @testset "hat_compare() Float64" begin
         @test hat_compare(1.0, 2.0) == -1

--- a/test/test_frequency_adaptation.jl
+++ b/test/test_frequency_adaptation.jl
@@ -1,3 +1,5 @@
+include("helper.jl")
+
 @testset "Frequency Adaptation" begin
 
     @testset "returns all indices once in the first block" begin

--- a/test/test_generating_set_search.jl
+++ b/test/test_generating_set_search.jl
@@ -1,3 +1,5 @@
+include("helper.jl")
+
 @testset "Generating set search" begin
 
     ss = RectSearchSpace(3, (0.0, 1.0))

--- a/test/test_max_func_evals.jl
+++ b/test/test_max_func_evals.jl
@@ -1,3 +1,5 @@
+include("helper.jl")
+
 @testset "MaxFuncEvals" begin
 
     # It was reported in an GitHub Issue that MaxFuncEvals doesn't have an effect

--- a/test/test_mutation_operators.jl
+++ b/test/test_mutation_operators.jl
@@ -1,3 +1,5 @@
+include("helper.jl")
+
 @testset "Mutation operators" begin
     ss = RectSearchSpace([(-1.0, 1.0), (0.0, 100.0), (-5.0, 0.0)])
 

--- a/test/test_natural_evolution_strategies.jl
+++ b/test/test_natural_evolution_strategies.jl
@@ -1,3 +1,5 @@
+include("helper.jl")
+
 @testset "sNES" begin
 
     function assign_weights_wrapper(candi_ixs::Vector{Int})

--- a/test/test_optimizationresult.jl
+++ b/test/test_optimizationresult.jl
@@ -1,3 +1,5 @@
+include("helper.jl")
+
 using BlackBoxOptim: general_stop_reason
 
 @testset "general_stop_reason" begin

--- a/test/test_parameters.jl
+++ b/test/test_parameters.jl
@@ -1,3 +1,5 @@
+include("helper.jl")
+
 @testset "DictChain" begin
     @testset "Matching keys and value types for get()/set() methods" begin
         dc1 = DictChain{Int, String}()

--- a/test/test_population.jl
+++ b/test/test_population.jl
@@ -1,3 +1,5 @@
+include("helper.jl")
+
 @testset "Population" begin
 
     @testset "FitPopulation" begin

--- a/test/test_random_search.jl
+++ b/test/test_random_search.jl
@@ -1,3 +1,5 @@
+include("helper.jl")
+
 @testset "Random search" begin
 
     @testset "ask()" begin

--- a/test/test_search_space.jl
+++ b/test/test_search_space.jl
@@ -1,3 +1,5 @@
+include("helper.jl")
+
 @testset "Search space" begin
     @testset "in()" begin
         for i in 1:NumTestRepetitions

--- a/test/test_selectors.jl
+++ b/test/test_selectors.jl
@@ -1,3 +1,6 @@
+include("helper.jl")
+using Random
+
 @testset "Selection operators" begin
 
     ss = RectSearchSpace(1, (0.0, 10.0))

--- a/test/test_set_candidate.jl
+++ b/test/test_set_candidate.jl
@@ -1,9 +1,11 @@
+include("helper.jl")
+
 using BlackBoxOptim: set_candidate!, candidate, set_candidates!
 
 # a 2d optimization problem with an optimum at (3.14, 7.2)
 fixed_optimum_prob(x) = (x[1] - 3.14)^2 + (x[2] - 7.2)^4
-const FixedOptimum = [3.14, 7.2]
-const FitnessOptimum = fixed_optimum_prob(FixedOptimum)
+FixedOptimum = [3.14, 7.2]
+FitnessOptimum = fixed_optimum_prob(FixedOptimum)
 
 @testset "set_candidate! for DE population optimizers" begin
     for m in [

--- a/test/test_smoketest_bboptimize.jl
+++ b/test/test_smoketest_bboptimize.jl
@@ -1,3 +1,5 @@
+include("helper.jl")
+
 @testset "bboptimize() single-objective methods smoketest" begin
     rosenbrock2d(x) = abs2(1.0 - x[1]) + 100.0 * abs2(x[2] - x[1]^2)
 

--- a/test/test_toplevel_bboptimize.jl
+++ b/test/test_toplevel_bboptimize.jl
@@ -1,3 +1,6 @@
+include("helper.jl")
+using Distributed
+
 @testset "Top-level interface" begin
     rosenbrock(x) = sum(i -> 100 * abs2(x[i + 1] - x[i]^2) + abs2(x[i] - 1), Base.OneTo(length(x) - 1))
 

--- a/test/test_tracing.jl
+++ b/test/test_tracing.jl
@@ -1,3 +1,5 @@
+include("helper.jl")
+
 @testset "Testing methods diagnostic tracing" begin
     rosenbrock(x) = sum(i -> 100 * abs2(x[i + 1] - x[i]^2) + abs2(x[i] - 1), Base.OneTo(length(x) - 1))
     schaffer1(x) = (sum(abs2, x), sum(xx -> abs2(xx - 2.0), x))

--- a/test/utilities/test_assign_ranks.jl
+++ b/test/utilities/test_assign_ranks.jl
@@ -1,3 +1,6 @@
+include("../helper.jl")
+using Random
+
 @testset "Assign ranks within tolerance" begin
 
     @testset "Ranks correctly if none are within tolerance of each other" begin

--- a/test/utilities/test_halton_sequence.jl
+++ b/test/utilities/test_halton_sequence.jl
@@ -1,3 +1,5 @@
+include("../helper.jl")
+
 haltonnumber = BlackBoxOptim.Utils.haltonnumber
 haltonsequence = BlackBoxOptim.Utils.haltonsequence
 

--- a/test/utilities/test_latin_hypercube_sampling.jl
+++ b/test/utilities/test_latin_hypercube_sampling.jl
@@ -1,3 +1,5 @@
+include("../helper.jl")
+
 @testset "Latin hypercube sampling" begin
     @test_throws DimensionMismatch BlackBoxOptim.Utils.latin_hypercube_sampling(Float64[], [1.0], 1)
     @test_throws DimensionMismatch BlackBoxOptim.Utils.latin_hypercube_sampling([1.0, 2.0], [1.0], 1)


### PR DESCRIPTION
Converts BlackBoxOptim.jl's test suite to [SciMLTesting.jl](https://github.com/SciML/SciMLTesting.jl) v1.2 using the **explicit-args** `run_tests` form.

## Why explicit-args (not folder-discovery)

BlackBoxOptim's tests are not cleanly folder-partitionable:

- Test files live flat in `test/` (plus `test/utilities/` and `test/problems/`) and were enumerated by `test/testset_normal.txt`, not discovered per-folder.
- `test/problems/` mixes real test units (`test_problem.jl`, `test_single_objective.jl`) with shared helper code (`common.jl`, included only by the heavy/manual problem suites that are *not* part of the normal CI run). Folder-discovery would try to run `common.jl` as a standalone unit and break.

So `test/runtests.jl` now calls `run_tests(; core = core_body, ...)` where `core_body` enumerates the real Core test files, each run isolated in its own `@safetestset` module via SciMLTesting's canonical `@safetestset "Name" include("file.jl")` structure.

## Changes

- **`test/runtests.jl`** — replaced the bespoke `module BlackBoxOptimTests` + `testset_normal.txt` file-list harness with `using SciMLTesting; run_tests(; core = core_body, qa = (; env = "qa", body = "qa/qa.jl"), all = ["Core"])`. `core_body` lists the 31 Core test files (the exact set previously in `testset_normal.txt`), each wrapped in its own `@safetestset`. `GROUP=All`/`Core` run Core; `GROUP=QA` runs the existing `test/qa` env (Aqua/JET), which already exists on `master`.
- **Per-file headers** — each Core test file now carries its own `include("helper.jl")` (which brings in `BlackBoxOptim`, `Test`, and the `NumTestRepetitions`/`random_candidate` helpers) plus any per-file extras it relied on from the old module-level `using`s (`Random`, `LinearAlgebra`, `SpatialIndexing as SI`, `Distributed`). This makes each file self-contained so it runs correctly in its own fresh `@safetestset` module. `test_set_candidate.jl`'s two file-scope `const`s became plain assignments (`const` is disallowed in a `@safetestset`/`@testset` local scope).
- **Deterministic RNG seed** — the suite has no per-file seeding and several stochastic tests assert on optimizer outcomes (e.g. `test_set_candidate`'s "found the injected optimum"), which are sensitive to the global-RNG state inherited from preceding files. `core_body` now `Random.seed!(1234)`s once up front so the whole Core run (and CI) is reproducible. This is a pre-existing flakiness on `master` (no seeding there either, so the un-pinned suite can fail intermittently on that test), now pinned rather than left to chance.
- **`Project.toml`** — added `SciMLTesting` and `SafeTestsets` (plus `SpatialIndexing`) to the test `[extras]`/`[targets]`/`[compat]`; dropped `Aqua`/`JET` from the *main* test target (they live in `test/qa/Project.toml`, which `run_tests` activates for the QA lane).

## Local verification

Full Core suite run locally on Julia 1.10 (the compat floor) via `Pkg.test()`:

```
     Testing BlackBoxOptim tests passed
```

All 31 Core test files pass; `0 failed, 0 errored`. The QA lane (`GROUP=QA`) was also run locally and passes.

---

Please ignore until reviewed by @ChrisRackauckas.
