### PR TITLE
Make the strict-QA release non-breaking

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "BlackBoxOptim"
 uuid = "a134a8b2-14d6-55f6-9291-3336d3ab0209"
-version = "0.7.0"
+version = "0.6.10"
 
 [deps]
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"


### PR DESCRIPTION
Ignore until reviewed by @ChrisRackauckas.

## What this changes

| package | from | to | why |
|---|---|---|---|
| `BlackBoxOptim` | 0.7.0 | 0.6.10 | QA reexport removal is not a public API break |


## Why

The version was bumped to a breaking release because the strict SciMLTesting 2.4
QA migration dropped `@reexport`s and other foreign names from the namespace.
Those names were never this package's documented public API, so re-exporting them
is not behaviour downstream users were entitled to rely on, and removing them does
not warrant a major bump. Every name the package itself exports is unchanged.

This lowers the version to the next non-breaking release instead.

Only the top-level `version` field of each `Project.toml` is touched.

After merge, each package still needs `@JuliaRegistrator register` (with
`subdir=` where applicable).