### PR TITLE
Release prep: bump BlackBoxOptim to 0.6.8

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "BlackBoxOptim"
 uuid = "a134a8b2-14d6-55f6-9291-3336d3ab0209"
-version = "0.6.7"
+version = "0.6.8"
 
 [deps]
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"


### PR DESCRIPTION
Patch release for accumulated docstring/QA/test-scaffolding changes since 0.6.7 (no functional/source changes).