### PR TITLE
Drop BlackBoxOptim QA self source

### DIFF
--- a/test/qa/Project.toml
+++ b/test/qa/Project.toml
@@ -5,9 +5,6 @@ JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
 SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
-[sources]
-BlackBoxOptim = {path = "../.."}
-
 [compat]
 Aqua = "0.8"
 JET = "0.9,0.10,0.11"


### PR DESCRIPTION
> **Please ignore until reviewed by @ChrisRackauckas.**

## Summary

- Remove the redundant `BlackBoxOptim = {path = "../.."}` `[sources]` entry from `test/qa/Project.toml`.
- Keep the SciMLTesting 2.1 QA setup otherwise unchanged.

## Verification

- `timeout 3600 env GROUP=QA /home/crackauc/.juliaup/bin/julia +release --project=. --startup-file=no -e 'using Pkg; Pkg.test(; coverage=false)'`\n  - passed: `QA | 14 pass, 5 broken` (existing QA broken annotations).\n