### PR TITLE
Bump BlackBoxOptim to v0.6.10

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "BlackBoxOptim"
 uuid = "a134a8b2-14d6-55f6-9291-3336d3ab0209"
-version = "0.6.9"
+version = "0.6.10"
 
 [deps]
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"


### PR DESCRIPTION
Bumps `BlackBoxOptim` **v0.6.9 → v0.6.10** (patch) so the accumulated unreleased `src/` changes on `master` can be registered.

**Rationale:** Require HTTP 1 for optional integration (#279) (docs/QA/compat/internal; no public API or behavior break)

Part of a sweep of SciML packages whose source changed since their last registered version without a version bump.

> [!NOTE]
> Please ignore until reviewed by @ChrisRackauckas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)