### PR TITLE
Release prep: bump version to 0.6.9

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "BlackBoxOptim"
 uuid = "a134a8b2-14d6-55f6-9291-3336d3ab0209"
-version = "0.6.8"
+version = "0.6.9"
 
 [deps]
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"


### PR DESCRIPTION
## Summary

Bumps the package version from 0.6.8 to 0.6.9 to register the commits merged since the last release (#275, tree-sha `26b865429c706d40aca2b9ced5bc331b33fd32ba`), which was left unreleased.

## Changes since 0.6.8 (commit b0c04c1)

- f6134ed — Update SciMLTesting QA compat
- a2e740b — Drop BlackBoxOptim QA self source (#276)

The only actual file change across these commits is in `test/qa/Project.toml` (a test/CI-internal manifest, not part of the shipped package): removal of a `[sources]` self-path override. No source files, no exported API, and no `[compat]` entries in the main `Project.toml` were touched.

## Bump type: PATCH (0.6.8 -> 0.6.9)

The diff is test/CI-infrastructure-only with no functional or API changes, so this is a patch-level release per SemVer conventions.

## Compat bounds

No changes needed — the diff does not touch any dependency usage or `[compat]` bounds in the main `Project.toml`, and no new SciML-ecosystem API usage was introduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)