### PR TITLE
Bump version to 0.6.7

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "BlackBoxOptim"
 uuid = "a134a8b2-14d6-55f6-9291-3336d3ab0209"
-version = "0.6.6"
+version = "0.6.7"
 
 [deps]
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"


### PR DESCRIPTION
Automated patch version bump (0.6.6 -> 0.6.7) to release unreleased commits on `master` via JuliaRegistrator.